### PR TITLE
chore: wait for the pills before shooting the hero

### DIFF
--- a/justfile
+++ b/justfile
@@ -56,9 +56,13 @@ logs:
     docker compose -f demo/compose.yaml logs -f
 
 # refresh the README hero from the running demo; do this before every release
-# (playwright lands in a gitignored node_modules, nothing is committed)
+# (playwright lands in a gitignored node_modules, nothing is committed).
+# The loop waits for Gatus to have polled, the way the CI demo job does. A fixed
+# delay used to be enough until it wasn't: it caught the page with every pill on
+# "unknown", which writes both files, fails nothing, and only shows up if
+# someone opens the png.
 shots: demo-rebuild
-    @sleep 4
+    @for i in $(seq 1 24); do p=$(curl -fs http://127.0.0.1:8080/en/ || true); echo "$p" | grep -q status-up && echo "$p" | grep -q status-down && break; [ "$i" = 24 ] && { echo "gatus never settled: every pill would read unknown" >&2; exit 1; }; sleep 5; done
     @npm --silent install --no-save --no-package-lock playwright
     @npx --yes playwright install --only-shell chromium
     @node scripts/screenshots.mjs


### PR DESCRIPTION
Found while cutting v1.12.0. `just shots` waited a flat four seconds after `demo-rebuild`, which was enough until it wasn't: the run caught the page before Gatus had polled once, and produced a hero with **every service on "unknown"**, grey dots all the way down.

Nothing failed. Both pngs were written, the recipe exited 0, and the only way to notice was to open the image. That hero was one `git add` away from being the first thing anyone sees on the README.

The loop is the one the CI `demo` job already runs: poll until the page shows both a `status-up` and a `status-down`, up to two minutes, then give up loudly rather than shoot something wrong.

Verified both ways: against a dead port it exits 1 with the message and never reaches the screenshot step; against the live demo it breaks on the first poll and reproduces the committed hero byte for byte.