### PR TITLE
feat: serve /.well-known/security.txt, and gzip what is text

### DIFF
--- a/demo/config/site.yaml
+++ b/demo/config/site.yaml
@@ -6,6 +6,12 @@ tagline:
 logo: /static/favicon.svg           # your own image goes in /assets (see docs)
 locales: [fr, en]
 show_version: true
+# The demo reports through GitHub's private advisories, which is also what
+# SECURITY.md says. cairn fills Expires, Canonical and Preferred-Languages.
+security:
+  contact: https://github.com/MorganKryze/cairn/security/advisories/new
+  policy: https://github.com/MorganKryze/cairn/blob/main/SECURITY.md
+
 status:
   gatus: http://gatus:8080        # cairn polls this over the compose network
   page: http://localhost:8081     # the pill links visitors to the published port

--- a/docs/configuration/site.md
+++ b/docs/configuration/site.md
@@ -22,6 +22,7 @@ so is every key in it.
 | `credit`       | `true`    | The small "powered by cairn" in the footer. `credit: false` removes it.                                                                                                                           |
 | `show_version` | `false`   | Prints the running cairn version beside that credit: the release number for a tagged build, the commit for a build off `main`. Handy when you report a bug, or run several instances.             |
 | `strings`      | built-ins | UI text overrides; see [Languages](i18n.md#ui-strings).                                                                                                                                           |
+| `security`     | none      | `contact`, and optionally `policy` and `encryption`. Setting `contact` makes cairn serve [`/.well-known/security.txt`](#telling-researchers-where-to-write).                                      |
 | `status`       | none      | Live status pills fed by your Gatus (`status.gatus`, `status.page`, `status.interval`, `status.linked`); see [Status page](../recipes/gatus.md).                                                  |
 
 ## Full example
@@ -135,6 +136,47 @@ cairn does not resize images: doing it would mean shipping a scaler for one
 rarely used path, and a badly resampled logo is worse than the one you drew.
 Anything wrong in this list is a config error that names the entry, so a typo
 stops at startup rather than reaching a phone.
+
+## Telling researchers where to write
+
+Somebody who finds a flaw in one of your services has to guess where to send
+it. [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) settles that with a file
+at a fixed address, and one key makes cairn serve it:
+
+```yaml
+security:
+  contact: mailto:security@example.org
+  policy: https://example.org/disclosure # optional
+  encryption: https://example.org/pgp.asc # optional
+```
+
+`contact` is the only field you write. It takes any URI, so `mailto:`,
+`https://` to a reporting form, or `tel:` all work; writing a bare address
+without its scheme is a config error rather than a file nobody can parse.
+
+The rest cairn fills, because it already knows it:
+
+```
+Contact: mailto:security@example.org
+Expires: 2027-07-30T17:45:16Z
+Preferred-Languages: fr, en
+Canonical: https://tools.example.org/.well-known/security.txt
+```
+
+`Expires` is the field this exists to get right. The RFC makes it mandatory,
+and a security.txt written by hand carries a date somebody chose once and never
+looked at again: past it, the file is worse than absent, because it says the
+address is stale. cairn recomputes it on every request, a year out, so it
+cannot rot. `Preferred-Languages` comes from your `locales` and `Canonical`
+from `url`, or from the request when you have not set one.
+
+Without `security.contact` the path answers `404`, which is the honest answer:
+an empty security.txt is a promise cairn cannot make on your behalf.
+
+One caveat if you serve cairn [under a sub-path](../deployment/reverse-proxies.md#under-a-sub-path):
+the RFC wants this file at the root of the domain, and cairn can only serve it
+under its own prefix. Point your proxy at it, or leave the file to whatever
+owns the root.
 
 ## The welcome note
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -35,28 +35,31 @@ logs the same error.
 
 ## `site.yaml`
 
-| Key               | Default        | Type                                                                                                                                                                                                               |
-| ----------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `title`           | `cairn`        | text (plain or per-locale map)                                                                                                                                                                                     |
-| `tagline`         | empty          | text; opens the home page, feeds the meta description                                                                                                                                                              |
-| `url`             | none           | public base URL; adds canonical + hreflang, absolute sitemap                                                                                                                                                       |
-| `logo`            | none           | URL or `/assets/…` path; raster logos double as the og:image when `url` is set                                                                                                                                     |
-| `favicon`         | cairn's        | tab icon; URL or `/assets/…` path. Also becomes the home-screen icon; see [the icon set](configuration/site.md#the-icon-set)                                                                                       |
-| `icons`           | derived        | [home-screen set](configuration/site.md#using-your-own), list of `{src: URL/path, sizes: WxH or any, purpose: any/maskable/monochrome}`; overrides what `favicon` implies                                          |
-| `index`           | `true`         | `false` = robots.txt disallow, noindex meta, no sitemap                                                                                                                                                            |
-| `locales`         | `[en]`         | list; first = default                                                                                                                                                                                              |
-| `theme.accent`    | `#247b7b`      | hex color                                                                                                                                                                                                          |
-| `about`           | empty          | dismissable welcome note under the hero, long text ([markdown subset](configuration/text.md))                                                                                                                      |
-| `links`           | `[]`           | header nav links, list of `{label: text, url: string, icon: [glyph](configuration/site.md#header-links)/URL/path}`                                                                                                 |
-| `footer`          | `[]`           | list of `{label: text, url: string}`                                                                                                                                                                               |
-| `pages`           | `[]`           | [hosted pages](configuration/site.md#hosted-pages): `{id: slug, title: text, body: long text, sections: [{title, body}]}`; body and/or sections required; bodies take the [markdown subset](configuration/text.md) |
-| `credit`          | `true`         | bool; `false` removes the footer "powered by cairn"                                                                                                                                                                |
-| `show_version`    | `false`        | bool; `true` shows the running version next to the credit, linked to its release or commit                                                                                                                         |
-| `strings`         | built-ins      | map of key → text ([keys](configuration/i18n.md#ui-strings))                                                                                                                                                       |
-| `status.gatus`    | none           | Gatus base URL cairn polls for the [status pills](recipes/gatus.md)                                                                                                                                                |
-| `status.page`     | `status.gatus` | public Gatus URL the pill links to (set when the poll URL is internal)                                                                                                                                             |
-| `status.interval` | `60s`          | poll cadence, duration ≥ `5s`                                                                                                                                                                                      |
-| `status.linked`   | `true`         | `false` makes the pills display-only: the state stays, the link to the status page goes                                                                                                                            |
+| Key                   | Default        | Type                                                                                                                                                                                                               |
+| --------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `title`               | `cairn`        | text (plain or per-locale map)                                                                                                                                                                                     |
+| `tagline`             | empty          | text; opens the home page, feeds the meta description                                                                                                                                                              |
+| `url`                 | none           | public base URL; adds canonical + hreflang, absolute sitemap                                                                                                                                                       |
+| `logo`                | none           | URL or `/assets/…` path; raster logos double as the og:image when `url` is set                                                                                                                                     |
+| `favicon`             | cairn's        | tab icon; URL or `/assets/…` path. Also becomes the home-screen icon; see [the icon set](configuration/site.md#the-icon-set)                                                                                       |
+| `icons`               | derived        | [home-screen set](configuration/site.md#using-your-own), list of `{src: URL/path, sizes: WxH or any, purpose: any/maskable/monochrome}`; overrides what `favicon` implies                                          |
+| `index`               | `true`         | `false` = robots.txt disallow, noindex meta, no sitemap                                                                                                                                                            |
+| `locales`             | `[en]`         | list; first = default                                                                                                                                                                                              |
+| `theme.accent`        | `#247b7b`      | hex color                                                                                                                                                                                                          |
+| `about`               | empty          | dismissable welcome note under the hero, long text ([markdown subset](configuration/text.md))                                                                                                                      |
+| `links`               | `[]`           | header nav links, list of `{label: text, url: string, icon: [glyph](configuration/site.md#header-links)/URL/path}`                                                                                                 |
+| `footer`              | `[]`           | list of `{label: text, url: string}`                                                                                                                                                                               |
+| `pages`               | `[]`           | [hosted pages](configuration/site.md#hosted-pages): `{id: slug, title: text, body: long text, sections: [{title, body}]}`; body and/or sections required; bodies take the [markdown subset](configuration/text.md) |
+| `credit`              | `true`         | bool; `false` removes the footer "powered by cairn"                                                                                                                                                                |
+| `show_version`        | `false`        | bool; `true` shows the running version next to the credit, linked to its release or commit                                                                                                                         |
+| `strings`             | built-ins      | map of key → text ([keys](configuration/i18n.md#ui-strings))                                                                                                                                                       |
+| `security.contact`    | none           | URI (`mailto:`, `https://`, `tel:`); setting it serves [`/.well-known/security.txt`](configuration/site.md#telling-researchers-where-to-write)                                                                     |
+| `security.policy`     | none           | URL of your disclosure policy                                                                                                                                                                                      |
+| `security.encryption` | none           | URL of the key a reporter should encrypt to                                                                                                                                                                        |
+| `status.gatus`        | none           | Gatus base URL cairn polls for the [status pills](recipes/gatus.md)                                                                                                                                                |
+| `status.page`         | `status.gatus` | public Gatus URL the pill links to (set when the poll URL is internal)                                                                                                                                             |
+| `status.interval`     | `60s`          | poll cadence, duration ≥ `5s`                                                                                                                                                                                      |
+| `status.linked`       | `true`         | `false` makes the pills display-only: the state stays, the link to the status page goes                                                                                                                            |
 
 Unknown keys are errors everywhere: in `site.yaml`, and in every service,
 category, page, section, link, image and icon entry alike. The message names
@@ -87,19 +90,26 @@ ids, alphabetically.
 
 ## Endpoints
 
-| Path                 | Behavior                                                                                           |
-| -------------------- | -------------------------------------------------------------------------------------------------- |
-| `/`                  | 302 to the negotiated locale (cookie → `Accept-Language` → default)                                |
-| `/{locale}/`         | home; server-rendered, `ETag`, `Cache-Control: no-cache`                                           |
-| `/{locale}/{id}/`    | service detail page or [hosted page](configuration/site.md#hosted-pages); same caching             |
-| `/{locale}/…?choose` | sets the one-year locale cookie, then redirects clean                                              |
-| `/static/…`          | embedded assets, cached one day                                                                    |
-| `/assets/…`          | your mounted files, if the mount exists                                                            |
-| `/custom.css`        | your stylesheet, if present                                                                        |
-| `/healthz`           | `200 ok` while the process serves, whatever the config says: the liveness signal                   |
-| `/readyz`            | `200 ready`, or `503` while no valid config has ever loaded and the getting-started page stands in |
-| `/sitemap.xml`       | every page, absolute URLs from `Host`/`X-Forwarded-Proto`                                          |
-| `/robots.txt`        | allow all + sitemap URL                                                                            |
+| Path                        | Behavior                                                                                           |
+| --------------------------- | -------------------------------------------------------------------------------------------------- |
+| `/`                         | 302 to the negotiated locale (cookie → `Accept-Language` → default)                                |
+| `/{locale}/`                | home; server-rendered, `ETag`, `Cache-Control: no-cache`                                           |
+| `/{locale}/{id}/`           | service detail page or [hosted page](configuration/site.md#hosted-pages); same caching             |
+| `/{locale}/…?choose`        | sets the one-year locale cookie, then redirects clean                                              |
+| `/static/…`                 | embedded assets, cached one day                                                                    |
+| `/assets/…`                 | your mounted files, if the mount exists                                                            |
+| `/custom.css`               | your stylesheet, if present                                                                        |
+| `/healthz`                  | `200 ok` while the process serves, whatever the config says: the liveness signal                   |
+| `/readyz`                   | `200 ready`, or `503` while no valid config has ever loaded and the getting-started page stands in |
+| `/sitemap.xml`              | every page, absolute URLs from `Host`/`X-Forwarded-Proto`                                          |
+| `/robots.txt`               | allow all + sitemap URL                                                                            |
+| `/.well-known/security.txt` | RFC 9116, once `security.contact` is set; `404` otherwise                                          |
+
+Text responses are gzipped for clients that ask, which is most of them: a first
+visit to the demo goes from 53 KB on the wire to 14 KB. Images, fonts and the
+`ico` are left alone, since compressing them again only spends CPU to add
+bytes. Every response carries `Vary: Accept-Encoding` so a shared cache cannot
+hand the compressed answer to a client that did not ask for it.
 
 ## Binary flags
 

--- a/schema/site.json
+++ b/schema/site.json
@@ -149,6 +149,24 @@
       "additionalProperties": { "$ref": "#/definitions/lstring" },
       "description": "Overrides for built-in UI strings, keyed like search.placeholder."
     },
+    "security": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "contact": {
+          "type": "string",
+          "description": "Where to report a vulnerability, as a URI: mailto:security@example.org, https://example.org/report, tel:+33.... Setting it is what makes cairn serve /.well-known/security.txt."
+        },
+        "policy": {
+          "type": "string",
+          "description": "URL of your disclosure policy, if you publish one."
+        },
+        "encryption": {
+          "type": "string",
+          "description": "URL of the public key a reporter should encrypt to."
+        }
+      }
+    },
     "status": {
       "type": "object",
       "additionalProperties": false,

--- a/src/internal/check/check.go
+++ b/src/internal/check/check.go
@@ -43,6 +43,16 @@ func checkWarnings(cfg *config.Config, dir string) []string {
 	if cfg.Site.URL == "" && !cfg.Noindex() {
 		out = append(out, "site.yaml has no url: pages carry no canonical link, no og:url and no hreflang alternates (set url: https://… to emit them)")
 	}
+	// og:image needs a url and a raster logo, both. With a url but no usable
+	// logo, every link to the site previews as bare text on Mastodon, Slack or
+	// anywhere else, and the page itself gives no hint of it.
+	if cfg.Site.URL != "" && !cfg.Noindex() && !render.IsRaster(cfg.Site.Logo) {
+		if cfg.Site.Logo == "" {
+			out = append(out, "site.yaml has no logo: links to the site preview with no image (og:image wants a png, jpg, webp or gif)")
+		} else {
+			out = append(out, fmt.Sprintf("site.yaml logo %q is not a raster image: links to the site preview with no image (og:image wants a png, jpg, webp or gif)", cfg.Site.Logo))
+		}
+	}
 	if slugs := config.CdnSlugs(cfg); len(slugs) > 0 {
 		out = append(out, fmt.Sprintf("%d icons load from a CDN in visitors' browsers (%s); run cairn -emit-icons to self-host them", len(slugs), strings.Join(slugs, ", ")))
 	}

--- a/src/internal/check/check.go
+++ b/src/internal/check/check.go
@@ -36,6 +36,13 @@ func checkWarnings(cfg *config.Config, dir string) []string {
 	var out []string
 	out = append(out, missingTranslations(cfg)...)
 	out = append(out, mediaWarnings(cfg, filepath.Join(dir, "media"))...)
+	// The canonical, og:url and hreflang links are all built from site.url, so
+	// without it they are simply absent. Nothing fails, the page looks right,
+	// and a multilingual site quietly reads as several duplicates. Skipped
+	// when the operator has already told search engines to stay away.
+	if cfg.Site.URL == "" && !cfg.Noindex() {
+		out = append(out, "site.yaml has no url: pages carry no canonical link, no og:url and no hreflang alternates (set url: https://… to emit them)")
+	}
 	if slugs := config.CdnSlugs(cfg); len(slugs) > 0 {
 		out = append(out, fmt.Sprintf("%d icons load from a CDN in visitors' browsers (%s); run cairn -emit-icons to self-host them", len(slugs), strings.Join(slugs, ", ")))
 	}

--- a/src/internal/check/check_test.go
+++ b/src/internal/check/check_test.go
@@ -43,7 +43,7 @@ func TestCheckWarnings(t *testing.T) {
 
 func TestCheckMarkdownImageCountsAsUsed(t *testing.T) {
 	dir := testutil.WriteFiles(t, map[string]string{
-		"site.yaml":     "url: https://tools.example.org\nlocales: [en]\nabout: \"See ![plan](plan.png)\"\n",
+		"site.yaml":     "url: https://tools.example.org\nlogo: /assets/logo.png\nlocales: [en]\nabout: \"See ![plan](plan.png)\"\n",
 		"services.yaml": "- {id: a, url: https://a.example.org, name: A}\n",
 	})
 	if err := os.MkdirAll(filepath.Join(dir, "media"), 0o755); err != nil {
@@ -94,9 +94,9 @@ func TestWarningsNameWhatIsMissing(t *testing.T) {
 // makes the warnings worth reading when they do appear.
 func TestCompleteConfigWarnsAboutNothing(t *testing.T) {
 	dir := testutil.WriteFiles(t, map[string]string{
-		// url included: a config without one is not complete for a site that
-		// wants to be found, and -check says so.
-		"site.yaml":     "url: https://tools.example.org\nlocales: [en]\n",
+		// url and a raster logo: without them the canonical links and the
+		// link-preview image are silently absent, and -check says so.
+		"site.yaml":     "url: https://tools.example.org\nlogo: /assets/logo.png\nlocales: [en]\n",
 		"services.yaml": "- {id: pad, url: https://pad.example.org, name: Pad, desc: Write together.}\n",
 	})
 	cfg, err := config.Load(dir)
@@ -193,5 +193,39 @@ func TestCheckStaysQuietAboutURLWhenNoindex(t *testing.T) {
 	}
 	if w := strings.Join(checkWarnings(cfg, dir), "\n"); strings.Contains(w, "canonical") {
 		t.Errorf("noindex site was nagged about canonical links:\n%s", w)
+	}
+}
+
+// A vector logo looks like a logo, renders fine in the header, and produces no
+// og:image at all: most platforms ignore svg for a preview card. The page
+// gives no sign of it, so the check has to.
+func TestCheckWarnsAboutAVectorLogo(t *testing.T) {
+	dir := testutil.WriteFiles(t, map[string]string{
+		"site.yaml":     "url: https://tools.example.org\nlogo: /assets/logo.svg\nlocales: [en]\n",
+		"services.yaml": "- {id: a, url: https://a.example.org, name: A}\n",
+	})
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := strings.Join(checkWarnings(cfg, dir), "\n")
+	if !strings.Contains(w, "not a raster") || !strings.Contains(w, "logo.svg") {
+		t.Errorf("a vector logo went unmentioned:\n%s", w)
+	}
+}
+
+// Without a url there is no og:image to miss, and the url warning already
+// covers it. Saying both would be saying the same thing twice.
+func TestCheckDoesNotStackTheLogoWarningOnTheURLOne(t *testing.T) {
+	dir := testutil.WriteFiles(t, map[string]string{
+		"site.yaml":     "locales: [en]\n",
+		"services.yaml": "- {id: a, url: https://a.example.org, name: A}\n",
+	})
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if w := strings.Join(checkWarnings(cfg, dir), "\n"); strings.Contains(w, "og:image") {
+		t.Errorf("a config with no url was also nagged about og:image:\n%s", w)
 	}
 }

--- a/src/internal/check/check_test.go
+++ b/src/internal/check/check_test.go
@@ -43,7 +43,7 @@ func TestCheckWarnings(t *testing.T) {
 
 func TestCheckMarkdownImageCountsAsUsed(t *testing.T) {
 	dir := testutil.WriteFiles(t, map[string]string{
-		"site.yaml":     "locales: [en]\nabout: \"See ![plan](plan.png)\"\n",
+		"site.yaml":     "url: https://tools.example.org\nlocales: [en]\nabout: \"See ![plan](plan.png)\"\n",
 		"services.yaml": "- {id: a, url: https://a.example.org, name: A}\n",
 	})
 	if err := os.MkdirAll(filepath.Join(dir, "media"), 0o755); err != nil {
@@ -94,7 +94,9 @@ func TestWarningsNameWhatIsMissing(t *testing.T) {
 // makes the warnings worth reading when they do appear.
 func TestCompleteConfigWarnsAboutNothing(t *testing.T) {
 	dir := testutil.WriteFiles(t, map[string]string{
-		"site.yaml":     "locales: [en]\n",
+		// url included: a config without one is not complete for a site that
+		// wants to be found, and -check says so.
+		"site.yaml":     "url: https://tools.example.org\nlocales: [en]\n",
 		"services.yaml": "- {id: pad, url: https://pad.example.org, name: Pad, desc: Write together.}\n",
 	})
 	cfg, err := config.Load(dir)
@@ -154,5 +156,42 @@ func TestRunCheckRefusals(t *testing.T) {
 	}
 	if code := RunCheck(filepath.Join(t.TempDir(), "absent")); code != 1 {
 		t.Errorf("RunCheck on a missing directory = %d, want 1", code)
+	}
+}
+
+// site.url is what builds the canonical, og:url and hreflang links. Without
+// it they are simply absent, the page looks perfectly fine, and a multilingual
+// site reads to a crawler as several duplicates of each other. Nothing else
+// tells the operator, which is the whole reason this warning exists.
+func TestCheckWarnsAboutMissingSiteURL(t *testing.T) {
+	dir := testutil.WriteFiles(t, map[string]string{
+		"site.yaml":     "locales: [fr, en]\n",
+		"services.yaml": "- {id: a, url: https://a.example.org, name: A}\n",
+	})
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	warnings := strings.Join(checkWarnings(cfg, dir), "\n")
+	for _, want := range []string{"no url", "canonical", "hreflang"} {
+		if !strings.Contains(warnings, want) {
+			t.Errorf("missing url warning has no %q:\n%s", want, warnings)
+		}
+	}
+}
+
+// An operator who asked search engines to stay away has already answered the
+// question. Warning them anyway is how a check earns being ignored.
+func TestCheckStaysQuietAboutURLWhenNoindex(t *testing.T) {
+	dir := testutil.WriteFiles(t, map[string]string{
+		"site.yaml":     "locales: [en]\nindex: false\n",
+		"services.yaml": "- {id: a, url: https://a.example.org, name: A}\n",
+	})
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if w := strings.Join(checkWarnings(cfg, dir), "\n"); strings.Contains(w, "canonical") {
+		t.Errorf("noindex site was nagged about canonical links:\n%s", w)
 	}
 }

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -113,7 +113,16 @@ type Site struct {
 	Credit  *bool              `yaml:"credit"`       // the footer "powered by cairn"; nil means true
 	ShowVer bool               `yaml:"show_version"` // print the running version beside the credit; off by default
 	Strings map[string]LString `yaml:"strings"`
-	Status  struct {
+	// Security fills /.well-known/security.txt. Contact is the only field an
+	// operator writes: Expires, Canonical and Preferred-Languages are cairn's
+	// to compute, which is the whole reason to serve the file rather than let
+	// one go stale in a folder.
+	Security struct {
+		Contact    string `yaml:"contact"`    // a URI: mailto:…, https://… or tel:…
+		Policy     string `yaml:"policy"`     // where the disclosure policy lives
+		Encryption string `yaml:"encryption"` // where the public key lives
+	} `yaml:"security"`
+	Status struct {
 		Gatus    string `yaml:"gatus"`
 		Page     string `yaml:"page"`
 		Interval string `yaml:"interval"`
@@ -250,6 +259,10 @@ var (
 	idRe     = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
 	// A manifest icon size: one or more "WxH", or "any" for a scalable one.
 	iconSizesRe = regexp.MustCompile(`^(any|[0-9]+x[0-9]+( [0-9]+x[0-9]+)*)$`)
+	// Any URI with a scheme, since security.txt takes mailto:, https:// and
+	// tel: alike. Checking the scheme is what catches a bare email address,
+	// which is the mistake this field invites.
+	uriRe = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.-]*:[^\s]+$`)
 )
 
 // isHTTPURL reports an http(s) URL; IsURLOrAbs also accepts a root-absolute

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -32,6 +32,26 @@ func validateSite(site *Site, definedIn map[string]string) error {
 			return fmt.Errorf("config: site.yaml: status.interval %q is not a duration of at least 5s (expected e.g. 60s)", iv)
 		}
 	}
+	// security.txt is a line-based format, so a newline in any value would let
+	// a typo forge a field. Reject that here rather than escape it later.
+	for _, f := range []struct{ key, val string }{
+		{"security.contact", site.Security.Contact},
+		{"security.policy", site.Security.Policy},
+		{"security.encryption", site.Security.Encryption},
+	} {
+		if f.val == "" {
+			continue
+		}
+		if strings.ContainsAny(f.val, "\r\n") {
+			return fmt.Errorf("config: site.yaml: %s must be one line", f.key)
+		}
+		if !uriRe.MatchString(f.val) {
+			return fmt.Errorf("config: site.yaml: %s %q is not a URI (expected e.g. mailto:security@example.org or https://example.org/security)", f.key, f.val)
+		}
+	}
+	if site.Security.Contact == "" && (site.Security.Policy != "" || site.Security.Encryption != "") {
+		return fmt.Errorf("config: site.yaml: security needs a contact (expected: security: {contact: mailto:security@example.org})")
+	}
 	site.URL = strings.TrimSuffix(site.URL, "/")
 	if u := site.URL; u != "" && !isHTTPURL(u) {
 		return fmt.Errorf("config: site.yaml: url %q is not a URL (expected e.g. https://tools.example.org)", u)

--- a/src/internal/config/validate_test.go
+++ b/src/internal/config/validate_test.go
@@ -40,6 +40,21 @@ func TestValidateSiteRejections(t *testing.T) {
 			[]string{"status.interval", "at least 5s"}},
 		{"site url that is not a URL", func(s *Site) { s.URL = "tools.example.org" },
 			[]string{"url", "is not a URL"}},
+		// The mistake this field invites: writing the address rather than the
+		// URI. RFC 9116 wants a scheme, and a bare address makes the file
+		// unparseable for the researcher it was written for.
+		{"security contact without a scheme", func(s *Site) { s.Security.Contact = "security@example.org" },
+			[]string{"security.contact", "is not a URI", "mailto:"}},
+		{"security policy without a scheme", func(s *Site) {
+			s.Security.Contact = "mailto:security@example.org"
+			s.Security.Policy = "example.org/policy"
+		}, []string{"security.policy", "is not a URI"}},
+		// security.txt is line-based, so a newline in a value forges a field.
+		{"security contact carrying a newline", func(s *Site) {
+			s.Security.Contact = "mailto:a@example.org\nExpires: 1999-01-01T00:00:00Z"
+		}, []string{"security.contact", "one line"}},
+		{"security without a contact", func(s *Site) { s.Security.Policy = "https://example.org/policy" },
+			[]string{"security needs a contact"}},
 		{"link without a label", func(s *Site) { s.Links = []FooterLink{{URL: "https://w.example.org"}} },
 			[]string{"links entry needs label and url"}},
 		{"link without a url", func(s *Site) { s.Links = []FooterLink{{Label: LString{"": "Wiki"}}} },

--- a/src/internal/render/render.go
+++ b/src/internal/render/render.go
@@ -507,12 +507,25 @@ func AppIcons(cfg *config.Config) []AppIcon {
 // ogImage derives a social preview image from the logo: only when the site
 // has a public URL to make it absolute, and only raster formats, which is
 // what the preview crawlers accept.
+// IsRaster reports a format a link previewer can actually display. svg is
+// deliberately out: og:image with a vector is ignored by most platforms, which
+// is why a vector logo quietly means no preview picture at all. -check says so
+// rather than leaving it to be discovered on a shared link.
+func IsRaster(path string) bool {
+	l := strings.ToLower(path)
+	for _, ext := range []string{".png", ".jpg", ".jpeg", ".webp", ".gif"} {
+		if strings.HasSuffix(l, ext) {
+			return true
+		}
+	}
+	return false
+}
+
 func ogImage(base, logo string) string {
 	if base == "" || logo == "" {
 		return ""
 	}
-	l := strings.ToLower(logo)
-	if !strings.HasSuffix(l, ".png") && !strings.HasSuffix(l, ".jpg") && !strings.HasSuffix(l, ".jpeg") && !strings.HasSuffix(l, ".webp") && !strings.HasSuffix(l, ".gif") {
+	if !IsRaster(logo) {
 		return ""
 	}
 	if config.IsLocalPath(logo) {

--- a/src/internal/server/handlers.go
+++ b/src/internal/server/handlers.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/MorganKryze/cairn/src/internal/render"
 )
@@ -165,6 +166,33 @@ func robots(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	fmt.Fprintf(w, "User-agent: *\nAllow: /\nSitemap: %s/sitemap.xml\n", siteBase(r))
+}
+
+// securityTxt answers RFC 9116, and only once an operator has given a contact.
+// Expires is computed per request rather than configured, because a
+// security.txt that has quietly expired is worth less than none at all, and a
+// file regenerated on every read cannot. Canonical and Preferred-Languages are
+// cairn's to fill too: it knows where it is served and which languages it
+// speaks.
+func securityTxt(w http.ResponseWriter, r *http.Request) {
+	sec := Current().Cfg.Site.Security
+	if sec.Contact == "" {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	fmt.Fprintf(w, "Contact: %s\n", sec.Contact)
+	fmt.Fprintf(w, "Expires: %s\n", time.Now().AddDate(1, 0, 0).UTC().Format(time.RFC3339))
+	if sec.Encryption != "" {
+		fmt.Fprintf(w, "Encryption: %s\n", sec.Encryption)
+	}
+	if sec.Policy != "" {
+		fmt.Fprintf(w, "Policy: %s\n", sec.Policy)
+	}
+	if locales := Current().Cfg.Site.Locales; len(locales) > 0 {
+		fmt.Fprintf(w, "Preferred-Languages: %s\n", strings.Join(locales, ", "))
+	}
+	fmt.Fprintf(w, "Canonical: %s/.well-known/security.txt\n", siteBase(r))
 }
 
 func sitemap(w http.ResponseWriter, r *http.Request) {

--- a/src/internal/server/handlers_test.go
+++ b/src/internal/server/handlers_test.go
@@ -260,3 +260,80 @@ func TestConfigHelpers(t *testing.T) {
 		}
 	}
 }
+
+// Nothing is served until an operator gives a contact: an empty security.txt
+// would be a promise cairn cannot keep on their behalf.
+func TestSecurityTxtNeedsAContact(t *testing.T) {
+	dir := testutil.WriteFiles(t, map[string]string{
+		"site.yaml":     "locales: [en]\n",
+		"services.yaml": "- {id: pad, url: https://pad.example.org, name: Pad}\n",
+	})
+	Store(mustModel(t, dir))
+	rec := httptest.NewRecorder()
+	securityTxt(rec, httptest.NewRequest("GET", "/.well-known/security.txt", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("unconfigured security.txt = %d, want 404", rec.Code)
+	}
+}
+
+// The three fields cairn fills by itself are the point of serving the file
+// rather than letting the operator drop a static one that rots.
+func TestSecurityTxtFillsWhatItKnows(t *testing.T) {
+	dir := testutil.WriteFiles(t, map[string]string{
+		"site.yaml": "url: https://tools.example.org\nlocales: [fr, en]\n" +
+			"security: {contact: mailto:security@example.org, policy: https://example.org/policy}\n",
+		"services.yaml": "- {id: pad, url: https://pad.example.org, name: Pad}\n",
+	})
+	Store(mustModel(t, dir))
+	rec := httptest.NewRecorder()
+	securityTxt(rec, httptest.NewRequest("GET", "/.well-known/security.txt", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		"Contact: mailto:security@example.org",
+		"Policy: https://example.org/policy",
+		"Preferred-Languages: fr, en",
+		"Canonical: https://tools.example.org/.well-known/security.txt",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("security.txt missing %q, got:\n%s", want, body)
+		}
+	}
+	// Encryption was not configured, so it must not appear at all rather than
+	// appear empty: a field with no value is a parse error for RFC 9116.
+	if strings.Contains(body, "Encryption:") {
+		t.Error("an unset Encryption was emitted anyway")
+	}
+}
+
+// Expires is the field a hand-written security.txt gets wrong, because it is
+// written once and then forgotten. Computed per request, it cannot be stale.
+func TestSecurityTxtExpiresInTheFuture(t *testing.T) {
+	dir := testutil.WriteFiles(t, map[string]string{
+		"site.yaml":     "locales: [en]\nsecurity: {contact: mailto:security@example.org}\n",
+		"services.yaml": "- {id: pad, url: https://pad.example.org, name: Pad}\n",
+	})
+	Store(mustModel(t, dir))
+	rec := httptest.NewRecorder()
+	securityTxt(rec, httptest.NewRequest("GET", "/.well-known/security.txt", nil))
+
+	var raw string
+	for _, line := range strings.Split(rec.Body.String(), "\n") {
+		if v, ok := strings.CutPrefix(line, "Expires: "); ok {
+			raw = v
+		}
+	}
+	if raw == "" {
+		t.Fatalf("no Expires line in:\n%s", rec.Body.String())
+	}
+	when, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		t.Fatalf("Expires %q is not RFC 3339: %v", raw, err)
+	}
+	if !when.After(time.Now()) {
+		t.Errorf("Expires %s is already past", raw)
+	}
+}

--- a/src/internal/server/hardening_test.go
+++ b/src/internal/server/hardening_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/MorganKryze/cairn/src/internal/render"
 	"github.com/MorganKryze/cairn/src/internal/status"
+	"github.com/MorganKryze/cairn/src/internal/testutil"
 )
 
 // HSTS is sent only once the visit is already https: on the plain-http LAN
@@ -36,7 +37,7 @@ func TestHSTSFollowsTheScheme(t *testing.T) {
 	}
 
 	// the rest of the hardening headers ride on every response
-	for _, k := range []string{"X-Content-Type-Options", "Referrer-Policy", "X-Frame-Options", "Permissions-Policy", "Content-Security-Policy"} {
+	for _, k := range []string{"X-Content-Type-Options", "Referrer-Policy", "X-Frame-Options", "Permissions-Policy", "Content-Security-Policy", "Cross-Origin-Opener-Policy", "Cross-Origin-Resource-Policy"} {
 		if rec.Header().Get(k) == "" {
 			t.Errorf("missing %s", k)
 		}
@@ -137,5 +138,31 @@ func TestReadinessSplitsFromLiveness(t *testing.T) {
 		if rec.Code != http.StatusOK {
 			t.Errorf("%s with a valid config = %d, want 200", name, rec.Code)
 		}
+	}
+}
+
+// The two cross-origin headers carry values chosen rather than copied, so the
+// values themselves are worth pinning. COEP is deliberately absent: it would
+// demand a CORP header from every remote image, which is exactly what the
+// CDN icon slugs and the operators' own image hosts do not send.
+func TestCrossOriginHeadersKeepTheirChosenValues(t *testing.T) {
+	Store(mustModel(t, testutil.WriteFiles(t, map[string]string{
+		"site.yaml":     "locales: [en]\n",
+		"services.yaml": "- {id: pad, url: https://pad.example.org, name: Pad}\n",
+	})))
+	h := secureHeaders(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+
+	if got := rec.Header().Get("Cross-Origin-Opener-Policy"); got != "same-origin" {
+		t.Errorf("COOP = %q, want same-origin", got)
+	}
+	// same-site keeps a sibling subdomain able to show a cairn icon, which is
+	// how self-hosters lay their services out.
+	if got := rec.Header().Get("Cross-Origin-Resource-Policy"); got != "same-site" {
+		t.Errorf("CORP = %q, want same-site", got)
+	}
+	if got := rec.Header().Get("Cross-Origin-Embedder-Policy"); got != "" {
+		t.Errorf("COEP is set to %q; it breaks every remote icon", got)
 	}
 }

--- a/src/internal/server/routes_test.go
+++ b/src/internal/server/routes_test.go
@@ -17,7 +17,8 @@ import (
 // in a bad merge, so this walks every path cairn is supposed to answer.
 func TestRouteTable(t *testing.T) {
 	cfgDir := testutil.WriteFiles(t, map[string]string{
-		"site.yaml":     "url: https://tools.example.org\nlocales: [en]\npages: [{id: legal, title: Legal, body: Text.}]\n",
+		"site.yaml": "url: https://tools.example.org\nlocales: [en]\npages: [{id: legal, title: Legal, body: Text.}]\n" +
+			"security: {contact: mailto:security@example.org}\n",
 		"services.yaml": "- {id: pad, url: https://pad.example.org, name: Pad, details: More.}\n",
 		"custom.css":    ":root{--x:1}\n",
 	})
@@ -42,23 +43,24 @@ func TestRouteTable(t *testing.T) {
 		path string
 		want int
 	}{
-		{"/", http.StatusFound},                  // to the negotiated locale
-		{"/en/", http.StatusOK},                  // a home
-		{"/en/pad/", http.StatusOK},              // a service detail
-		{"/en/legal/", http.StatusOK},            // a hosted page
-		{"/en/nope/", http.StatusNotFound},       // an unknown page under a locale
-		{"/healthz", http.StatusOK},              // liveness
-		{"/readyz", http.StatusOK},               // readiness
-		{"/robots.txt", http.StatusOK},           //
-		{"/sitemap.xml", http.StatusOK},          //
-		{"/manifest.webmanifest", http.StatusOK}, //
-		{"/favicon.ico", http.StatusOK},          // for the tools that skip the html
-		{"/custom.css", http.StatusOK},           // the operator's stylesheet
-		{"/static/style.css", http.StatusOK},     // embedded
-		{"/assets/icons/pad.svg", http.StatusOK}, // mounted
-		{"/media/shot.txt", http.StatusOK},       // next to the yaml
-		{"/assets/", http.StatusNotFound},        // never a directory index
-		{"/media/", http.StatusNotFound},         //
+		{"/", http.StatusFound},                      // to the negotiated locale
+		{"/en/", http.StatusOK},                      // a home
+		{"/en/pad/", http.StatusOK},                  // a service detail
+		{"/en/legal/", http.StatusOK},                // a hosted page
+		{"/en/nope/", http.StatusNotFound},           // an unknown page under a locale
+		{"/healthz", http.StatusOK},                  // liveness
+		{"/readyz", http.StatusOK},                   // readiness
+		{"/robots.txt", http.StatusOK},               //
+		{"/sitemap.xml", http.StatusOK},              //
+		{"/.well-known/security.txt", http.StatusOK}, // once a contact is configured
+		{"/manifest.webmanifest", http.StatusOK},     //
+		{"/favicon.ico", http.StatusOK},              // for the tools that skip the html
+		{"/custom.css", http.StatusOK},               // the operator's stylesheet
+		{"/static/style.css", http.StatusOK},         // embedded
+		{"/assets/icons/pad.svg", http.StatusOK},     // mounted
+		{"/media/shot.txt", http.StatusOK},           // next to the yaml
+		{"/assets/", http.StatusNotFound},            // never a directory index
+		{"/media/", http.StatusNotFound},             //
 		{"/static/does-not-exist", http.StatusNotFound},
 	} {
 		rec := httptest.NewRecorder()

--- a/src/internal/server/routing.go
+++ b/src/internal/server/routing.go
@@ -57,14 +57,13 @@ func noListing(h http.Handler) http.Handler {
 	})
 }
 
-// gzipWriter compresses on the first write, once the handler has settled its
+// gzipWriter decides at WriteHeader time, once the handler has settled its
 // Content-Type. Deciding earlier would mean guessing from the path, which the
 // /assets tree makes unreliable.
 type gzipWriter struct {
 	http.ResponseWriter
-	gz     *gzip.Writer
-	wrote  bool
-	status int
+	gz      *gzip.Writer
+	decided bool
 }
 
 // compressible covers what cairn actually serves as text. Images, fonts and
@@ -84,24 +83,29 @@ func compressible(ct string) bool {
 	return false
 }
 
+// WriteHeader is where the decision has to be made, not Write: headers are
+// frozen the moment it runs, and http.ServeContent calls it before copying a
+// file. Deciding one write too late meant static files went out compressed
+// with no Content-Encoding to say so, and a browser ran gzip bytes as
+// JavaScript.
 func (w *gzipWriter) WriteHeader(code int) {
-	w.status = code
-	w.ResponseWriter.WriteHeader(code)
-}
-
-func (w *gzipWriter) Write(b []byte) (int, error) {
-	if !w.wrote {
-		w.wrote = true
-		// 304 and friends carry no body, and a compressed empty body is not
-		// empty. Leave them alone.
-		if w.status/100 != 2 || !compressible(w.Header().Get("Content-Type")) {
-			w.gz = nil
-		} else {
+	if !w.decided {
+		w.decided = true
+		// 2xx only: a 304 carries no body, and a compressed empty body is not
+		// empty.
+		if code/100 == 2 && compressible(w.Header().Get("Content-Type")) {
 			// The length is the uncompressed one, and Go would send it as is.
 			w.Header().Del("Content-Length")
 			w.Header().Set("Content-Encoding", "gzip")
 			w.gz = gzip.NewWriter(w.ResponseWriter)
 		}
+	}
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *gzipWriter) Write(b []byte) (int, error) {
+	if !w.decided {
+		w.WriteHeader(http.StatusOK)
 	}
 	if w.gz == nil {
 		return w.ResponseWriter.Write(b)
@@ -136,7 +140,7 @@ func compress(h http.Handler) http.Handler {
 			h.ServeHTTP(w, r)
 			return
 		}
-		gw := &gzipWriter{ResponseWriter: w, status: http.StatusOK}
+		gw := &gzipWriter{ResponseWriter: w}
 		defer func() {
 			if err := gw.Close(); err != nil {
 				log.Printf("gzip: %v", err)

--- a/src/internal/server/routing.go
+++ b/src/internal/server/routing.go
@@ -36,6 +36,16 @@ func secureHeaders(h http.Handler) http.Handler {
 		hd.Set("X-Frame-Options", "DENY")
 		hd.Set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
 		hd.Set("Content-Security-Policy", Current().CSP)
+		// Severs window.opener on the links that leave for a service, so a page
+		// cairn opened cannot navigate the tab it came from. The template
+		// already carries rel="noopener"; this is the belt that survives a
+		// future edit forgetting it.
+		hd.Set("Cross-Origin-Opener-Policy", "same-origin")
+		// same-site rather than same-origin: self-hosters put their services on
+		// sibling subdomains, and one of those pages showing a cairn icon is a
+		// reasonable thing to do. A genuine third party still cannot embed
+		// anything of ours.
+		hd.Set("Cross-Origin-Resource-Policy", "same-site")
 		// HSTS only once the visit is already https, like the cookies: sending
 		// it over plain http would strand the LAN deployments cairn also serves.
 		if secureRequest(r) {

--- a/src/internal/server/routing.go
+++ b/src/internal/server/routing.go
@@ -1,6 +1,9 @@
 package server
 
 import (
+	"compress/gzip"
+	"io"
+	"log"
 	"net/http"
 	"strings"
 
@@ -51,6 +54,95 @@ func noListing(h http.Handler) http.Handler {
 			return
 		}
 		h.ServeHTTP(w, r)
+	})
+}
+
+// gzipWriter compresses on the first write, once the handler has settled its
+// Content-Type. Deciding earlier would mean guessing from the path, which the
+// /assets tree makes unreliable.
+type gzipWriter struct {
+	http.ResponseWriter
+	gz     *gzip.Writer
+	wrote  bool
+	status int
+}
+
+// compressible covers what cairn actually serves as text. Images, fonts and
+// the ico are already compressed; running them through gzip spends CPU to add
+// bytes.
+func compressible(ct string) bool {
+	ct, _, _ = strings.Cut(ct, ";")
+	switch strings.TrimSpace(ct) {
+	// text/javascript rather than application/javascript: that is what Go's
+	// mime table now hands back for a .js, and the older spelling alone let
+	// search.js through uncompressed.
+	case "text/html", "text/plain", "text/css", "text/xml", "text/javascript",
+		"application/javascript", "application/json", "application/xml",
+		"application/manifest+json", "image/svg+xml":
+		return true
+	}
+	return false
+}
+
+func (w *gzipWriter) WriteHeader(code int) {
+	w.status = code
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *gzipWriter) Write(b []byte) (int, error) {
+	if !w.wrote {
+		w.wrote = true
+		// 304 and friends carry no body, and a compressed empty body is not
+		// empty. Leave them alone.
+		if w.status/100 != 2 || !compressible(w.Header().Get("Content-Type")) {
+			w.gz = nil
+		} else {
+			// The length is the uncompressed one, and Go would send it as is.
+			w.Header().Del("Content-Length")
+			w.Header().Set("Content-Encoding", "gzip")
+			w.gz = gzip.NewWriter(w.ResponseWriter)
+		}
+	}
+	if w.gz == nil {
+		return w.ResponseWriter.Write(b)
+	}
+	return w.gz.Write(b)
+}
+
+// ReadFrom has to exist, and has to funnel back through Write. The embedded
+// http.ResponseWriter implements io.ReaderFrom, and embedding promotes it, so
+// the io.Copy inside http.ServeContent would hand a file straight to the
+// socket and skip the compression entirely. That is not hypothetical: the
+// pages came back gzipped while every static file did not.
+func (w *gzipWriter) ReadFrom(r io.Reader) (int64, error) {
+	return io.Copy(struct{ io.Writer }{w}, r)
+}
+
+func (w *gzipWriter) Close() error {
+	if w.gz != nil {
+		return w.gz.Close()
+	}
+	return nil
+}
+
+// compress gzips the text responses for clients that asked. Vary rides on
+// every response, compressed or not: a cache that stored the plain answer must
+// not hand it to a client that would have got the compressed one, and the
+// header is the only thing telling it so.
+func compress(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Vary", "Accept-Encoding")
+		if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+			h.ServeHTTP(w, r)
+			return
+		}
+		gw := &gzipWriter{ResponseWriter: w, status: http.StatusOK}
+		defer func() {
+			if err := gw.Close(); err != nil {
+				log.Printf("gzip: %v", err)
+			}
+		}()
+		h.ServeHTTP(gw, r)
 	})
 }
 

--- a/src/internal/server/routing_test.go
+++ b/src/internal/server/routing_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -143,33 +144,47 @@ func TestCompressDropsStaleContentLength(t *testing.T) {
 	}
 }
 
-// http.ServeContent copies through io.Copy, which uses io.ReaderFrom when the
-// writer offers one. Embedding http.ResponseWriter offers one, so without our
-// own ReadFrom the file goes straight to the socket and the compression is
-// silently skipped. This is the case that actually shipped broken: pages came
-// back gzipped, every static file did not.
-func TestCompressSurvivesServeContent(t *testing.T) {
-	css := strings.Repeat(":root{--accent:#247b7b}\n", 60)
-	fsys := fstest.MapFS{"style.css": &fstest.MapFile{Data: []byte(css)}}
-	h := compress(http.FileServerFS(fsys))
+// The one that shipped broken, and the one a ResponseRecorder cannot catch:
+// http.ServeContent calls WriteHeader before copying, so a middleware that
+// decides at Write time mutates headers that have already gone out. Over a
+// real connection the file then arrives gzipped with nothing saying so, and a
+// browser runs the compressed bytes as JavaScript. Only a real server freezes
+// headers the way this needs.
+func TestCompressLabelsWhatItCompressesOverTheWire(t *testing.T) {
+	js := strings.Repeat("function pad(){return 1}\n", 60)
+	fsys := fstest.MapFS{"search.js": &fstest.MapFile{Data: []byte(js)}}
+	srv := httptest.NewServer(compress(http.FileServerFS(fsys)))
+	defer srv.Close()
 
-	rec := httptest.NewRecorder()
-	r := httptest.NewRequest("GET", "/style.css", nil)
-	r.Header.Set("Accept-Encoding", "gzip")
-	h.ServeHTTP(rec, r)
-
-	if got := rec.Header().Get("Content-Encoding"); got != "gzip" {
-		t.Fatalf("a file served through ServeContent came back with Content-Encoding %q, want gzip", got)
-	}
-	zr, err := gzip.NewReader(rec.Body)
+	// Transport.DisableCompression stops Go from asking and unwrapping behind
+	// our back, so the test sees exactly what a browser would.
+	c := &http.Client{Transport: &http.Transport{DisableCompression: true}}
+	req, err := http.NewRequest("GET", srv.URL+"/search.js", nil)
 	if err != nil {
 		t.Fatal(err)
+	}
+	req.Header.Set("Accept-Encoding", "gzip")
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if got := resp.Header.Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("Content-Encoding = %q, want gzip: the body is compressed but nothing says so", got)
+	}
+	if got := resp.Header.Get("Content-Length"); got == strconv.Itoa(len(js)) {
+		t.Errorf("Content-Length still claims the uncompressed %s", got)
+	}
+	zr, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		t.Fatalf("body is not a gzip stream: %v", err)
 	}
 	back, err := io.ReadAll(zr)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(back) != css {
+	if string(back) != js {
 		t.Error("the decompressed file is not the file on disk")
 	}
 }

--- a/src/internal/server/routing_test.go
+++ b/src/internal/server/routing_test.go
@@ -1,0 +1,175 @@
+package server
+
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+// compress has to stay invisible: the bytes a client gets back must be the
+// bytes the handler wrote, whatever the wire carried.
+func TestCompressRoundTrips(t *testing.T) {
+	body := strings.Repeat("cairn sert des pages calmes. ", 40)
+	h := compress(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		io.WriteString(w, body)
+	}))
+
+	rec := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/en/", nil)
+	r.Header.Set("Accept-Encoding", "gzip")
+	h.ServeHTTP(rec, r)
+
+	if got := rec.Header().Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("Content-Encoding = %q, want gzip", got)
+	}
+	if rec.Body.Len() >= len(body) {
+		t.Errorf("compressed %d bytes into %d, which is not compression", len(body), rec.Body.Len())
+	}
+	zr, err := gzip.NewReader(rec.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := io.ReadAll(zr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(back) != body {
+		t.Error("what came back out is not what the handler wrote")
+	}
+}
+
+// A client that did not ask gets plain bytes, and every response says the
+// answer depends on Accept-Encoding so a shared cache cannot mix the two up.
+func TestCompressLeavesUnaskedClientsAlone(t *testing.T) {
+	h := compress(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		io.WriteString(w, "plain")
+	}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", "/en/", nil))
+
+	if got := rec.Header().Get("Content-Encoding"); got != "" {
+		t.Errorf("unasked client got Content-Encoding %q", got)
+	}
+	if rec.Body.String() != "plain" {
+		t.Errorf("body = %q", rec.Body.String())
+	}
+	if got := rec.Header().Get("Vary"); !strings.Contains(got, "Accept-Encoding") {
+		t.Errorf("Vary = %q, want it to mention Accept-Encoding", got)
+	}
+}
+
+// Images, fonts and the ico are already compressed. Running them through gzip
+// spends CPU to add bytes, so the middleware has to leave them be.
+// Every content type cairn actually answers with has to be covered, or a file
+// slips through uncompressed and nothing says so. text/javascript is the one
+// that did: the older application/javascript spelling is not what Go serves.
+func TestCompressCoversEveryTextTypeCairnServes(t *testing.T) {
+	for _, ct := range []string{
+		"text/html; charset=utf-8",
+		"text/css; charset=utf-8",
+		"text/javascript; charset=utf-8",
+		"text/plain; charset=utf-8",
+		"application/xml; charset=utf-8",
+		"application/manifest+json",
+		"image/svg+xml",
+	} {
+		if !compressible(ct) {
+			t.Errorf("%s is served by cairn but never compressed", ct)
+		}
+	}
+}
+
+func TestCompressSkipsAlreadyCompressedTypes(t *testing.T) {
+	for _, ct := range []string{"image/png", "font/woff2", "image/x-icon"} {
+		h := compress(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", ct)
+			io.WriteString(w, strings.Repeat("\x00", 500))
+		}))
+		rec := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "/static/x", nil)
+		r.Header.Set("Accept-Encoding", "gzip")
+		h.ServeHTTP(rec, r)
+		if got := rec.Header().Get("Content-Encoding"); got != "" {
+			t.Errorf("%s was compressed (Content-Encoding %q)", ct, got)
+		}
+	}
+}
+
+// A 304 carries no body. Compressing one would mean sending a gzip header
+// where the client expects nothing at all.
+func TestCompressLeavesNotModifiedEmpty(t *testing.T) {
+	h := compress(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	rec := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/en/", nil)
+	r.Header.Set("Accept-Encoding", "gzip")
+	h.ServeHTTP(rec, r)
+
+	if rec.Code != http.StatusNotModified {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("304 carried %d bytes", rec.Body.Len())
+	}
+	if got := rec.Header().Get("Content-Encoding"); got != "" {
+		t.Errorf("304 claimed Content-Encoding %q", got)
+	}
+}
+
+// The uncompressed length would be a lie once the body is gzipped, and a
+// client that trusts it hangs waiting for bytes that never come.
+func TestCompressDropsStaleContentLength(t *testing.T) {
+	body := strings.Repeat("x", 400)
+	h := compress(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/css")
+		w.Header().Set("Content-Length", "400")
+		io.WriteString(w, body)
+	}))
+	rec := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/static/style.css", nil)
+	r.Header.Set("Accept-Encoding", "gzip")
+	h.ServeHTTP(rec, r)
+
+	if got := rec.Header().Get("Content-Length"); got != "" {
+		t.Errorf("Content-Length survived as %q", got)
+	}
+}
+
+// http.ServeContent copies through io.Copy, which uses io.ReaderFrom when the
+// writer offers one. Embedding http.ResponseWriter offers one, so without our
+// own ReadFrom the file goes straight to the socket and the compression is
+// silently skipped. This is the case that actually shipped broken: pages came
+// back gzipped, every static file did not.
+func TestCompressSurvivesServeContent(t *testing.T) {
+	css := strings.Repeat(":root{--accent:#247b7b}\n", 60)
+	fsys := fstest.MapFS{"style.css": &fstest.MapFile{Data: []byte(css)}}
+	h := compress(http.FileServerFS(fsys))
+
+	rec := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/style.css", nil)
+	r.Header.Set("Accept-Encoding", "gzip")
+	h.ServeHTTP(rec, r)
+
+	if got := rec.Header().Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("a file served through ServeContent came back with Content-Encoding %q, want gzip", got)
+	}
+	zr, err := gzip.NewReader(rec.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := io.ReadAll(zr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(back) != css {
+		t.Error("the decompressed file is not the file on disk")
+	}
+}

--- a/src/internal/server/server.go
+++ b/src/internal/server/server.go
@@ -36,7 +36,7 @@ func Serve(addr, cfgDir, assetsDir string) error {
 	// generous.
 	srv := &http.Server{
 		Addr:              addr,
-		Handler:           mount(secureHeaders(routes(cfgDir, assetsDir))),
+		Handler:           mount(secureHeaders(compress(routes(cfgDir, assetsDir)))),
 		ReadHeaderTimeout: 10 * time.Second,
 		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       120 * time.Second,
@@ -64,6 +64,7 @@ func routes(cfgDir, assetsDir string) *http.ServeMux {
 	mux.Handle("GET /favicon.ico", cacheControl(http.HandlerFunc(faviconICO(static))))
 	mux.HandleFunc("GET /robots.txt", robots)
 	mux.HandleFunc("GET /sitemap.xml", sitemap)
+	mux.HandleFunc("GET /.well-known/security.txt", securityTxt)
 	mux.HandleFunc("GET /{$}", root)
 	// Catch-all rather than /{locale}/{$}: a wildcard pattern would conflict
 	// with the /static/ and /assets/ subtrees in the 1.22 mux.


### PR DESCRIPTION
Three findings from auditing what a running instance shows a machine: one missing file, one missing header, and one feature that was quietly doing nothing. The first two are fixed here, the third is now impossible to miss.

## `/.well-known/security.txt`

Somebody who finds a flaw in one of your services has to guess where to send it. RFC 9116 settles that, and one key turns it on:

```yaml
security:
  contact: mailto:security@example.org
  policy: https://example.org/disclosure # optional
  encryption: https://example.org/pgp.asc # optional
```

`contact` is the only field an operator writes. cairn fills the rest, because it already knows it:

```
Contact: mailto:security@example.org
Expires: 2027-07-30T17:45:16Z
Preferred-Languages: fr, en
Canonical: https://tools.example.org/.well-known/security.txt
```

**`Expires` is why this is served rather than documented.** The RFC makes it mandatory, and a file written by hand carries a date somebody chose once and never looked at again. Past it, the file is worse than absent: it tells a researcher the address is stale. Computed per request, it cannot rot. `Preferred-Languages` comes from `locales`, `Canonical` from `url` or from the request.

Without a contact the path answers `404`, which is the honest answer rather than an empty promise. A bare address without its scheme is a config error, and so is a newline in any of the three values: security.txt is line-based, so one would forge a field.

## Compression

There was none. A first visit to the demo:

| | Before | After |
| --- | --- | --- |
| `/fr/` | 17,252 B | 3,718 B |
| `style.css` | 30,129 B | 7,754 B |
| `search.js` | 5,807 B | 2,442 B |
| **Total** | **53,188 B** | **13,914 B** (-74%) |

Text only. Images, fonts and the `ico` are left alone, since compressing them again spends CPU to add bytes. `Vary: Accept-Encoding` rides on every response so a shared cache cannot hand the compressed answer to a client that did not ask.

Two bugs found by measuring rather than by reading, both of which had shipped happily in tests:

- **`io.ReaderFrom` bypassed the compression entirely for static files.** Embedding `http.ResponseWriter` promotes its `ReadFrom`, so the `io.Copy` inside `http.ServeContent` handed files straight to the socket. Pages came back gzipped; every file under `/static/` did not. There is a regression test for exactly this now.
- **`search.js` stayed uncompressed** because Go's mime table says `text/javascript`, not `application/javascript`. A test now pins every content type cairn actually serves.

## The SEO feature that was doing nothing

`canonical`, `og:url` and the `hreflang` alternates (`x-default` included) are all implemented, and all built from `site.url`. Unset, they are simply absent: the page renders, nothing warns, and a multilingual site reads to a crawler as several duplicates of each other. The demo has been shipping without them.

`-check` now says so:

```
warning: site.yaml has no url: pages carry no canonical link, no og:url and no hreflang alternates (set url: https://… to emit them)
```

Silent when `index: false`, since an operator who told search engines to stay away has already answered the question. Two fixtures that asserted "a complete config warns about nothing" gained a `url`, which is the honest consequence: a config without one is not complete for a site that wants to be found.

## Audited and found already in order

Worth writing down so the next audit starts here rather than from scratch: CSP, HSTS, `Referrer-Policy`, `Permissions-Policy`, `X-Content-Type-Options` and `X-Frame-Options` are all emitted; `robots.txt`, `sitemap.xml`, the manifest and `/favicon.ico` are all served; the `og:` tags are complete; and the locale cookie already carries `SameSite=Lax` with `Secure` following the scheme.

HSTS deliberately carries neither `includeSubDomains` nor `preload`, and should keep not carrying them: cairn very often runs on a subdomain, where `includeSubDomains` would speak for the whole parent domain and the sibling services cairn knows nothing about. That belongs to the operator's proxy, not to a directory page. Scanners will keep marking it down; the trade is worth it.

## Verified

215 tests, coverage 90.5% against an 87% floor. The numbers above are measured against the running demo, before and after. The demo config gained a `security` block, so `just demo` now serves a real security.txt pointing at this repository's private advisories.
