### PR TITLE
Track the brand icons and the script that generates them

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ passed.
 
 With [just](https://just.systems) installed, `just` lists the shortcuts:
 `test`, `test-search`, `lint`, `build`, `demo`, `demo-rebuild`, `down`,
-`logs`, `hooks`.
+`logs`, `hooks`, `icons`.
 Linting is [golangci-lint](https://golangci-lint.run) with a near-default
 config (`.golangci.yml`); CI runs it on every code push.
 
@@ -91,6 +91,24 @@ it is safe to make a required check.
 Anything you change in `search.js` belongs there, particularly the paths back
 to an empty query: clearing the field, Escape, and typing only spaces all have
 to return the full list rather than "no results".
+
+## The icons
+
+Every icon comes from one drawing, in `scripts/icons.mjs`. `just icons`
+regenerates the lot: the five files the binary embeds and serves, and the three
+in `docs/assets/brand/` that the icon collections ask for, cropped to the mark
+rather than to its padded square. Running it on an unchanged mark rewrites the
+same bytes, so a diff after `just icons` means the drawing moved.
+
+Change the mark there and nowhere else. The same shapes are inlined in
+`layout.tmpl` as the icon a service without one falls back to, and
+`TestTheMarkIsDrawnTheSameInBothPlaces` fails if that copy stops matching
+`favicon.svg`; it has drifted a whole release before.
+
+The script also checks what the manifest promises: the app icons are declared
+`maskable`, which tells Android nothing lives outside the middle 80% of the
+square. It measures the rendered ink and exits non-zero if a redrawn mark
+breaks that.
 
 ## Releasing
 

--- a/docs/assets/brand/cairn-dark.svg
+++ b/docs/assets/brand/cairn-dark.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="3.188 2.563 25.063 26.438" fill="#1a5c5c"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg>

--- a/docs/assets/brand/cairn-light.svg
+++ b/docs/assets/brand/cairn-light.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="3.188 2.563 25.063 26.438" fill="#5fc4c0"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg>

--- a/docs/assets/brand/cairn.svg
+++ b/docs/assets/brand/cairn.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="3.188 2.563 25.063 26.438" fill="#247b7b"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg>

--- a/justfile
+++ b/justfile
@@ -64,3 +64,10 @@ test-search:
     @/tmp/cairn-search -config example -addr 127.0.0.1:8099 & echo $! > /tmp/cairn-search.pid
     @for _ in $(seq 1 20); do curl -fsS http://127.0.0.1:8099/healthz >/dev/null 2>&1 && break; sleep 1; done
     @node scripts/search.mjs http://127.0.0.1:8099/en/; s=$?; kill $(cat /tmp/cairn-search.pid); exit $s
+
+# regenerate every icon from the one drawing in the script; checks the
+# maskable safe zone the manifest promises Android
+icons:
+    @npm --silent install --no-save --no-package-lock playwright
+    @npx --yes playwright install --only-shell chromium
+    @node scripts/icons.mjs

--- a/scripts/icons.mjs
+++ b/scripts/icons.mjs
@@ -1,0 +1,171 @@
+// Every icon cairn ships, generated from the one drawing below, so none of the
+// set can drift from the rest. Run it with `just icons`.
+//
+//   src/internal/render/assets/     compiled into the binary and served
+//     favicon.svg             the tab icon; every current browser uses this
+//     favicon.ico             16/32/48, for the tools that fetch /favicon.ico
+//                             and never read the html
+//     touch-icon.png    180   apple-touch-icon: an iPhone or iPad home screen
+//     icon-192.png      192   Chromium offers "install" only with both of
+//     icon-512.png      512   these present; also the Android splash
+//
+//   docs/assets/brand/              not embedded, not served: for the icon
+//     cairn.svg               collections that ask for a copy of the mark,
+//     cairn-light.svg         cropped to its own edges the way they require.
+//     cairn-dark.svg          -light is for dark backgrounds, and vice versa:
+//                             their suffix names the background, not the ink.
+//
+// The mark is also inlined in templates/layout.tmpl, as the icon a service
+// falls back to when it declares none. That copy is pinned to favicon.svg by
+// TestTheMarkIsDrawnTheSameInBothPlaces, which is what keeps the two honest.
+import { chromium } from 'playwright';
+import { mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const ASSETS = join(ROOT, 'src', 'internal', 'render', 'assets');
+const BRAND = join(ROOT, 'docs', 'assets', 'brand');
+mkdirSync(BRAND, { recursive: true });
+
+// The mark: four stones of the same gauge, the top one set down at nine
+// degrees. Four rather than five because five merge into a cone at 16px, and
+// the tilt because a stack built by hand is not square to anything.
+const MARK =
+  '<rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/>' +
+  '<rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/>' +
+  '<rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/>' +
+  '<rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/>';
+
+const BRAND_INK = '#247b7b'; // the accent, and the only ink the product uses
+const ON_DARK = '#5fc4c0';   // -light: light ink, for dark backgrounds
+const ON_LIGHT = '#1a5c5c';  // -dark: dark ink, for light backgrounds
+const PAGE = '#eef0ea';      // the light page colour, under every app icon
+
+// How much of the square the mark covers in the app icons: as full as it can
+// be while its far corners still clear Android's crop circle. Checked below.
+const FILL = 0.69;
+
+const doc = (viewBox, fill) =>
+  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${viewBox}" fill="${fill}">${MARK}</svg>\n`;
+
+const browser = await chromium.launch();
+
+// Renders the mark to a png. A null background leaves it transparent, which is
+// what a favicon wants and what a home-screen icon must never be.
+async function png(size, fill, bg) {
+  const p = await browser.newPage({ viewport: { width: size, height: size }, deviceScaleFactor: 1 });
+  await p.setContent(`<!doctype html><meta charset="utf-8"><style>
+    html,body { margin:0; width:${size}px; height:${size}px; ${bg ? `background:${bg};` : ''} }
+    body { display:grid; place-items:center; }
+    svg { width:${size * fill}px; height:${size * fill}px; display:block; }
+  </style>${doc('0 0 32 32', BRAND_INK)}`);
+  const buf = await p.screenshot({ omitBackground: !bg });
+  await p.close();
+  return buf;
+}
+
+// An ICO is a small header plus, since Vista, plain pngs. No dependency needed.
+function ico(images) {
+  const dir = Buffer.alloc(6);
+  dir.writeUInt16LE(1, 2); // type: icon
+  dir.writeUInt16LE(images.length, 4);
+  let offset = 6 + images.length * 16;
+  const entries = images.map(({ size, data }) => {
+    const e = Buffer.alloc(16);
+    e.writeUInt8(size === 256 ? 0 : size, 0); // width, 0 means 256
+    e.writeUInt8(size === 256 ? 0 : size, 1); // height
+    e.writeUInt16LE(1, 4);  // colour planes
+    e.writeUInt16LE(32, 6); // bits per pixel
+    e.writeUInt32LE(data.length, 8);
+    e.writeUInt32LE(offset, 12);
+    offset += data.length;
+    return e;
+  });
+  return Buffer.concat([dir, ...entries, ...images.map((i) => i.data)]);
+}
+
+// Measures the ink in viewBox units, so the brand files can be cropped to the
+// mark rather than to its padded square. Measured off a raster rather than
+// computed: the tilted stone and its rounded corners put the analytic box out
+// by about a third of a unit.
+const probe = await browser.newPage({ viewport: { width: 600, height: 600 } });
+const inkBox = async (markup) => probe.evaluate(async (svg) => {
+  const S = 512;
+  const img = new Image();
+  await new Promise((r) => { img.onload = r; img.src = 'data:image/svg+xml;base64,' + btoa(svg); });
+  const c = document.createElement('canvas');
+  c.width = c.height = S;
+  const ctx = c.getContext('2d');
+  ctx.drawImage(img, 0, 0, S, S);
+  const { data } = ctx.getImageData(0, 0, S, S);
+  let x0 = S, y0 = S, x1 = 0, y1 = 0;
+  for (let y = 0; y < S; y++) {
+    for (let x = 0; x < S; x++) {
+      if (data[(y * S + x) * 4 + 3] > 8) {
+        if (x < x0) x0 = x; if (x > x1) x1 = x;
+        if (y < y0) y0 = y; if (y > y1) y1 = y;
+      }
+    }
+  }
+  const u = 32 / S;
+  return { x: x0 * u, y: y0 * u, w: (x1 - x0 + 1) * u, h: (y1 - y0 + 1) * u };
+}, markup);
+
+// --- the tab icon ---------------------------------------------------------
+writeFileSync(join(ASSETS, 'favicon.svg'), doc('0 0 32 32', BRAND_INK));
+writeFileSync(join(ASSETS, 'favicon.ico'), ico(
+  await Promise.all([16, 32, 48].map(async (size) => ({ size, data: await png(size, 1, null) }))),
+));
+
+// --- the home-screen icons ------------------------------------------------
+writeFileSync(join(ASSETS, 'touch-icon.png'), await png(180, FILL, PAGE));
+writeFileSync(join(ASSETS, 'icon-192.png'), await png(192, FILL, PAGE));
+writeFileSync(join(ASSETS, 'icon-512.png'), await png(512, FILL, PAGE));
+
+// --- the brand files, cropped to the ink ----------------------------------
+const box = await inkBox(doc('0 0 32 32', BRAND_INK));
+const r3 = (n) => Number(n.toFixed(3));
+const tight = `${r3(box.x)} ${r3(box.y)} ${r3(box.w)} ${r3(box.h)}`;
+writeFileSync(join(BRAND, 'cairn.svg'), doc(tight, BRAND_INK));
+writeFileSync(join(BRAND, 'cairn-light.svg'), doc(tight, ON_DARK));
+writeFileSync(join(BRAND, 'cairn-dark.svg'), doc(tight, ON_LIGHT));
+
+// --- and the guarantee the manifest makes ---------------------------------
+// The app icons are declared "any maskable", which promises Android that
+// nothing lives outside a circle of 80% of the canvas. That is a property of
+// FILL and of the mark's proportions, so a redrawn mark could quietly break it.
+let failed = false;
+for (const [name, size] of [['icon-192.png', 192], ['icon-512.png', 512], ['touch-icon.png', 180]]) {
+  const far = await probe.evaluate(async ([src, S]) => {
+    const img = new Image();
+    await new Promise((r) => { img.onload = r; img.src = src; });
+    const c = document.createElement('canvas');
+    c.width = c.height = S;
+    const ctx = c.getContext('2d');
+    ctx.drawImage(img, 0, 0);
+    const { data } = ctx.getImageData(0, 0, S, S);
+    const bg = [data[0], data[1], data[2]];
+    let d = 0;
+    for (let y = 0; y < S; y++) {
+      for (let x = 0; x < S; x++) {
+        const i = (y * S + x) * 4;
+        if (Math.abs(data[i] - bg[0]) + Math.abs(data[i + 1] - bg[1]) + Math.abs(data[i + 2] - bg[2]) <= 40) continue;
+        d = Math.max(d, Math.hypot(x + 0.5 - S / 2, y + 0.5 - S / 2));
+      }
+    }
+    return d;
+  }, ['data:image/png;base64,' + readFileSync(join(ASSETS, name)).toString('base64'), size]);
+
+  const safe = 0.4 * size;
+  const ok = far <= safe;
+  failed ||= !ok;
+  console.log(`  ${name.padEnd(16)} farthest ink ${far.toFixed(1)}px / safe radius ${safe.toFixed(1)}px  ${ok ? 'ok' : 'OUTSIDE THE CROP'}`);
+}
+
+await browser.close();
+if (failed) {
+  console.error('\nan app icon reaches outside the maskable safe zone; lower FILL or redraw');
+  process.exit(1);
+}
+console.log(`\nbrand files cropped to viewBox="${tight}"`);


### PR DESCRIPTION
`docs/assets/brand/cairn.svg`, `-light` and `-dark` are now in the repository, next to `scripts/icons.mjs`, which produces them and everything else from the one drawing.

## Why both

The three brand files exist for the icon collections (dashboard-icons, selfh.st, and the listings after them), which ask for a copy of the mark cropped to its own edges rather than to the padded square the tab icon uses. They are not embedded and not served: putting them in `render/assets/` would compile two dead files into the image.

Tracking them alone would have been worse than not tracking them, though. Nobody could regenerate a 358-byte svg from memory once the mark moves, and `docs/configuration/site.md` already tells operators the set is "all generated from one drawing so none of it can drift" — a claim about a script that lived in a scratch directory. `just icons` makes that true and checkable.

## What the script does

Eight files from one `MARK` constant: the five the binary embeds (`favicon.svg`, `favicon.ico` at 16/32/48, `touch-icon.png`, `icon-192.png`, `icon-512.png`) and the three brand ones. The ico is assembled by hand, since it is only a header plus plain pngs and that beats a dependency. The brand crop is measured off a raster rather than computed: the tilted top stone and its rounded corners put the analytic bounding box out by about a third of a unit.

It also re-checks the promise the manifest makes. The app icons are declared `maskable`, which tells Android nothing lives outside the middle 80% of the square. That is a property of the fill ratio and of the mark's proportions, so a redrawn mark could break it silently. The script measures the rendered ink and exits non-zero:

```
  icon-192.png     farthest ink 71.5px / safe radius 76.8px  ok
  icon-512.png     farthest ink 190.3px / safe radius 204.8px  ok
  touch-icon.png   farthest ink 67.2px / safe radius 72.0px  ok
```

## Verified

Running `just icons` against the mark already in `main` rewrites the five embedded files **byte for byte**: `git status` shows nothing. That is the property that makes the script the source rather than a second opinion, so it was worth checking rather than assuming.

199 tests still pass. CONTRIBUTING gains a section saying the mark is changed there and nowhere else, and pointing at the test that pins the copy inlined in `layout.tmpl` — the copy that already went a whole release out of step.