### PR TITLE
chore: bump the chart to 1.12.0

### DIFF
--- a/charts/cairn/Chart.yaml
+++ b/charts/cairn/Chart.yaml
@@ -7,8 +7,8 @@ type: application
 # the chart, so a published chart always carries the cairn it installs. What
 # is written here only matters to someone running `helm install ./charts/cairn`
 # from a checkout.
-version: 1.11.0
-appVersion: "1.11.0"
+version: 1.12.0
+appVersion: "1.12.0"
 
 # networking.k8s.io/v1 Ingress, which is 1.19 and later. Declaring it here
 # means the templates can use one API version instead of sniffing .Capabilities.


### PR DESCRIPTION
Both fields, so `helm install ./charts/cairn` from a v1.12.0 checkout reports the version it actually installs. The release job stamps the tag over these anyway, which is what makes a forgotten bump harmless rather than wrong.

`just shots` was run first: the hero comes out byte-identical, and nothing under `src/` has moved since v1.11.0, so there was no drift to commit.