### PR TITLE
docs: the comparison, the scratch argument, and a Kubernetes page

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ understanding how a thing works, start anywhere below.
 | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Start**     | [Getting started](docs/getting-started.md), the five-minute path                                                                                                     |
 | **Configure** | [Services](docs/configuration/services.md) · [Site](docs/configuration/site.md) · [Text](docs/configuration/text.md) · [Theming](docs/configuration/theming.md) · [Languages](docs/configuration/i18n.md) |
-| **Deploy**    | [Docker Compose](docs/deployment/docker-compose.md) · [Podman](docs/deployment/podman.md) · [Bare binary](docs/deployment/binary.md) · [Reverse proxies](docs/deployment/reverse-proxies.md)                                                          |
+| **Deploy**    | [Docker Compose](docs/deployment/docker-compose.md) · [Podman](docs/deployment/podman.md) · [Bare binary](docs/deployment/binary.md) · [Kubernetes](docs/deployment/kubernetes.md) · [Reverse proxies](docs/deployment/reverse-proxies.md)                                                          |
 | **Recipes**   | [Status page with Gatus](docs/recipes/gatus.md) · [Icons](docs/recipes/icons.md) · [Multiple files](docs/recipes/multiple-files.md) · [Migration](docs/recipes/migration.md)                                  |
 | **Look up**   | [Reference](docs/reference.md) · [FAQ](docs/faq.md) · [Comparison](docs/comparison.md)                                                                               |
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/github/v/release/MorganKryze/cairn?label=release&color=247b7b)](https://github.com/MorganKryze/cairn/releases)
 [![License: GPL-3.0](https://img.shields.io/badge/license-GPL--3.0-blue.svg)](LICENSE)
 [![Go](https://img.shields.io/badge/Go-single%20static%20binary-00ADD8?logo=go&logoColor=white)](https://go.dev)
-[![Image](https://img.shields.io/badge/image-FROM%20scratch%20·%20~14%20MB-2496ED?logo=docker&logoColor=white)](https://github.com/MorganKryze/cairn/pkgs/container/cairn)
+[![Image](https://img.shields.io/badge/image-FROM%20scratch%20·%20under%2010%20MB-2496ED?logo=docker&logoColor=white)](https://github.com/MorganKryze/cairn/pkgs/container/cairn)
 [![Self-hosted](https://img.shields.io/badge/self--hosted-yes-ff69b4)](docs/deployment/docker-compose.md)
 
 </div>
@@ -63,7 +63,7 @@ account or a manual, and boring for you to operate.
 
 ## What you get as the operator
 
-- **One static binary, ~14 MB**, zero runtime dependencies, no database.
+- **One static binary, under 10 MB**, zero runtime dependencies, no database.
 - **YAML mounted read-only**; edits apply live within seconds, and a config
   error names the file, the line and the expected shape instead of taking the
   site down.

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ reading anything: <https://cairn.libresoftware.cloud>.
 - [Docker Compose](deployment/docker-compose.md): the hardened reference setup.
 - [Podman](deployment/podman.md): the same container as a systemd quadlet.
 - [Bare binary](deployment/binary.md): no container, a hardened systemd unit.
+- [Kubernetes](deployment/kubernetes.md): a ConfigMap, a Deployment, no volume.
 - [Reverse proxies](deployment/reverse-proxies.md): Caddy, Traefik, Nginx, Pangolin.
 
 **Recipes**

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,7 +1,20 @@
 # Comparison
 
-Honest guide. These are good projects; pick by audience, not by feature
-count.
+If you already run a dashboard, cairn is probably not a replacement for it.
+
+Every project on this page draws a grid of links in cards, so the family
+resemblance is real. The difference is who the grid is drawn for. Homer,
+Homepage, Dashy and the rest are built for the person who runs the server:
+dense, informative, tuned to an operator's eye. cairn is built for the people
+that person hosts services *for*, who did not choose the stack, do not know
+what a container is, and mostly want to know what this place is and whether
+the thing they need works right now.
+
+Which is why plenty of setups run both: Homepage on the private side for you,
+cairn on the public side for everyone else. They are not competing for the
+same tab.
+
+## Pick by audience
 
 | You want                                          | Use          |
 | ------------------------------------------------- | ------------ |
@@ -14,30 +27,57 @@ count.
 | A portal with per-user tabs wrapped around Plex and the \*arrs | [Organizr](https://github.com/causefx/Organizr) |
 | Shared boards for a household or team, edited in a GUI, with accounts | [Homarr](https://github.com/homarr-labs/homarr) |
 
-Where cairn stands apart:
+## What cairn does that a dashboard does not
 
-- **Guest-first content.** Descriptions answer "what does this do for me",
-  detail pages answer "when would I use it". No uptime numbers, no CPU
-  graphs: your visitors don't run the servers.
-- **Structural i18n.** One config with translations inline; language
-  detection, switcher, per-locale SEO. The others need one config per
-  language, if that.
-- **Editorial layout.** A hero that says what the place is, typography meant
-  for reading, not a wall of tiles.
+- **It writes for guests.** Descriptions answer "what does this do for me",
+  optional detail pages answer "when would I use it". No uptime percentages,
+  no CPU graphs: the people reading do not run the servers, and numbers they
+  cannot act on are noise.
+- **It speaks their language, structurally.** One config carries every
+  translation inline, the server negotiates from the browser, a switcher pins
+  the choice, and each locale gets its own canonical and `hreflang`. Seven
+  interface languages ship built in, and right-to-left scripts lay out
+  properly rather than being bolted on.
+- **It serves the legal pages.** Legal notice, privacy, anything else you
+  need, from the same YAML. Self-hosters, and associations especially, are
+  required to publish these and usually have nowhere to put them.
+- **It says where each service lives.** An optional flag marks a tool as
+  self-hosted or external, so a visitor can see at a glance which links keep
+  their data on your machine and which hand it to someone else. That is a
+  trust question, and no dashboard answers it because operators already know.
+- **It can make no third-party request at all.** Icons are served from your
+  own files if you want them to be, there is no CDN font, no analytics, no
+  outbound call except the one Gatus URL you configure. The
+  [demo](../demo/README.md) runs on a network with no route out to prove it.
+- **It is a sub-10 MB `FROM scratch` image**, non-root, no shell, no interpreter,
+  one Go dependency. The image is signed, ships SLSA provenance and an SBOM,
+  and the binaries are attested. That matters when the page is the one thing
+  you expose publicly.
+- **It reads like a page, not a control panel.** A hero that says what this
+  place is, typography meant for prose, contrast measured against WCAG AA, and
+  every feature still working with JavaScript turned off.
 
-Where the others win, so you don't discover it late:
+## What the others do that cairn never will
 
-- cairn has **no widgets and no integrations**: it will not show download
-  speeds, container states or calendar events, and that's permanent.
-- **No auth, no users, no admin UI**: config is a mounted file, the page is
-  public by design.
-- **No per-guest views** (that is accounts wearing a costume) and **no
-  analytics** (your reverse proxy log already counts visits). Organizr and
-  Homarr do these well precisely because they embraced users and state;
+Worth knowing now rather than discovering after you have migrated.
+
+- **No widgets, no integrations.** cairn will not show download speeds,
+  container states or calendar events. That is permanent, not a roadmap item.
+- **No auth, no users, no admin UI.** The config is a file you mount read
+  only; the page is public by design. Nothing to log into, nothing to lock.
+- **No per-guest views**, which are accounts wearing a costume, and **no
+  analytics**, because your reverse proxy log already counts visits. Organizr
+  and Homarr do these well precisely because they embraced users and state.
   cairn stays the page before the login.
-- If the audience is *you*, Homer or Homepage will make you happier; admin
-  dashboards are their home turf, and cairn's guest features would just be in
+- **No Docker socket**, so nothing is auto-discovered. You write the services
+  you want shown, which is a chore the others spare you and a permission cairn
+  never needs.
+- If the audience is *you*, Homer or Homepage will make you happier. Admin
+  dashboards are their home turf, and cairn's guest features would only get in
   your way.
 
-All of the above share the deployment model: one container, a YAML file, no
-database.
+## Coming from one of them
+
+Homer and Homepage configs map over field by field: see
+[Migration](recipes/migration.md). You do not have to choose, and most people
+who adopt cairn keep the dashboard they already had.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -49,10 +49,18 @@ same tab.
   own files if you want them to be, there is no CDN font, no analytics, no
   outbound call except the one Gatus URL you configure. The
   [demo](../demo/README.md) runs on a network with no route out to prove it.
-- **It is a sub-10 MB `FROM scratch` image**, non-root, no shell, no interpreter,
-  one Go dependency. The image is signed, ships SLSA provenance and an SBOM,
-  and the binaries are attested. That matters when the page is the one thing
-  you expose publicly.
+- **The image holds two files.** `FROM scratch` is stricter than distroless:
+  distroless removes the distribution but keeps a small userland, so a scanner
+  still finds packages in it. cairn's image contains the binary and a CA
+  bundle, and nothing else. No shell for a compromised process to spawn, no
+  package manager, no libc, so an entire family of advisories simply does not
+  apply. Trivy reports one target, the Go binary itself. Under 10 MB, non-root,
+  one Go dependency, and the image is signed with SLSA provenance and an SBOM.
+
+  This removes somewhere to go, not the possibility of a bug: a flaw in cairn
+  is still a flaw. What it buys is that the flaw has no shell to pivot into and
+  nothing to install, and that your scanner stays empty without you patching
+  anything.
 - **It reads like a page, not a control panel.** A hero that says what this
   place is, typography meant for prose, contrast measured against WCAG AA, and
   every feature still working with JavaScript turned off.
@@ -81,3 +89,14 @@ Worth knowing now rather than discovering after you have migrated.
 Homer and Homepage configs map over field by field: see
 [Migration](recipes/migration.md). You do not have to choose, and most people
 who adopt cairn keep the dashboard they already had.
+
+That said, cairn exists because its author did choose. I ran Homer as the
+public page and a separate dashboard for myself, and cairn replaced both. Not
+because it does more, but because once the config is YAML in a repository and
+deployment is GitOps, the admin side of what I actually used was a list of
+links I could already read. The widgets I thought I needed turned out to be
+things I looked at once a month.
+
+Whether that works for you is a question about your habits, not about the
+software. If you genuinely watch container states or download queues from your
+dashboard, keep it: cairn will never show them.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -16,14 +16,14 @@ same tab.
 
 ## Pick by audience
 
-| You want                                          | Use          |
-| ------------------------------------------------- | ------------ |
-| A page your **guests** read: plain language, their language, "what is this and when do I use it" | **cairn**    |
-| A fast personal tile board, huge theme ecosystem  | [Homer](https://github.com/bastienwirtz/homer) |
+| You want | Use |
+| --- | --- |
+| A page your **guests** read: plain language, their language, "what is this and when do I use it" | **cairn** |
+| A fast personal tile board, huge theme ecosystem | [Homer](https://github.com/bastienwirtz/homer) |
 | Widgets and live integrations (Docker, \*arr, monitoring) on your own dashboard | [Homepage](https://github.com/gethomepage/homepage) |
 | A feeds-and-widgets start page (RSS, weather, markets) | [Glance](https://github.com/glanceapp/glance) |
-| A dashboard with a built-in config UI and auth    | [Dashy](https://github.com/Lissy93/dashy) |
-| The most minimal start page with pinned apps      | [Flame](https://github.com/pawelmalak/flame) |
+| A dashboard with a built-in config UI and auth | [Dashy](https://github.com/Lissy93/dashy) |
+| The most minimal start page with pinned apps | [Flame](https://github.com/pawelmalak/flame) |
 | A portal with per-user tabs wrapped around Plex and the \*arrs | [Organizr](https://github.com/causefx/Organizr) |
 | Shared boards for a household or team, edited in a GUI, with accounts | [Homarr](https://github.com/homarr-labs/homarr) |
 

--- a/docs/deployment/binary.md
+++ b/docs/deployment/binary.md
@@ -52,4 +52,4 @@ read-only, and cairn never writes anything anyway. Edit the YAML and the
 page follows within seconds; `journalctl -u cairn -f` shows the same logs
 `docker logs` would.
 
-Next: [Reverse proxies](reverse-proxies.md)
+Next: [Kubernetes](kubernetes.md)

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -1,0 +1,146 @@
+# Kubernetes
+
+cairn happens to fit Kubernetes almost too well: one stateless container, no
+database, no persistent volume, no write anywhere. The whole deployment is a
+ConfigMap holding your YAML, a Deployment reading it, a Service, and whatever
+you already use for ingress.
+
+## The whole thing
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cairn-config
+data:
+  site.yaml: |
+    title: Our tools
+    locales: [fr, en]
+    about:
+      fr: Bienvenue. Voici les services que nous hébergeons.
+      en: Welcome. Here are the services we host.
+  services.yaml: |
+    - id: pad
+      url: https://pad.example.org
+      icon: hedgedoc
+      name: { fr: Bloc-notes, en: Notepad }
+      desc: { fr: Écrire à plusieurs., en: Write together. }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cairn
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: cairn }
+  template:
+    metadata:
+      labels: { app: cairn }
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: cairn
+          image: ghcr.io/morgankryze/cairn:stable
+          ports:
+            - containerPort: 8080
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: ["ALL"] }
+          livenessProbe:
+            httpGet: { path: /healthz, port: 8080 }
+          readinessProbe:
+            httpGet: { path: /readyz, port: 8080 }
+          resources:
+            requests: { cpu: 10m, memory: 16Mi }
+            limits: { memory: 64Mi }
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+      volumes:
+        - name: config
+          configMap: { name: cairn-config }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cairn
+spec:
+  selector: { app: cairn }
+  ports:
+    - port: 80
+      targetPort: 8080
+```
+
+Add your usual Ingress or HTTPRoute pointing at the `cairn` Service on port 80.
+Forward `X-Forwarded-Proto` so `sitemap.xml` and `robots.txt` emit `https://`
+URLs; every common controller does it already.
+
+## Why the two probes differ
+
+`livenessProbe` uses `/healthz`, which answers `200` whenever the process is
+up, whatever the configuration says. That is deliberate. cairn serves a
+getting-started page instead of dying when the config is missing or invalid, so
+a liveness probe that failed on a bad config would restart-loop the pod and
+undo the point.
+
+`readinessProbe` uses `/readyz`, which answers `503` until a valid config has
+loaded. So a pod that came up with an empty ConfigMap is running, visible in
+`kubectl get pods`, and correctly kept out of the Service until it has
+something real to serve.
+
+## Editing the config
+
+Change the ConfigMap and cairn picks it up. No rollout, no restart.
+
+This is not luck. A ConfigMap mount is not an ordinary directory: kubelet never
+edits the files in place, it writes a new timestamped directory and atomically
+repoints a `..data` symlink at it. File watchers routinely miss that, which is
+exactly why cairn polls its config directory instead of using inotify.
+
+The one thing to expect is the delay. cairn polls every two seconds, but
+kubelet only refreshes a mounted ConfigMap on its own sync loop, up to about a
+minute. So an edit lands within a minute or so rather than instantly. If a new
+config is invalid, cairn logs the file and the line and keeps serving the
+previous pages, staying ready: the site is up, just not on your newest edit.
+
+## What does not fit in a ConfigMap
+
+- **Preview images.** A ConfigMap is limited to about 1 MiB and holds text.
+  Point `images:` at absolute URLs, or mount a volume at `/config/media`.
+- **Your own icons and logo.** Same answer: a second ConfigMap mounted at
+  `/assets` works for SVG, a volume for anything heavier. See
+  [Icons](../recipes/icons.md).
+- **A very large catalogue.** Hundreds of services still fit comfortably in
+  text, but if you split across many files, remember the limit applies to the
+  ConfigMap as a whole. [Multiple files](../recipes/multiple-files.md) works
+  the same way here: every `*.yaml` key in the mount is read.
+
+## Serving from a sub-path
+
+If your Ingress puts cairn under `example.org/cairn/` rather than its own host,
+tell cairn where it lives and it carries the prefix through every link,
+redirect and asset by itself, so the Ingress needs no rewrite annotation:
+
+```yaml
+          args: ["-base-path", "/cairn"]
+```
+
+Both probes keep answering at the root, so the manifest above stays valid.
+More in [Reverse proxies](reverse-proxies.md#under-a-sub-path).
+
+## Checking a config before it ships
+
+`cairn -check` validates a directory and exits non-zero, which makes it a
+natural gate in whatever pipeline renders your manifests:
+
+```sh
+docker run --rm -v ./config:/config ghcr.io/morgankryze/cairn:stable -check
+```
+
+Next: [Reverse proxies](reverse-proxies.md)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -42,7 +42,7 @@ Headings derive from the `category` id unless you name them in
 `categories.yaml`; see the [reference](reference.md#categoriesyaml).
 
 **How big is this?**
-One ~14 MB image, one process, a few MB of RAM. `FROM scratch`, non-root, no
+One sub-10 MB image, one process, a few MB of RAM. `FROM scratch`, non-root, no
 shell inside.
 
 **Can visitors switch language permanently?**


### PR DESCRIPTION
One documentation pass, three things validated together.

**The comparison page had the wrong job.** It was written around v1.6 and still described that cairn, missing the hosting flag, the legal pages, right-to-left and the signed supply chain. More importantly it argued feature by feature, when the question a reader actually arrives with is "how is this not another dashboard". It now concedes the family resemblance outright, since every one of these projects draws a grid of links in cards, and puts the difference where it belongs: who the grid is drawn for. Coexistence is stated rather than implied.

It also ends with the author's own migration, which is the most credible thing on the page: Homer for the public side plus a separate dashboard, both replaced, because once config is YAML in a repository the admin side was a list of links already. Placed so it qualifies the opening rather than contradicting it, with the condition and the caveat spelled out.

**`FROM scratch` is stricter than distroless, and the page now says why.** Distroless removes the distribution but keeps a userland, so a scanner still finds packages in it. Measured on the published 1.10.0 image, cairn's contains two files: the binary and a CA bundle. Trivy reports one target, the Go binary, and no OS layer at all. The claim is framed honestly: this removes somewhere to pivot, not the possibility of a bug.

**The image was advertised heavier than it is.** `~14 MB` appeared in the README badge, a README bullet, the FAQ and the comparison. Measured: 9.6 MB on amd64, 9.0 MB on arm64. All four now say under 10 MB. Understating your own product is a credibility leak in the direction nobody forgives, since anyone can check with one command.

**A Kubernetes page, which did not exist.** cairn is one stateless container with no database and no volume, so it fits unusually well, and the homelab audience increasingly runs k3s. The page carries a complete manifest set, explains why liveness uses `/healthz` while readiness uses `/readyz`, and covers what does not fit in a ConfigMap: preview images, own icons, the 1 MiB ceiling.

The part that could have been wrong was tested rather than assumed. A ConfigMap mount is not an ordinary directory: kubelet never edits files in place, it writes a timestamped directory and atomically repoints a `..data` symlink at it, which file watchers routinely miss. That exact structure and that exact swap were reproduced locally, and cairn reloaded (`config reloaded: 1 services`), which is precisely what the polling design in `watch` was chosen for. The manifests parse to three valid objects, and the example config in the ConfigMap passes `cairn -check`.
