### PR TITLE
ci: let every pull request run the required checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,15 +10,11 @@ on:
       - "go.mod"
       - "go.sum"
       - ".github/workflows/build.yml"
+  # No paths filter here on purpose: these jobs are required checks, and a
+  # required check that never runs leaves a docs-only pull request waiting
+  # forever. The push trigger above keeps its filter.
   pull_request:
     branches: [main]
-    paths:
-      - "src/**"
-      - "docker/**"
-      - "demo/**"
-      - "go.mod"
-      - "go.sum"
-      - ".github/workflows/build.yml"
 
 # Least privilege by default; the two jobs that write ask for it themselves.
 permissions:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,14 +12,11 @@ on:
       - "go.sum"
       - "docker/**"
       - ".github/workflows/security.yml"
+  # No paths filter here on purpose: these jobs are required checks, and a
+  # required check that never runs leaves a docs-only pull request waiting
+  # forever. The push trigger above keeps its filter.
   pull_request:
     branches: [main]
-    paths:
-      - "src/**"
-      - "go.mod"
-      - "go.sum"
-      - "docker/**"
-      - ".github/workflows/security.yml"
 
 permissions:
   contents: read


### PR DESCRIPTION
The `paths:` filter on the `pull_request` trigger meant a docs-only pull request never started `build` or `security`. Now that those jobs are required checks, a run that never happens leaves the pull request waiting for a status that will never be reported.

Dropping the filter on `pull_request` only. The `push` trigger keeps its filter, so pushes to `main` still skip irrelevant runs.

This pull request is also the first real exercise of the new branch protection: it should show all nine required checks reporting.