### PR TITLE
feat: show the running version beside the cairn credit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,9 @@ jobs:
           context: .
           file: docker/Dockerfile
           platforms: linux/amd64,linux/arm64
-          build-args: VERSION=${{ steps.meta.outputs.version }}
+          # The commit, not "unstable": with show_version on, an untagged build
+          # then names the exact revision it was cut from, and links to it.
+          build-args: VERSION=${{ github.sha }}
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/demo/config/site.yaml
+++ b/demo/config/site.yaml
@@ -5,6 +5,7 @@ tagline:
   en: A sample directory backed by real services and a real Gatus.
 logo: /static/favicon.svg           # your own image goes in /assets (see docs)
 locales: [fr, en]
+show_version: true
 status:
   gatus: http://gatus:8080        # cairn polls this over the compose network
   page: http://localhost:8081     # the pill links visitors to the published port

--- a/docs/configuration/site.md
+++ b/docs/configuration/site.md
@@ -20,6 +20,7 @@ so is every key in it.
 | `footer`       | `[]`      | Links at the bottom of every page.                |
 | `pages`        | `[]`      | Pages cairn serves itself (legal notice, privacy…); see below. Bodies accept the [markdown subset](text.md). |
 | `credit`       | `true`    | The small "powered by cairn" in the footer. `credit: false` removes it. |
