### PR TITLE
fix: tell monitors when no valid config ever loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,11 @@ account or a manual, and boring for you to operate.
 - **At home on a phone**: the layout reflows to one hand, the header steps
   aside as you scroll and returns the moment you head back up, and a burger
   keeps search within thumb's reach.
-- **Readable by everyone**: contrast that clears WCAG AA in both themes, a
-  skip link, named landmarks, results announced to screen readers, and
-  right-to-left languages laid out the right way round.
+- **Built to stay readable**: contrast measured against WCAG AA in both
+  themes, a skip link, named landmarks, search results announced through a
+  live region, and right-to-left languages laid out the right way round.
+  Tested with a browser, not yet with a real screen reader: if you use one,
+  [tell us what breaks](https://github.com/MorganKryze/cairn/issues).
 - **Calm typography, light and dark, keyboard-friendly**, and every feature
   degrades gracefully without JavaScript.
 
@@ -100,7 +102,14 @@ deliberately tight, from the image down to the wire.
 
 ## Quickstart
 
-Two files, one command:
+Nothing to write, nothing to mount, just look at it:
+
+```sh
+docker run --rm -p 8080:8080 ghcr.io/morgankryze/cairn:stable
+```
+
+That is a running cairn on <http://localhost:8080>, telling you what to feed
+it. When you are ready to feed it, two files and one command:
 
 ```yaml
 # config/services.yaml

--- a/docs/configuration/i18n.md
+++ b/docs/configuration/i18n.md
@@ -66,6 +66,12 @@ strings:
 Missing your language? Adding it to cairn itself is a small, welcome pull
 request: see [Add your language](../../CONTRIBUTING.md#add-your-language).
 
+A word on quality: French and English are written by someone who speaks them.
+The other five are careful but unreviewed, and interface words are exactly
+where a slightly-off translation grates. If one of them is your language and a
+string reads wrong, correcting it is a one-line pull request and genuinely
+welcome.
+
 ## Right-to-left languages
 
 Set a right-to-left locale and the page turns around on its own: cairn writes

--- a/docs/deployment/docker-compose.md
+++ b/docs/deployment/docker-compose.md
@@ -77,3 +77,30 @@ To build from source instead, replace `image:` with:
 ```
 
 Next: [Podman](podman.md)
+
+## Knowing it is actually serving your site
+
+There are two probes, and the difference matters the day a config edit goes
+wrong.
+
+`/healthz` answers `200` whenever the process is up, whatever the config says.
+That is what the container healthcheck above uses, and what a Kubernetes
+liveness probe should use: cairn deliberately serves a getting-started page
+rather than dying on a bad config, and a probe that killed it for that would
+undo the whole point.
+
+`/readyz` answers `503` while no valid config has ever loaded. Point your
+uptime monitor at that one. Otherwise the day you mount an empty volume by
+mistake, everything is green while your visitors read "Almost there".
+
+```yaml
+# Kubernetes, if that is where you run it
+livenessProbe:
+  httpGet: { path: /healthz, port: 8080 }
+readinessProbe:
+  httpGet: { path: /readyz, port: 8080 }
+```
+
+A reload that fails *after* a good boot keeps the last working pages and stays
+ready, which is the honest answer: the site is serving, just not the newest
+edit. The container log names the file and the line.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -91,7 +91,8 @@ ids, alphabetically.
 | `/static/…`     | embedded assets, cached one day                           |
 | `/assets/…`     | your mounted files, if the mount exists                   |
 | `/custom.css`   | your stylesheet, if present                               |
-| `/healthz`      | `200 ok`; stays at the domain root even with `-base-path` |
+| `/healthz`      | `200 ok` while the process serves, whatever the config says: the liveness signal |
+| `/readyz`       | `200 ready`, or `503` while no valid config has ever loaded and the getting-started page stands in |
 | `/sitemap.xml`  | every page, absolute URLs from `Host`/`X-Forwarded-Proto` |
 | `/robots.txt`   | allow all + sitemap URL                                   |
 
@@ -113,7 +114,7 @@ ids, alphabetically.
 With `-base-path`, every path above moves under the prefix (`/cairn/en/`,
 `/cairn/static/…`) and cairn strips it back off itself, so the proxy in front
 needs no rewriting. `/healthz` is the one exception: it answers at the root
-too, because container healthchecks reach cairn directly.
+too, alongside `/readyz`, because an orchestrator reaches cairn directly.
 
 ## The display font
 

--- a/src/hardening_test.go
+++ b/src/hardening_test.go
@@ -105,3 +105,34 @@ func TestLiveRegionAttributesAreNotJSEscaped(t *testing.T) {
 		t.Error("the count string was JS-escaped: an attribute is being read as an on* handler")
 	}
 }
