### PR TITLE
Correct the light/dark suffix comment

### DIFF
--- a/scripts/icons.mjs
+++ b/scripts/icons.mjs
@@ -12,8 +12,12 @@
 //   docs/assets/brand/              not embedded, not served: for the icon
 //     cairn.svg               collections that ask for a copy of the mark,
 //     cairn-light.svg         cropped to its own edges the way they require.
-//     cairn-dark.svg          -light is for dark backgrounds, and vice versa:
-//                             their suffix names the background, not the ink.
+//     cairn-dark.svg
+//
+// The suffix names the ink, so -light is the pale one and belongs on a dark
+// background, -dark the deep one and belongs on a light background. It reads
+// backwards to anyone who parses "-light" as "for the light theme", which is
+// why it is the mistake those collections reject most often.
 //
 // The mark is also inlined in templates/layout.tmpl, as the icon a service
 // falls back to when it declares none. That copy is pinned to favicon.svg by


### PR DESCRIPTION
The comment in `scripts/icons.mjs` had the convention backwards. It said the suffix names the background; it names the ink.

`cairn-light.svg` is the pale one, and it is pale *because* it goes on a dark background. Both readings land in the same place, which is exactly why the sloppy phrasing survived being written down: the files were always right.

Measured, so this is not a matter of opinion:

| file | ink | luminance | on #eef0ea | on #14181a |
| --- | --- | --- | --- | --- |
| `cairn.svg` | `#247b7b` | 0.160 | 4.36:1 | 3.57:1 |
| `cairn-light.svg` | `#5fc4c0` | 0.457 | 1.80:1 | **8.63:1** |
| `cairn-dark.svg` | `#1a5c5c` | 0.086 | **6.70:1** | 2.32:1 |

The comment now also names the trap it exists to prevent: reading `-light` as "for the light theme" inverts the pair, and that is the mistake the icon collections reject most often.

No file output changes. `just icons` after this rewrites all eight bytes-identical.