### PR TITLE
Add a Helm chart, published and signed like the image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
       - "src/**"
       - "docker/**"
       - "demo/**"
+      - "charts/**"
       - "go.mod"
       - "go.sum"
       - ".github/workflows/build.yml"
@@ -76,6 +77,23 @@ jobs:
           /tmp/cairn -config example -addr 127.0.0.1:8099 &
           for _ in $(seq 1 20); do curl -fsS http://127.0.0.1:8099/healthz >/dev/null && break; sleep 1; done
           node scripts/search.mjs http://127.0.0.1:8099/en/
+
+  chart:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+      # `helm lint` reads the chart; rendering proves the templates actually
+      # produce manifests. Twice, because the Ingress is the half of the chart
+      # the default values never reach.
+      - name: lint and render the chart
+        run: |
+          helm lint charts/cairn
+          helm template cairn charts/cairn >/dev/null
+          helm template cairn charts/cairn \
+            --set ingress.enabled=true \
+            --set ingress.host=cairn.example.org \
+            --set ingress.tls.enabled=true >/dev/null
 
   image:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,3 +104,34 @@ jobs:
             cosign sign --yes "${tag%%:*}@${DIGEST}"
             break # one signature covers the digest, whatever tags point at it
           done
+
+
+  chart:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # pushes the chart as an OCI artifact to ghcr.io
+      id-token: write # cosign signs keylessly, same as the image
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      # Chart version and app version both come from the tag, so a chart
+      # pulled at 1.2.3 installs cairn 1.2.3 and there is no second number to
+      # remember at release time. What Chart.yaml carries in git only matters
+      # to someone installing from a checkout.
+      - name: package, push and sign the chart
+        env:
+          ACTOR: ${{ github.actor }}
+          OWNER: ${{ github.repository_owner }}
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          ns=$(echo "$OWNER" | tr '[:upper:]' '[:lower:]') # ghcr paths are lowercase, the owner is not
+          helm package charts/cairn --version "$version" --app-version "$version"
+          echo "$TOKEN" | helm registry login ghcr.io --username "$ACTOR" --password-stdin
+          helm push "cairn-${version}.tgz" "oci://ghcr.io/${ns}/charts"
+          cosign sign --yes "ghcr.io/${ns}/charts/cairn:${version}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,8 @@ The Docker build runs `go vet` and the test suite; if the image builds, it
 passed.
 
 With [just](https://just.systems) installed, `just` lists the shortcuts:
-`test`, `test-search`, `lint`, `build`, `demo`, `demo-rebuild`, `down`,
-`logs`, `hooks`, `icons`.
+`test`, `test-search`, `lint`, `build`, `chart`, `demo`, `demo-rebuild`,
+`down`, `logs`, `hooks`, `icons`.
 Linting is [golangci-lint](https://golangci-lint.run) with a near-default
 config (`.golangci.yml`); CI runs it on every code push.
 
@@ -33,6 +33,7 @@ src/internal/
   check/              backs -check: validates like a boot would
   testutil/           the one helper shared by every package's tests
 docker/               Dockerfile (FROM scratch) and the hardened compose
+charts/cairn/         the Helm chart, same objects as docs/deployment/kubernetes.md
 example/              the config served by the dev loop and the docs
 docs/                 GitHub-native Markdown, no generator
 ```
@@ -116,6 +117,12 @@ breaks that.
 demo. Run it before every release: the screenshot is the first thing anyone
 sees, and it goes stale quietly. Playwright installs itself into a gitignored
 `node_modules/` on demand, so nothing is added to the repository.
+
+The chart needs nothing at release time. CI packages it with the tag as both
+`version` and `appVersion`, so chart 1.2.3 installs cairn 1.2.3 and the numbers
+in `Chart.yaml` only matter to someone installing from a checkout. Changing the
+chart means changing [docs/deployment/helm.md](docs/deployment/helm.md) in the
+same PR: `values.yaml` is a public API, and renaming a key breaks installs.
 
 ## Conduct
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ understanding how a thing works, start anywhere below.
 | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Start**     | [Getting started](docs/getting-started.md), the five-minute path                                                                                                     |
 | **Configure** | [Services](docs/configuration/services.md) · [Site](docs/configuration/site.md) · [Text](docs/configuration/text.md) · [Theming](docs/configuration/theming.md) · [Languages](docs/configuration/i18n.md) |
-| **Deploy**    | [Docker Compose](docs/deployment/docker-compose.md) · [Podman](docs/deployment/podman.md) · [Bare binary](docs/deployment/binary.md) · [Kubernetes](docs/deployment/kubernetes.md) · [Reverse proxies](docs/deployment/reverse-proxies.md)                                                          |
+| **Deploy**    | [Docker Compose](docs/deployment/docker-compose.md) · [Podman](docs/deployment/podman.md) · [Bare binary](docs/deployment/binary.md) · [Kubernetes](docs/deployment/kubernetes.md) · [Helm](docs/deployment/helm.md) · [Reverse proxies](docs/deployment/reverse-proxies.md)                                                          |
 | **Recipes**   | [Status page with Gatus](docs/recipes/gatus.md) · [Icons](docs/recipes/icons.md) · [Multiple files](docs/recipes/multiple-files.md) · [Migration](docs/recipes/migration.md)                                  |
 | **Look up**   | [Reference](docs/reference.md) · [FAQ](docs/faq.md) · [Comparison](docs/comparison.md)                                                                               |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,6 +31,15 @@ cosign verify ghcr.io/morgankryze/cairn:stable \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
 
+The [Helm chart](docs/deployment/helm.md) is published the same way, as an OCI
+artifact next to the image, and signed by the same workflow:
+
+```sh
+cosign verify ghcr.io/morgankryze/charts/cairn:1.12.0 \
+  --certificate-identity-regexp '^https://github.com/MorganKryze/cairn/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
 It also ships SLSA build provenance and a software bill of materials:
 
 ```sh

--- a/charts/cairn/Chart.yaml
+++ b/charts/cairn/Chart.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+name: cairn
+description: The directory page for the people you host services for
+type: application
+
+# Both fields are stamped from the git tag when the release workflow packages
+# the chart, so a published chart always carries the cairn it installs. What
+# is written here only matters to someone running `helm install ./charts/cairn`
+# from a checkout.
+version: 1.11.0
+appVersion: "1.11.0"
+
+# networking.k8s.io/v1 Ingress, which is 1.19 and later. Declaring it here
+# means the templates can use one API version instead of sniffing .Capabilities.
+kubeVersion: ">=1.19.0-0"
+
+home: https://cairn.libresoftware.cloud
+sources:
+  - https://github.com/MorganKryze/cairn
+icon: https://raw.githubusercontent.com/MorganKryze/cairn/main/src/internal/render/assets/favicon.svg
+keywords:
+  - directory
+  - homepage
+  - dashboard
+  - self-hosted
+  - gatus
+maintainers:
+  - name: MorganKryze
+    url: https://github.com/MorganKryze

--- a/charts/cairn/templates/NOTES.txt
+++ b/charts/cairn/templates/NOTES.txt
@@ -1,0 +1,18 @@
+cairn {{ .Chart.AppVersion }} is coming up as {{ include "cairn.fullname" . }} in namespace {{ .Release.Namespace }}.
+{{ if .Values.ingress.enabled }}
+Your page: http{{ if .Values.ingress.tls.enabled }}s{{ end }}://{{ .Values.ingress.host }}{{ .Values.basePath }}/
+{{ else }}
+No Ingress in this release, so reach it directly for now:
+
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "cairn.fullname" . }} 8080:{{ .Values.service.port }}
+
+then open http://localhost:8080{{ .Values.basePath }}/
+{{ end }}
+{{- if and (not .Values.config) (not .Values.existingConfigMap) }}
+There is no config yet, which is a valid state rather than a failure: cairn
+serves its getting-started page and readiness keeps it out of the Service
+until you feed it. Put your YAML under `config:` in your values file, or point
+`existingConfigMap:` at your own, and it lands within a minute, no restart.
+
+  https://github.com/MorganKryze/cairn/blob/main/docs/getting-started.md
+{{ end }}

--- a/charts/cairn/templates/_helpers.tpl
+++ b/charts/cairn/templates/_helpers.tpl
@@ -1,0 +1,29 @@
+{{/*
+The name every resource in the release takes.
+
+`helm install cairn …` gives plain "cairn" rather than "cairn-cairn"; any
+other release name is prefixed, so two cairns can share a namespace.
+
+No nameOverride / fullnameOverride: nobody has asked, and adding a value later
+breaks nothing for anyone.
+*/}}
+{{- define "cairn.fullname" -}}
+{{- if eq .Release.Name .Chart.Name -}}
+{{- .Chart.Name -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* What the Service selects on: immutable once installed, so it stays small. */}}
+{{- define "cairn.selectorLabels" -}}
+app.kubernetes.io/name: cairn
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "cairn.labels" -}}
+{{ include "cairn.selectorLabels" . }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/charts/cairn/templates/configmap.yaml
+++ b/charts/cairn/templates/configmap.yaml
@@ -1,0 +1,10 @@
+{{- if not .Values.existingConfigMap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cairn.fullname" . }}
+  labels:
+    {{- include "cairn.labels" . | nindent 4 }}
+data:
+  {{- toYaml .Values.config | nindent 2 }}
+{{- end }}

--- a/charts/cairn/templates/deployment.yaml
+++ b/charts/cairn/templates/deployment.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cairn.fullname" . }}
+  labels:
+    {{- include "cairn.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "cairn.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      # No checksum/config annotation here on purpose. The usual trick rolls
+      # the pods whenever the ConfigMap changes; cairn polls its config
+      # directory and reloads within seconds, so an edit needs no restart and
+      # the site never blinks.
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "cairn.selectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: cairn
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.basePath }}
+          args: ["-base-path", {{ . | quote }}]
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          # The two probes differ deliberately. /healthz answers 200 whenever
+          # the process is up, whatever the config says, because cairn serves a
+          # getting-started page instead of dying on a bad config and a
+          # liveness probe that failed on that would restart-loop the pod.
+          # /readyz answers 503 until a valid config has loaded, which keeps a
+          # pod that came up with an empty ConfigMap out of the Service.
+          # Both keep answering at the root under -base-path.
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ .Values.existingConfigMap | default (include "cairn.fullname" .) }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/cairn/templates/ingress.yaml
+++ b/charts/cairn/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "cairn.fullname" . }}
+  labels:
+    {{- include "cairn.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ .Values.ingress.tls.secretName | default (printf "%s-tls" (include "cairn.fullname" .)) | quote }}
+  {{- end }}
+  # One host, one path: the shape every self-hosted cairn has. Serving the same
+  # instance on several hostnames is rare enough to be worth its own Ingress
+  # object next to the release.
+  rules:
+    - host: {{ required "ingress.host is required when ingress.enabled is true" .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path | quote }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "cairn.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}

--- a/charts/cairn/templates/service.yaml
+++ b/charts/cairn/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cairn.fullname" . }}
+  labels:
+    {{- include "cairn.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "cairn.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/charts/cairn/values.yaml
+++ b/charts/cairn/values.yaml
@@ -1,0 +1,104 @@
+# cairn: https://github.com/MorganKryze/cairn
+#
+# Everything here is optional. The defaults install a running cairn that
+# serves its own getting-started page and tells you what to feed it.
+
+image:
+  repository: ghcr.io/morgankryze/cairn
+  # Empty means the chart's appVersion, which is the cairn this chart was
+  # released with. Set a tag to pin a version or to follow `stable`.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+# Your cairn YAML, one entry per file, rendered into a ConfigMap and mounted
+# read-only at /config. Exactly the files you would bind-mount under Docker:
+# https://github.com/MorganKryze/cairn/blob/main/docs/configuration/services.md
+#
+# Leave it empty and cairn still starts: it serves the getting-started page and
+# readiness keeps it out of the Service until a valid config lands.
+config: {}
+#   site.yaml: |
+#     title: Our tools
+#     locales: [fr, en]
+#     about:
+#       fr: Bienvenue. Voici les services que nous hébergeons.
+#       en: Welcome. Here are the services we host.
+#   services.yaml: |
+#     - id: pad
+#       url: https://pad.example.org
+#       icon: hedgedoc
+#       name: { fr: Bloc-notes, en: Notepad }
+#       desc: { fr: Écrire à plusieurs., en: Write together. }
+
+# Keep the ConfigMap out of the release and manage it yourself (kustomize,
+# sops, a git-ops repo of its own). The `config` block above is then ignored
+# and no ConfigMap is created.
+existingConfigMap: ""
+
+# Serve under a sub-path of a domain you already use: "/cairn" puts the site
+# at example.org/cairn/. cairn carries the prefix through every link, redirect
+# and asset itself, so the Ingress needs no rewrite annotation. Set
+# `ingress.path` to the same value.
+basePath: ""
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  # Required as soon as `enabled` is true.
+  host: ""
+  path: /
+  pathType: Prefix
+  tls:
+    enabled: false
+    # Empty means "<release>-tls", which is what cert-manager creates when the
+    # annotation above asks it to.
+    secretName: ""
+
+# Measured on the demo instance: cairn idles near nothing and renders from
+# memory. No CPU limit on purpose, so a burst of visitors is not throttled
+# into slow pages; the memory limit is the one that protects the node.
+resources:
+  requests:
+    cpu: 10m
+    memory: 16Mi
+  limits:
+    memory: 64Mi
+
+# The hardening is the point of this image, not a suggestion. Override only if
+# your cluster forces something else (OpenShift assigns its own UID range: set
+# runAsUser to null there).
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  runAsGroup: 65534
+  seccompProfile:
+    type: RuntimeDefault
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+
+# Anything else you want in the pod: your own icons and logo as a second
+# ConfigMap mounted at /assets, preview images on a volume at /config/media.
+# cairn reads /assets by default, so mounting there needs no extra flag.
+extraVolumes: []
+#   - name: assets
+#     configMap:
+#       name: cairn-assets
+extraVolumeMounts: []
+#   - name: assets
+#     mountPath: /assets
+#     readOnly: true
+
+podAnnotations: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ reading anything: <https://cairn.libresoftware.cloud>.
 - [Podman](deployment/podman.md): the same container as a systemd quadlet.
 - [Bare binary](deployment/binary.md): no container, a hardened systemd unit.
 - [Kubernetes](deployment/kubernetes.md): a ConfigMap, a Deployment, no volume.
+- [Helm](deployment/helm.md): the same four objects, and your Ingress from values.
 - [Reverse proxies](deployment/reverse-proxies.md): Caddy, Traefik, Nginx, Pangolin.
 
 **Recipes**

--- a/docs/deployment/helm.md
+++ b/docs/deployment/helm.md
@@ -1,0 +1,221 @@
+# Helm
+
+The [Kubernetes page](kubernetes.md) hands you four objects to paste and edit,
+which is honest work right until the Ingress: hostname, TLS secret, class,
+annotations, all the parts that differ per cluster and that a manifest printed
+in a document cannot know. That is what the chart is for. Everything else it
+installs is the same ConfigMap, Deployment and Service, rendered from values
+instead of copied by hand.
+
+## Installing
+
+The chart ships as an OCI artifact next to the image, so there is no repository
+to add first:
+
+```sh
+helm install cairn oci://ghcr.io/morgankryze/charts/cairn
+```
+
+That is a running cairn with no config, which is a valid state rather than a
+failure: it serves its getting-started page, and readiness deliberately keeps
+it out of the Service until you feed it. Look at it now:
+
+```sh
+kubectl port-forward svc/cairn 8080:80
+```
+
+Add `--version` with the number from the
+[releases](https://github.com/MorganKryze/cairn/releases) to pin. Chart version
+and cairn version are the same number, always: chart `1.12.0` installs cairn
+`1.12.0`, so there is only ever one version to talk about, and `image.tag` is
+there if you ever want to break the pair apart.
+
+## Feeding it your config
+
+Your YAML goes under `config:`, one entry per file, exactly the files you would
+bind-mount under Docker. They land in a ConfigMap mounted read-only at
+`/config`:
+
+```yaml
+# values.yaml
+config:
+  site.yaml: |
+    title: Our tools
+    locales: [fr, en]
+    about:
+      fr: Bienvenue. Voici les services que nous hébergeons.
+      en: Welcome. Here are the services we host.
+  services.yaml: |
+    - id: pad
+      url: https://pad.example.org
+      icon: hedgedoc
+      name: { fr: Bloc-notes, en: Notepad }
+      desc: { fr: Écrire à plusieurs., en: Write together. }
+```
+
+```sh
+helm upgrade --install cairn oci://ghcr.io/morgankryze/charts/cairn -f values.yaml
+```
+
+The `|` is doing real work there. It makes each block one opaque string, so
+your config reaches cairn as written, with its own indentation and its own
+`{ fr: …, en: … }` maps, instead of being folded into Helm's values tree where
+a key of yours could collide with a key of the chart's. Everything in
+[Services](../configuration/services.md) and [Site](../configuration/site.md)
+applies unchanged inside those blocks, and
+[multiple files](../recipes/multiple-files.md) works the way it does anywhere
+else: every `*.yaml` entry is read.
+
+## Editing it later
+
+`helm upgrade` with your edited values updates the ConfigMap, and there it
+stops. No rollout, no restart, no pod churn: cairn polls its config directory
+and picks the change up by itself, within a minute or so, once kubelet has
+refreshed the mounted ConfigMap on its own sync loop.
+
+This is why the chart carries no `checksum/config` annotation, the trick most
+charts use to force a restart when a ConfigMap changes. Here it would cost you
+a rolling restart to achieve something that already happens.
+
+If the new config is invalid, cairn names the file and the line in its log and
+keeps serving the previous pages, staying ready. The site is up, just not on
+your newest edit.
+
+## Keeping the ConfigMap out of the release
+
+If your config already lives somewhere else, sealed secrets, a kustomize
+overlay, a git-ops repository of its own, point the chart at it and it creates
+no ConfigMap at all:
+
+```yaml
+existingConfigMap: cairn-config
+```
+
+## Ingress
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  host: cairn.example.org
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+  tls:
+    enabled: true
+```
+
+`tls.secretName` defaults to `<release>-tls`, which is what cert-manager
+creates when the annotation above asks it to. Set it yourself if the
+certificate already exists.
+
+One host and one path is all the chart renders. Serving one instance on several
+hostnames is rare enough to deserve its own Ingress object next to the release,
+and the Service is there, named after the release, ready to be pointed at.
+
+Forward `X-Forwarded-Proto` so `sitemap.xml` and `robots.txt` emit `https://`
+URLs. Every common controller already does.
+
+## Under a sub-path
+
+```yaml
+basePath: /cairn
+ingress:
+  enabled: true
+  host: example.org
+  path: /cairn
+```
+
+Two keys, one value, and they answer different questions: `basePath` tells
+cairn where it lives so it carries the prefix through every link, redirect and
+asset itself, `ingress.path` tells the controller what to route. Neither side
+needs a rewrite rule. Both probes keep answering at the root, so nothing else
+in the release moves. More in
+[Reverse proxies](reverse-proxies.md#under-a-sub-path).
+
+## Icons, images, anything that is not text
+
+A ConfigMap holds text and stops at about 1 MiB, which is right for YAML and
+wrong for a logo. Mount whatever you need through the two escape hatches:
+
+```yaml
+extraVolumes:
+  - name: assets
+    configMap:
+      name: cairn-assets
+extraVolumeMounts:
+  - name: assets
+    mountPath: /assets
+    readOnly: true
+```
+
+cairn serves `/assets` by default, so mounting there needs no extra flag. SVG
+fits comfortably in a second ConfigMap; anything heavier wants a volume. See
+[Icons](../recipes/icons.md).
+
+## Every value
+
+| Key                                                | Default                       | What it does                                                     |
+| -------------------------------------------------- | ----------------------------- | ---------------------------------------------------------------- |
+| `config`                                            | `{}`                          | Your YAML, one entry per file, rendered into a ConfigMap          |
+| `existingConfigMap`                                 | `""`                          | Use your own ConfigMap instead; `config` is then ignored          |
+| `basePath`                                          | `""`                          | Serve under a sub-path, e.g. `/cairn`                             |
+| `image.repository` / `image.tag` / `image.pullPolicy` | ghcr.io image, appVersion, `IfNotPresent` | Which cairn to run                             |
+| `replicaCount`                                      | `1`                           | Stateless, so more is fine, and rarely necessary                  |
+| `service.type` / `service.port`                     | `ClusterIP`, `80`             | The Service in front of the pods                                  |
+| `ingress.*`                                         | disabled                      | `enabled`, `className`, `host`, `path`, `pathType`, `annotations`, `tls.enabled`, `tls.secretName` |
+| `resources`                                         | 10m/16Mi requested, 64Mi limit | No CPU limit on purpose, so a burst of visitors is not throttled |
+| `podSecurityContext` / `securityContext`            | the hardened set below        | Change only if your cluster forces it                             |
+| `extraVolumes` / `extraVolumeMounts`                | `[]`                          | Assets, media, anything else on disk                              |
+| `podAnnotations`, `nodeSelector`, `tolerations`, `affinity` | empty                 | The usual scheduling knobs                                        |
+
+## The hardening
+
+The defaults are the ones from the [hardened compose](docker-compose.md):
+non-root as 65534, read-only root filesystem, every capability dropped,
+`RuntimeDefault` seccomp. cairn writes nowhere and needs none of what it gives
+up.
+
+They are values rather than hardcoded for one reason: OpenShift assigns its own
+UID range and rejects a fixed `runAsUser`. Set it to `null` there and let the
+platform choose, the image runs under any UID. Anywhere else, leaving this
+block alone is the right move.
+
+## Checking the chart came from here
+
+The chart is signed the same way the image is, keylessly, bound to the workflow
+that published it:
+
+```sh
+cosign verify ghcr.io/morgankryze/charts/cairn:1.12.0 \
+  --certificate-identity-regexp '^https://github.com/MorganKryze/cairn/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+More in [SECURITY.md](../../SECURITY.md#verifying-what-you-pulled).
+
+## What the chart deliberately leaves out
+
+No HorizontalPodAutoscaler: a page rendered from memory by a process that idles
+near zero is not the thing that falls over. No ServiceAccount: cairn talks to no
+API, so the default one it never uses is enough. No PersistentVolumeClaim, no
+PodDisruptionBudget, no CRD, nothing to back up.
+
+If you need something the values do not cover, take the manifests and own them:
+
+```sh
+helm template cairn oci://ghcr.io/morgankryze/charts/cairn -f values.yaml > cairn.yaml
+```
+
+That prints exactly what would be installed, which is also the honest way to
+review a chart before trusting it.
+
+## Uninstalling
+
+```sh
+helm uninstall cairn
+```
+
+Everything goes with it. cairn stores nothing, so there is no volume to reclaim
+and no leftover to hunt down.
+
+Next: [Reverse proxies](reverse-proxies.md)

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -5,6 +5,11 @@ database, no persistent volume, no write anywhere. The whole deployment is a
 ConfigMap holding your YAML, a Deployment reading it, a Service, and whatever
 you already use for ingress.
 
+This page is the manifest, kept complete on purpose: it is what the chart
+renders, and what you want if you template your cluster some other way. If you
+run Helm, the [chart](helm.md) installs the same four objects and takes the
+Ingress off your hands.
+
 ## The whole thing
 
 ```yaml
@@ -143,4 +148,4 @@ natural gate in whatever pipeline renders your manifests:
 docker run --rm -v ./config:/config ghcr.io/morgankryze/cairn:stable -check
 ```
 
-Next: [Reverse proxies](reverse-proxies.md)
+Next: [Helm](helm.md)

--- a/justfile
+++ b/justfile
@@ -10,6 +10,13 @@ default:
 build:
     docker build -f docker/Dockerfile -t cairn:local .
 
+# lint the Helm chart and render the two shapes CI renders
+chart:
+    helm lint charts/cairn
+    helm template cairn charts/cairn >/dev/null
+    helm template cairn charts/cairn --set ingress.enabled=true --set ingress.host=cairn.example.org --set ingress.tls.enabled=true >/dev/null
+    echo "chart ok"
+
 # run vet + tests
 test:
     go vet ./... && go test ./...

--- a/llms.txt
+++ b/llms.txt
@@ -20,6 +20,8 @@ https://cairn.libresoftware.cloud
 - [Theming](docs/configuration/theming.md): accent, light/dark toggle, custom.css variables
 - [Languages](docs/configuration/i18n.md): locale negotiation, translatable fields, UI strings
 - [Docker Compose](docs/deployment/docker-compose.md): hardened reference setup and image tags
+- [Kubernetes](docs/deployment/kubernetes.md): ConfigMap, Deployment, Service, why the two probes differ
+- [Helm](docs/deployment/helm.md): chart at oci://ghcr.io/morgankryze/charts/cairn, config in values, Ingress
 - [Reverse proxies](docs/deployment/reverse-proxies.md): Caddy, Traefik, Nginx examples
 - [Status with Gatus](docs/recipes/gatus.md): -emit-gatus, polling, pill behavior
 - [Icons](docs/recipes/icons.md): slugs, URLs, self-hosted files


### PR DESCRIPTION
The [Kubernetes page](docs/deployment/kubernetes.md) has been enough for anyone templating their own cluster, right up to the Ingress it leaves as an exercise: host, class, TLS secret, annotations, the four things that differ per cluster and that a document cannot know. That is what this chart is for. Everything else it installs is the same ConfigMap, Deployment and Service that page already prints, rendered from values instead of copied by hand.

```sh
helm install cairn oci://ghcr.io/morgankryze/charts/cairn -f values.yaml
```

No repository to add first: the chart is pushed as an OCI artifact next to the image, by the same workflow, and signed with cosign the same way.

## Two decisions worth stating

**Chart version and app version are the same number.** The release job packages with the tag in both fields, so chart 1.12.0 installs cairn 1.12.0. There is no second number to remember at release time, and what `Chart.yaml` carries in git only matters to someone installing from a checkout.

**No `checksum/config` annotation.** The standard trick rolls the pods whenever the ConfigMap changes. cairn polls its config directory and reloads by itself, so here it would cost a rolling restart to achieve something that already happens. The deployment template says so in place, so nobody adds it back later as an improvement.

## The values

`config:` takes your YAML as one entry per file, as block scalars, so it reaches cairn exactly as written instead of being folded into the values tree where a key of yours could meet a key of the chart's. `existingConfigMap:` opts out of the ConfigMap entirely, for anyone already managing it with kustomize or sops.

The security contexts are values rather than hardcoded, carrying the defaults from the [hardened compose](docs/deployment/docker-compose.md): non-root as 65534, read-only root filesystem, every capability dropped, `RuntimeDefault` seccomp. They are exposed for one reason only, which the file states: OpenShift assigns its own UID range and rejects a fixed `runAsUser`.

`ingress.host` is `required` once the Ingress is enabled, so a forgotten hostname is a sentence at install time rather than an Ingress object with an empty host.

Assets and media go through one generic `extraVolumes` / `extraVolumeMounts` pair rather than three specific keys. cairn serves `/assets` by default, so mounting a second ConfigMap there needs no extra flag.

## Verified

- `helm lint` clean, and both shapes render: bare defaults, then Ingress with TLS under a sub-path. The new `chart` job in `build.yml` runs exactly that on every pull request, and `just chart` runs the same three commands locally.
- The rendered ConfigMap was extracted back into a directory and fed to `cairn -check`, which answers `ok: 4 services, 3 categories, 0 pages, locales [fr en]`. That is the one path where the chart could quietly mangle somebody's config, so it was checked rather than assumed.
- `helm package --version 1.12.0 --app-version 1.12.0` yields a chart reporting both, which is what the release job does with the tag.
- 199 tests still pass. No Go code is touched.

## Docs

A [Helm page](docs/deployment/helm.md) sits in the deployment sequence between Kubernetes and Reverse proxies: installing, config in values, editing without a rollout, Ingress and TLS, sub-paths, assets, every value in one table, and verifying the signature. The Kubernetes page now says what it is for, the complete manifest and what the chart renders, and links across. SECURITY.md gains the chart's `cosign verify`, CONTRIBUTING the layout entry and a release note.

## Deliberately not shipped

- **`values.schema.json`.** `required` covers the one fatal mistake, and a wrong type fails at the API server with a readable message. Worth having the day the values grow.
- **HPA, ServiceAccount, PDB, PVC.** A page rendered from memory by a process that idles near zero is not the thing that falls over, and cairn talks to no API and stores nothing.
- **Multi-host Ingress.** One host, one path. A second hostname deserves its own Ingress object next to the release, and the Service is named after it, ready to be pointed at.
- **ArtifactHub annotations.** They start mattering the day the repository is registered there.

## One thing to do after the first release

`helm push` creates `ghcr.io/morgankryze/charts/cairn` as a **private** package. It needs flipping to public once, by hand, or the `helm install` printed in the docs fails for everyone.