+
+// A container whose config never loaded serves the getting-started page. It is
+// alive, so /healthz says so and a liveness probe leaves it running; it is not
+// serving the operator's site, so /readyz says that plainly instead of letting
+// a monitor sit green on "Almost there".
+func TestReadinessSplitsFromLiveness(t *testing.T) {
+	current.Store(starterModel())
+	rec := httptest.NewRecorder()
+	healthz(rec, httptest.NewRequest("GET", "/healthz", nil))
+	if rec.Code != http.StatusOK {
+		t.Errorf("healthz on a stand-in page = %d, want 200: a liveness probe must not restart it", rec.Code)
+	}
+	rec = httptest.NewRecorder()
+	readyz(rec, httptest.NewRequest("GET", "/readyz", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("readyz with no valid config = %d, want 503", rec.Code)
+	}
+
+	// once a real config lands, both agree
+	storeModel(t, map[string]string{
+		"site.yaml":     "locales: [en]\n",
+		"services.yaml": "- {id: pad, url: https://pad.example.org, name: Pad}\n",
+	})
+	for name, h := range map[string]http.HandlerFunc{"healthz": healthz, "readyz": readyz} {
+		rec = httptest.NewRecorder()
+		h(rec, httptest.NewRequest("GET", "/"+name, nil))
+		if rec.Code != http.StatusOK {
+			t.Errorf("%s with a valid config = %d, want 200", name, rec.Code)
+		}
+	}
+}

--- a/src/main.go
+++ b/src/main.go
@@ -127,6 +127,7 @@ func main() {
 	// Service preview images live next to the yaml, in <config>/media/.
 	mux.Handle("GET /media/", http.StripPrefix("/media/", noListing(http.FileServer(http.Dir(filepath.Join(*cfgDir, "media"))))))
 	mux.HandleFunc("GET /healthz", healthz)
+	mux.HandleFunc("GET /readyz", readyz)
 	mux.HandleFunc("GET /custom.css", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "no-cache")
 		http.ServeFile(w, r, filepath.Join(*cfgDir, "custom.css"))
@@ -155,17 +156,33 @@ func main() {
 	log.Fatal(srv.ListenAndServe())
 }
 
+// healthz answers while the process serves, whatever the config says. It is
+// the liveness signal: a broken config is not a reason to kill a container
+// that is happily serving the getting-started page.
 func healthz(w http.ResponseWriter, _ *http.Request) { io.WriteString(w, "ok\n") }
 
-// mount puts the whole site under basePath. /healthz stays at the root
-// whatever the prefix: a container healthcheck talks to cairn directly, not
-// through the proxy that adds it.
+// readyz is the honest one: 503 while no valid config has ever loaded, so a
+// monitor does not sit green on a site that only says "Almost there". A
+// reload that fails later keeps the last good pages, which is degraded but
+// genuinely serving, so it stays ready.
+func readyz(w http.ResponseWriter, _ *http.Request) {
+	if !current.Load().Ready {
+		http.Error(w, "no valid config yet\n", http.StatusServiceUnavailable)
+		return
+	}
+	io.WriteString(w, "ready\n")
+}
+
+// mount puts the whole site under basePath. The two probes stay at the root
+// whatever the prefix: an orchestrator talks to cairn directly, not through
+// the proxy that adds it.
 func mount(h http.Handler) http.Handler {
 	if basePath == "" {
 		return h
 	}
 	outer := http.NewServeMux()
 	outer.HandleFunc("GET /healthz", healthz)
+	outer.HandleFunc("GET /readyz", readyz)
 	// registering the subtree also makes ServeMux redirect a bare /cairn to
 	// /cairn/, so the mount point works with or without its trailing slash
 	outer.Handle(basePath+"/", http.StripPrefix(basePath, h))

--- a/src/render.go
+++ b/src/render.go
@@ -33,6 +33,10 @@ type Model struct {
 	Pages    map[string]Page
 	Statuses map[string]bool
 	CSP      string
+	// Ready is false only while the getting-started page stands in for a
+	// config that never loaded. /readyz reports it; /healthz does not, so a
+	// liveness probe cannot restart-loop a container that is serving fine.
+	Ready bool
 }
 
 // prePaintScript must stay byte-identical to the inline script in
@@ -362,7 +366,7 @@ func buildModel(cfg *Config, statuses map[string]bool) (*Model, error) {
 			pages[loc+"/"+p.ID] = page
 		}
 	}
-	return &Model{Cfg: cfg, Pages: pages, Statuses: statuses, CSP: buildCSP(cfg)}, nil
+	return &Model{Cfg: cfg, Pages: pages, Statuses: statuses, CSP: buildCSP(cfg), Ready: true}, nil
 }
 
 func render(name string, v any) (Page, error) {

--- a/src/starter.go
+++ b/src/starter.go
@@ -32,6 +32,7 @@ func starterModel() *Model {
 		// Templates are embedded; this cannot fail outside development.
 		log.Fatal(err)
 	}
+	m.Ready = false // this page is a stand-in, not the operator's site
 	return m
 }
 


### PR DESCRIPTION
Three small things, all found by asking what an operator actually experiences.

**A container with a broken config reported healthy.** cairn deliberately serves the getting-started page instead of dying, which is right, but `/healthz` answered `200` all the same: the uptime monitor sat green while visitors read "Almost there".

Turning `/healthz` into the honest one would have been wrong. A Kubernetes liveness probe on it would then restart-loop a container whose config is broken, undoing the very reason the getting-started page exists. So the two signals are split instead:

- `/healthz` stays liveness: 200 whenever the process serves, whatever the config says.
- `/readyz` is new: `503` while no valid config has ever loaded, `200` otherwise.

A reload that fails *after* a good boot keeps the last working pages and stays ready, which is the truth: serving, just not the newest edit.

**The README never mentioned that cairn runs with no config at all.** `docker run --rm -p 8080:8080 ghcr.io/morgankryze/cairn:stable` gives a working page that explains the next step. The Quickstart opened with a compose file and a volume, so a reader assumed setup was required. That one line is the cheapest thing to try in the whole project.

**Two claims were ahead of the evidence.** The accessibility bullet now says what was actually measured and admits no real screen reader has been used, with an invitation to report. The languages page says plainly that French and English are written by a speaker and the other five are careful but unreviewed, which turns a soft spot into a one-line contribution.

Verified on a running binary: broken config gives healthz 200 and readyz 503, valid config gives both 200, and under `-base-path` both probes stay at the domain root.