### PR TITLE
ci: give the demo five tries to get past docker hub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,11 +103,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # Six images come from Docker Hub anonymously, sharing a rate limit
+      # across the whole runner pool, so a timed-out pull is routine rather
+      # than exceptional. Five tries with a flat 30s gap rides out the usual
+      # outage; the job is deliberately not a required check.
       - name: bring the demo up (retry past registry hiccups)
         run: |
-          for i in 1 2 3; do
+          for i in 1 2 3 4 5; do
             docker compose -f demo/compose.yaml up -d --build --wait && exit 0
-            echo "attempt $i failed (registry?), retrying"; sleep $((i * 10))
+            echo "attempt $i failed (registry?), retrying in 30s"
+            docker compose -f demo/compose.yaml down --remove-orphans >/dev/null 2>&1 || true
+            sleep 30
           done
           exit 1
       - name: the pills settle green and red


### PR DESCRIPTION
The demo job pulls six images from Docker Hub anonymously, which shares a rate limit across the whole runner pool, so a timed-out pull is routine rather than exceptional: it failed twice today, once on a 502 and once on a full connection timeout.

Three tries with 10s and 20s gaps only spanned 30 seconds, which is shorter than the outages actually seen. Five tries with a flat 30s gap spans two minutes.

Also tears the partial stack down between attempts, so a half-started run does not confuse the next one.

The durable fix is authenticating to Docker Hub for its own quota, but that needs a secret and fork pull requests would not get it. This job is no longer a required check, so a bad Docker Hub day costs a red mark rather than a blocked merge.