+| `show_version` | `false`   | Prints the running cairn version beside that credit: the release number for a tagged build, the commit for a build off `main`. Handy when you report a bug, or run several instances. |
 | `strings`      | built-ins | UI text overrides; see [Languages](i18n.md#ui-strings). |
 | `status`       | none      | Live status pills fed by your Gatus (`status.gatus`, `status.page`, `status.interval`); see [Status page](../recipes/gatus.md). |
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -50,6 +50,7 @@ logs the same error.
 | `footer`       | `[]`      | list of `{label: text, url: string}` |
 | `pages`        | `[]`      | [hosted pages](configuration/site.md#hosted-pages): `{id: slug, title: text, body: long text, sections: [{title, body}]}`; body and/or sections required; bodies take the [markdown subset](configuration/text.md) |
 | `credit`       | `true`    | bool; `false` removes the footer "powered by cairn" |
+| `show_version` | `false`   | bool; `true` shows the running version next to the credit, linked to its release or commit |
 | `strings`      | built-ins | map of key → text ([keys](configuration/i18n.md#ui-strings)) |
 | `status.gatus` | none      | Gatus base URL cairn polls for the [status pills](recipes/gatus.md) |
 | `status.page`  | `status.gatus` | public Gatus URL the pill links to (set when the poll URL is internal) |

--- a/schema/site.json
+++ b/schema/site.json
@@ -117,6 +117,10 @@
       "type": "boolean",
       "description": "false removes the footer \"powered by cairn\"."
     },
+    "show_version": {
+      "type": "boolean",
+      "description": "true prints the running cairn version beside the credit: the release number for a tagged build, the commit for a build off main. Off by default."
+    },
     "strings": {
       "type": "object",
       "additionalProperties": { "$ref": "#/definitions/lstring" },

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -733,6 +733,11 @@ footer {
 .powered { display: inline-flex; align-items: center; gap: .45rem; margin-inline-start: auto; font-size: .82rem; color: var(--muted); }
 .powered .foot-mark { width: .95rem; height: .95rem; }
 .powered a { color: var(--accent-ink); font-weight: 500; }
+/* the optional build stamp: present for whoever needs it, quiet enough that
+   the footer still reads as one line */
+.foot-version { font-size: .95em; color: var(--muted); font-variant-numeric: tabular-nums; }
+.powered a.foot-version { color: var(--muted); font-weight: 400; }
+.powered a.foot-version:hover { color: var(--fg); }
 .powered a:hover, .powered a:focus-visible { color: var(--accent-ink); text-decoration: underline; }
 
 /* ---- utilities ---- */

--- a/src/config.go
+++ b/src/config.go
@@ -100,7 +100,8 @@ type Site struct {
 	Links   []FooterLink       `yaml:"links"`
 	Footer  []FooterLink       `yaml:"footer"`
 	Pages   []SitePage         `yaml:"pages"`
-	Credit  *bool              `yaml:"credit"` // the footer "powered by cairn"; nil means true
+	Credit  *bool              `yaml:"credit"`       // the footer "powered by cairn"; nil means true
+	ShowVer bool               `yaml:"show_version"` // print the running version beside the credit; off by default
 	Strings map[string]LString `yaml:"strings"`
 	Status  struct {
 		Gatus    string `yaml:"gatus"`

--- a/src/render.go
+++ b/src/render.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"html/template"
+	"regexp"
 	"sort"
 	"strings"
 )
@@ -84,7 +85,8 @@ type pageView struct {
 	Locale, SiteTitle, PageTitle, MetaDesc, Logo, Favicon, TouchIcon, OGImage, Accent, SwitchPath, Base, Version, AboutHash string
 	Prefix                                                                                                                  string // "" or "/cairn", see basePath
 	Dir                                                                                                                     string // "ltr" or "rtl", from the locale
-	CustomCSS, Search, Credit, Noindex                                                                                      bool
+	CustomCSS, Search, Credit, Noindex, ShowVer                                                                             bool
+	VerLabel, VerHref                                                                                                       string
 	Locales                                                                                                                 []string
 	Links                                                                                                                   []linkView
 	Footer                                                                                                                  []linkView
@@ -227,6 +229,7 @@ func buildModel(cfg *Config, statuses map[string]bool) (*Model, error) {
 			Base:      cfg.Site.URL + basePath,
 			Version:   version,
 			Credit:    cfg.Site.Credit == nil || *cfg.Site.Credit,
+			ShowVer:   cfg.Site.ShowVer,
 			SiteTitle: cfg.Site.Title.Get(loc, def),
 			Logo:      appURL(cfg.Site.Logo),
 			Favicon:   appURL(cfg.Site.Favicon),
@@ -258,6 +261,7 @@ func buildModel(cfg *Config, statuses map[string]bool) (*Model, error) {
 				Top:               cfg.Str(loc, "nav.top"),
 			},
 		}
+		base.VerLabel, base.VerHref = versionInfo(version)
 		for _, l := range cfg.Site.Links {
 			lv := linkView{Label: l.Label.Get(loc, def), URL: l.URL}
 			linkIcon(&lv, l.Icon)
@@ -414,4 +418,28 @@ func mediaURL(src string) string {
 		return src
 	}
 	return "/media/" + src
+}
+
+// The repository the credit and the version stamp point at.
+const repoURL = "https://github.com/MorganKryze/cairn"
+
+var (
+	semverRe = regexp.MustCompile(`^\d+\.\d+\.\d+`)
+	commitRe = regexp.MustCompile(`^[0-9a-f]{7,40}$`)
+)
+
+// versionInfo turns the build stamp into what the footer shows and where it
+// points, which depends on where the binary came from: a tagged release links
+// to its release notes, a build off main links to the commit it was cut from,
+// and anything else (a local `go build`, which stamps nothing) is named but
+// not linked, since there is no public page for it.
+func versionInfo(v string) (label, href string) {
+	switch {
+	case semverRe.MatchString(v):
+		return v, repoURL + "/releases/tag/v" + v
+	case commitRe.MatchString(v):
+		return "@" + v[:7], repoURL + "/commit/" + v
+	default:
+		return v, ""
+	}
 }

--- a/src/templates/layout.tmpl
+++ b/src/templates/layout.tmpl
@@ -75,7 +75,7 @@
 {{define "bottom"}}</div></main>
 <footer><div class="wrap foot">
   {{if .Footer}}<div class="foot-links">{{range .Footer}}<a href="{{.URL}}">{{.Label}}</a>{{end}}</div>
-  {{end}}{{if .Credit}}<span class="powered"><span class="foot-mark">{{template "glyph"}}</span>{{.S.Powered}} <a href="https://github.com/MorganKryze/cairn" title="cairn {{.Version}}">cairn</a></span>
+  {{end}}{{if .Credit}}<span class="powered"><span class="foot-mark">{{template "glyph"}}</span>{{.S.Powered}} <a href="https://github.com/MorganKryze/cairn" title="cairn {{.Version}}">cairn</a>{{if .ShowVer}} {{if .VerHref}}<a class="foot-version" href="{{.VerHref}}">{{.VerLabel}}</a>{{else}}<span class="foot-version">{{.VerLabel}}</span>{{end}}{{end}}</span>
   {{end}}</div></footer>
 <a class="totop" href="#top" aria-label="{{.S.Top}}"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 19V5M5 12l7-7 7 7"/></svg></a>
 <script src="{{.Prefix}}/static/search.js" defer></script>

--- a/src/version_test.go
+++ b/src/version_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The footer stamp reads differently depending on where the binary came from,
+// and each shape has to point somewhere useful, or nowhere at all.
+func TestVersionInfo(t *testing.T) {
+	for _, c := range []struct{ in, label, href string }{
+		{"1.8.0", "1.8.0", repoURL + "/releases/tag/v1.8.0"},
+		{"1.8.0-rc1", "1.8.0-rc1", repoURL + "/releases/tag/v1.8.0-rc1"},
+		{"10.2.13", "10.2.13", repoURL + "/releases/tag/v10.2.13"},
+		{"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0", "@a1b2c3d", repoURL + "/commit/a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0"},
+		{"a1b2c3d", "@a1b2c3d", repoURL + "/commit/a1b2c3d"},
+		// nothing public to link to for these
+		{"dev", "dev", ""},
+		{"unstable", "unstable", ""},
+		{"", "", ""},
+	} {
+		label, href := versionInfo(c.in)
+		if label != c.label || href != c.href {
+			t.Errorf("versionInfo(%q) = (%q, %q), want (%q, %q)", c.in, label, href, c.label, c.href)
+		}
+	}
+}
+
+// Off by default: an operator who never heard of the key sees the footer they
+// already had.
+func TestShowVersionIsOptIn(t *testing.T) {
+	storeModel(t, map[string]string{
+		"site.yaml":     "locales: [en]\n",
+		"services.yaml": "- {id: pad, url: https://pad.example.org, name: Pad}\n",
+	})
+	if html := string(current.Load().Pages["en"].HTML); strings.Contains(html, "foot-version") {
+		t.Error("the version stamp showed up without show_version")
+	}
+}
+
+func TestShowVersionRenders(t *testing.T) {
+	prev := version
+	t.Cleanup(func() { version = prev })
+
+	// a tagged build names its release and links to it
+	version = "1.8.0"
+	storeModel(t, map[string]string{
+		"site.yaml":     "locales: [en]\nshow_version: true\n",
+		"services.yaml": "- {id: pad, url: https://pad.example.org, name: Pad}\n",
+	})
+	html := string(current.Load().Pages["en"].HTML)
+	want := `<a class="foot-version" href="` + repoURL + `/releases/tag/v1.8.0">1.8.0</a>`
+	if !strings.Contains(html, want) {
+		t.Errorf("missing the release stamp %s", want)
+	}
+
+	// an untagged build names its commit instead
+	version = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0"
+	storeModel(t, map[string]string{
+		"site.yaml":     "locales: [en]\nshow_version: true\n",
+		"services.yaml": "- {id: pad, url: https://pad.example.org, name: Pad}\n",
+	})
+	html = string(current.Load().Pages["en"].HTML)
+	if !strings.Contains(html, `/commit/a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0">@a1b2c3d</a>`) {
+		t.Error("missing the commit stamp")
+	}
+
+	// a local build is named but not linked
+	version = "dev"
+	storeModel(t, map[string]string{
+		"site.yaml":     "locales: [en]\nshow_version: true\n",
+		"services.yaml": "- {id: pad, url: https://pad.example.org, name: Pad}\n",
+	})
+	html = string(current.Load().Pages["en"].HTML)
+	if !strings.Contains(html, `<span class="foot-version">dev</span>`) {
+		t.Error("a local build should be named without a link")
+	}
+}
+
+// The stamp lives inside the credit, so turning the credit off takes it along:
+// no orphan version floating in an otherwise empty footer.
+func TestShowVersionFollowsTheCredit(t *testing.T) {
+	prev := version
+	version = "1.8.0"
+	t.Cleanup(func() { version = prev })
+
+	storeModel(t, map[string]string{
+		"site.yaml":     "locales: [en]\nshow_version: true\ncredit: false\n",
+		"services.yaml": "- {id: pad, url: https://pad.example.org, name: Pad}\n",
+	})
+	if html := string(current.Load().Pages["en"].HTML); strings.Contains(html, "foot-version") {
+		t.Error("the version stamp outlived the credit it belongs to")
+	}
+}


### PR DESCRIPTION
`show_version: true` in `site.yaml` prints the running cairn version next to the footer credit. Off by default, so nothing changes for anyone who does not ask for it.

What it shows depends on where the binary came from:

| build | footer | links to |
| --- | --- | --- |
| tagged release | `powered by cairn 1.8.0` | the release notes |
| off `main` | `powered by cairn @a1b2c3d` | that commit |
| local `go build` | `powered by cairn dev` | nothing, there is no public page |

The untagged image used to stamp the literal string `unstable`, which named nothing. It now stamps `github.sha`, so an `unstable` image can say exactly which revision it is, and link to it. That is the point of the feature: when someone reports a bug, the page itself says what it is running.

The stamp lives inside the credit, so `credit: false` takes it along rather than leaving an orphan version in an empty footer. A test pins that.

Also enabled on the demo config, so the live demo shows the feature. Say the word and I will turn it back off.

Schema, `site.md` and `reference.md` updated. Coverage 83.2%.