### PR TITLE
Finish the audit: accessibility, and the checks that were missing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,10 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: bash .github/coverage-badge.sh "$PCT"
 
+  # Named `search` and it stays named `search`, whatever else it grows to run:
+  # this is a required check on a protected branch, and a required check under
+  # a new name never runs, which leaves every pull request waiting forever for
+  # a job that no longer exists.
   search:
     runs-on: ubuntu-latest
     steps:
@@ -65,18 +69,25 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: stable
-      # search.js is the only behaviour the Go tests cannot reach: they assert
-      # the markup that ships, not what happens once someone types into it.
-      # Deliberately not the demo stack, so this pulls nothing from a registry
-      # and can be a required check.
-      - name: drive the search in a browser
+      # search.js, the theme toggle's state, the mobile category swap and the
+      # burger's scroll dismissal are the behaviours the Go tests cannot reach:
+      # they assert the markup that ships, not what happens once someone types,
+      # clicks or scrolls. Deliberately not the demo stack, so this pulls
+      # nothing from a registry and can be a required check. Same two instances
+      # as `just test-browser`: example/, and the fixture with more than seven
+      # categories and a header burger that example/ has neither of.
+      - name: drive search and the accessibility behaviours in a browser
         run: |
           npm --silent install --no-save --no-package-lock playwright
           npx --yes playwright install --with-deps --only-shell chromium
           go build -o /tmp/cairn ./src/cmd/cairn
-          /tmp/cairn -config example -addr 127.0.0.1:8099 &
-          for _ in $(seq 1 20); do curl -fsS http://127.0.0.1:8099/healthz >/dev/null && break; sleep 1; done
-          node scripts/search.mjs http://127.0.0.1:8099/en/
+          /tmp/cairn -config example -addr 127.0.0.1:8090 &
+          /tmp/cairn -config scripts/fixtures/many-categories -addr 127.0.0.1:8091 &
+          for port in 8090 8091; do
+            for _ in $(seq 1 20); do curl -fsS http://127.0.0.1:$port/healthz >/dev/null && break; sleep 1; done
+          done
+          node scripts/search.mjs http://127.0.0.1:8090/en/
+          node scripts/a11y.mjs http://127.0.0.1:8090/en/ http://127.0.0.1:8091/en/
 
   chart:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ The Docker build runs `go vet` and the test suite; if the image builds, it
 passed.
 
 With [just](https://just.systems) installed, `just` lists the shortcuts:
-`test`, `test-search`, `coverage`, `lint`, `build`, `chart`, `demo`,
+`test`, `test-browser`, `coverage`, `lint`, `build`, `chart`, `demo`,
 `demo-rebuild`, `down`, `logs`, `shots`, `hooks`, `icons`.
 Linting is [golangci-lint](https://golangci-lint.run) with a near-default
 config (`.golangci.yml`); CI runs it on every code push.
@@ -44,6 +44,7 @@ src/internal/
 docker/               Dockerfile (FROM scratch) and the hardened compose
 charts/cairn/         the Helm chart, same objects as docs/deployment/kubernetes.md
 example/              the config served by the dev loop and the docs
+scripts/              the browser tests and their fixtures, icons, screenshots
 docs/                 GitHub-native Markdown, no generator
 ```
 
@@ -90,17 +91,33 @@ docs: quickstart readme and example config
 
 No trailers, no bodies unless the _why_ genuinely needs a sentence.
 
-## The search
+## The browser tests
 
-`search.js` is the only behaviour `go test` cannot reach: the Go tests assert
-the markup that ships, not what happens once someone types into it. `just
-test-search` drives it in a real browser against the example config, and CI
-runs the same script. It pulls nothing from a registry, so unlike the demo job
-it is safe to make a required check.
+A handful of behaviours are what `go test` cannot reach: the Go tests assert
+the markup that ships, not what happens once someone types, clicks or scrolls.
+`just test-browser` drives them in a real browser and CI runs the same two
+scripts. They pull nothing from a registry, so unlike the demo job they are
+safe to make a required check.
 
-Anything you change in `search.js` belongs there, particularly the paths back
-to an empty query: clearing the field, Escape, and typing only spaces all have
-to return the full list rather than "no results".
+`scripts/search.mjs` drives the search against `example/`. Anything you change
+in `search.js` belongs there, particularly the paths back to an empty query:
+clearing the field, Escape, and typing only spaces all have to return the full
+list rather than "no results".
+
+`scripts/a11y.mjs` drives four things no markup assertion can see: the theme
+toggle's `aria-pressed`, the 3:1 boundary on the controls a visitor can
+operate, the mobile category swap with JavaScript on and with it off, and the
+burger menu surviving a scroll while the keyboard is inside it. The last two
+need a site `example/` cannot provide, so they run against
+`scripts/fixtures/many-categories/`: more than seven categories, which is where
+the chip row gives way to a select, and enough header links to raise the
+burger.
+
+The recipe serves both configs, on 8090 and 8091, and kills them on the way
+out. The CI job stays named `search` whatever else it grows to run: it is a
+required check on a protected branch, and a required check under a new name
+never runs, which leaves every pull request waiting for a job that no longer
+exists.
 
 ## The icons
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,14 @@ account or a manual, and boring for you to operate.
 - **At home on a phone**: the layout reflows to one hand, the header steps
   aside as you scroll and returns the moment you head back up, and a burger
   keeps search within thumb's reach.
-- **Built to stay readable**: contrast measured against WCAG AA in both
+- **Built to stay readable**: text contrast measured against WCAG AA in both
   themes, a skip link, named landmarks, search results announced through a
-  live region, and right-to-left languages laid out the right way round.
-  Tested with a browser, not yet with a real screen reader: if you use one,
+  live region, a theme toggle that says which way it is set, and
+  right-to-left languages laid out the right way round. The controls a
+  visitor can operate, the search box and the phone's jump-to select, carry a
+  boundary that clears 3:1, remeasured in a real browser on every pull
+  request. Tested with a browser, never audited as a whole, and not yet with a
+  real screen reader: if you use one,
   [tell us what breaks](https://github.com/MorganKryze/cairn/issues).
 - **Calm typography, light and dark, keyboard-friendly**, and every feature
   degrades gracefully without JavaScript.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -64,8 +64,9 @@ same tab.
   anything.
 
 - **It reads like a page, not a control panel.** A hero that says what this
-  place is, typography meant for prose, contrast measured against WCAG AA, and
-  every feature still working with JavaScript turned off.
+  place is, typography meant for prose, text contrast measured against WCAG AA,
+  and a directory that is still whole with JavaScript turned off: every
+  category, every card, every link, minus the search.
 
 ## What the others do that cairn never will
 

--- a/docs/configuration/i18n.md
+++ b/docs/configuration/i18n.md
@@ -42,6 +42,11 @@ A plain string applies to every locale. A per-locale map resolves to the
 visitor's locale, then the default locale, then any value rather than
 nothing.
 
+That fallback is what makes a half-finished map hard to see: the page reads
+fine, in the wrong language. `cairn -check` lists every field of the kind above
+that answers for some of your locales and not the rest, the site title and the
+link labels included, and names the locales it misses.
+
 ## UI strings
 
 The interface text ships built in for **English, French, German, Spanish,
@@ -65,6 +70,13 @@ strings:
 
 Missing your language? Adding it to cairn itself is a small, welcome pull
 request: see [Add your language](../../CONTRIBUTING.md#add-your-language).
+
+Until then, `cairn -check` says which locale is in that position rather than
+leaving you to spot English menus on a Polish page:
+
+```console
+warning: locale "pl" has no built-in interface: its pages carry that lang and an English menu, buttons and search messages (cairn ships de, en, es, fr, it, nl, pt; a strings: block supplies the rest)
+```
 
 A word on quality: French and English are written by someone who speaks them.
 The other five are careful but unreviewed, and interface words are exactly
@@ -116,6 +128,9 @@ with `strings` above. The direction works either way; the words are yours.
 | `status.link`        | view status                   | status pill link hint (a11y)                     |
 
 A partial override only applies to the locales it names; the built-ins fill
-the rest.
+the rest. So `nav.menu: { fr: Sommaire }` on a `[fr, en]` site gives the French
+pages your word and the English pages cairn's, and neither page shows which of
+the two it is using. `cairn -check` names the key and the locales it leaves
+out.
 
 Next: [Docker Compose](../deployment/docker-compose.md)

--- a/docs/configuration/services.md
+++ b/docs/configuration/services.md
@@ -88,8 +88,11 @@ name; each entry is a plain path or a `{src, caption}` pair:
 
 They appear on the detail page, in order, between the text and the button.
 cairn serves `media/` itself at `/media/`, so previews stay self-hosted like
-everything else; a full URL or an absolute `/assets/…` path passes through
-unchanged. Referencing a file that is not in `media/` is a config error that
-names the expected location.
+everything else; a full URL or an `/assets/…` path passes through unchanged.
+
+`screen.png` and `/media/screen.png` are two spellings of the same file, and
+cairn opens the file behind either one before it serves the page. A name that
+reaches nothing is a config error giving the path it looked for, so a typo
+stops at startup rather than showing a visitor an empty frame.
 
 Next: [Site](site.md)

--- a/docs/configuration/site.md
+++ b/docs/configuration/site.md
@@ -148,6 +148,38 @@ config: site.yaml: url "https://example.org/cairn" must be the domain alone, wit
 
 More on the sub-path in [Reverse proxies](../deployment/reverse-proxies.md#under-a-sub-path).
 
+## Links a browser will not follow
+
+`javascript:` and `vbscript:` are a config error in every field of this file
+that holds a link: `logo`, `favicon`, the `url` and `icon` of a `links` or
+`footer` entry, and the three `security` fields.
+
+```console
+config: site.yaml: footer url "javascript:alert(1)" uses the javascript: or vbscript: scheme, which loads nothing (expected https://…, mailto:… or an absolute path)
+```
+
+The rest of the file was already answered: a service `url` has to be a URL or
+a path, an unknown `links` icon is met with the list of glyphs. These fields
+are the ones where nothing else would have spoken. A header link takes
+`mailto:` and `tel:` besides `https://`, and `security.contact` takes any URI
+at all, which is what [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) asks
+of it; `logo` and `favicon` are checked by nothing at boot, since a missing
+file there is a plausible typo and earns a `cairn -check` warning rather than a
+refusal.
+
+What the refusal buys is an error instead of a silence. Nothing here would have
+run: `html/template` blanks a `javascript:` href on the way out, so the link
+renders in the header of every page and goes nowhere, with nothing in the log
+to say why. The favicon is the sharper case, since it reaches the web manifest
+as JSON, which template escaping does not cover, and comes back from
+`/favicon.ico` as a `Location` header.
+
+The value is read the way a browser reads it, not the way it is written: a
+browser drops tabs and newlines from a URL and strips leading control
+characters before it looks at the scheme. `JavaScript:`, a leading space and a
+tab inside the word are all the same URL as the plain one, so they all get the
+same answer.
+
 ## The icon set
 
 Out of the box cairn serves a complete set, all generated from one drawing so
@@ -210,6 +242,22 @@ Anything wrong in this list is a config error that names the entry, so a typo
 stops at startup rather than reaching a phone. A list that is merely short of
 the 192 and 512 pair is not wrong, only quieter than you meant, so that one is
 a `cairn -check` warning instead.
+
+So is a `sizes` the file disagrees with. cairn cannot measure for you and
+publishes your number in the manifest as fact, and a wrong one is invisible
+from every side: the manifest validates, the file loads, and a phone simply
+picks it for a slot it does not fill, which is how a home-screen icon comes out
+blurred. With the assets directory in reach, `-check` opens each file and
+compares:
+
+```console
+$ cairn -check -config ./config -assets ./assets
+warning: site.yaml icons entry 2 declares sizes "512x512" but /assets/brand-512.png measures 256x256: the manifest states the declared size as fact, so a phone picks this file for a slot it does not fill (correct sizes, or supply a file that size)
+```
+
+An entry whose `src` names no file at all gets its own line. Both checks need
+that directory, so they say nothing when it is not mounted; see
+[Icons: your own files](../recipes/icons.md#your-own-files).
 
 ## Telling researchers where to write
 

--- a/docs/configuration/site.md
+++ b/docs/configuration/site.md
@@ -150,29 +150,41 @@ More on the sub-path in [Reverse proxies](../deployment/reverse-proxies.md#under
 
 ## Links a browser will not follow
 
-`javascript:` and `vbscript:` are a config error in every field of this file
-that holds a link: `logo`, `favicon`, the `url` and `icon` of a `links` or
-`footer` entry, and the three `security` fields.
+`javascript:`, `vbscript:` and `data:` are a config error in every field of
+this file that holds a link: `logo`, `favicon`, the `url` and `icon` of a
+`links` or `footer` entry, and the three `security` fields.
 
 ```console
-config: site.yaml: footer url "javascript:alert(1)" uses the javascript: or vbscript: scheme, which loads nothing (expected https://…, mailto:… or an absolute path)
+config: site.yaml: footer url "javascript:alert(1)" uses the javascript: scheme; cairn refuses javascript:, vbscript: and data: wherever a link goes (expected https://…, mailto:… or an absolute path)
 ```
+
+The first two run code. `data:` is refused with them because `data:text/html`
+carries a whole document, script and all, and because a list of two invites the
+next reader to assume the third was weighed and kept. It costs nothing: an
+inline `data:` favicon has never once reached a browser from cairn, for the
+reason below.
 
 The rest of the file was already answered: a service `url` has to be a URL or
 a path, an unknown `links` icon is met with the list of glyphs. These fields
 are the ones where nothing else would have spoken. A header link takes
-`mailto:` and `tel:` besides `https://`, and `security.contact` takes any URI
-at all, which is what [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) asks
-of it; `logo` and `favicon` are checked by nothing at boot, since a missing
-file there is a plausible typo and earns a `cairn -check` warning rather than a
-refusal.
+`mailto:` besides `https://`, and `security.contact` takes any URI at all,
+which is what [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) asks of it;
+`logo` and `favicon` are checked by nothing at boot, since a missing file there
+is a plausible typo and earns a `cairn -check` warning rather than a refusal.
 
 What the refusal buys is an error instead of a silence. Nothing here would have
-run: `html/template` blanks a `javascript:` href on the way out, so the link
-renders in the header of every page and goes nowhere, with nothing in the log
-to say why. The favicon is the sharper case, since it reaches the web manifest
-as JSON, which template escaping does not cover, and comes back from
-`/favicon.ico` as a `Location` header.
+run: `html/template` emits only `http`, `https`, `mailto` and paths, and
+replaces every other scheme with a dead placeholder, so the link renders in the
+header of every page and goes nowhere, with nothing in the log to say why. The
+favicon is the sharper case, since it reaches the web manifest as JSON, which
+template escaping does not cover, and comes back from `/favicon.ico` as a
+`Location` header.
+
+That same rule is worth knowing for its own sake: a `tel:` link is blanked
+exactly like these three. It is not refused, because it is nobody's attack and
+refusing it would stop a site from loading over a link that merely does
+nothing, but it will not work either. Write the number in the label and point
+the link at a page.
 
 The value is read the way a browser reads it, not the way it is written: a
 browser drops tabs and newlines from a URL and strips leading control

--- a/docs/configuration/text.md
+++ b/docs/configuration/text.md
@@ -36,6 +36,15 @@ Images resolve exactly like [service preview images](services.md#preview-images)
 a bare name is a file in your `media/` folder, a URL or an absolute path
 passes through.
 
+They are checked differently, though, and it is worth knowing which way round.
+A missing `images:` entry stops the load and names itself; a missing one here
+only earns a `cairn -check` warning, because prose is not worth refusing a
+whole site over:
+
+```console
+warning: page "legal" body shows "seal.png", which is not there: the page renders a broken image (expected a file at ./config/media/seal.png)
+```
+
 A full example, in a hosted page:
 
 ```yaml

--- a/docs/configuration/theming.md
+++ b/docs/configuration/theming.md
@@ -48,16 +48,26 @@ The stylesheet is built on custom properties; override those first:
 | `--muted`        | secondary text                                      |
 | `--card`         | card, tile and search backgrounds                   |
 | `--faint`        | icon tiles, subtle fills                            |
-| `--border`       | card, chip and input borders                        |
+| `--border`       | card, chip and rule outlines                        |
+| `--ui-border`    | the edge of a control you can operate               |
 | `--accent`       | fills, focus rings, buttons (set by `theme.accent`) |
 | `--accent-ink`   | accent tuned for text contrast (derived)            |
 | `--up`, `--down` | status dot colors                                   |
+
+Two border colors, because they answer to different rules. `--border` draws
+decoration: the outline of a card, a rule, the trail's spine, all things the
+page would still be legible without. `--ui-border` draws the edge of something
+a visitor operates, the search box on the home page and the jump-to select a
+phone gets, where nothing else says where to type or tap. That edge is held at
+3:1 against the page and against its own fill, which is the floor
+[WCAG asks for a control's boundary](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html);
+if you override it, keep it there.
 
 Anything beyond variables is regular CSS on stable class names (`.card`,
 `.cat`, `.way`, `.tile`, `.about`, `.menu`, `.toc`, `.detail`, `.btn`, …).
 Keep [WCAG AA
 contrast](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html)
-in mind; the defaults pass it.
+in mind for text; the defaults pass it.
 
 ### Typography
 

--- a/docs/deployment/airgap.md
+++ b/docs/deployment/airgap.md
@@ -131,6 +131,13 @@ ok: 2 services, 1 categories, 0 pages, locales [fr]
 As long as that line names an icon, your air gap has a hole in it. Once it is
 clean, `sha256sum * > SHA256SUMS` and cross.
 
+The mount earns its place twice over, because two other checks go quiet without
+it rather than loud: an `/assets` path that names no file, and an icon whose
+declared `sizes` the file contradicts. Both have to open the file, and with no
+directory to open they say nothing at all. A clean run on `/config` alone is
+therefore worth less than it looks, which matters here more than anywhere: on
+the far side of the gap there is no fixing a broken image with a download.
+
 ## 3. Inside, with a registry
 
 ```sh

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -17,10 +17,12 @@ its visitors. Your reverse proxy already writes an access log; if you need
 numbers, count there.
 
 **Does it need JavaScript?**
-No. Pages are fully server-rendered; small scripts progressively add the
-search box, the category trail, the theme toggle and the welcome note's
-dismiss button. Without them, visitors simply see the whole directory in
-their system's theme.
+No. Pages are fully server-rendered; small scripts add the search box, the
+theme toggle, the welcome note's dismiss button and the highlight that follows
+you down the category trail. Without them the directory is all still there,
+every category, every card, every link, in the system's theme. On a phone the
+trail stays a row of chips instead of folding into the compact jump-to select,
+which is a control only a script can drive.
 
 **Can I put it behind authentication?**
 You can (any proxy auth works: Authelia, Tinyauth, basic auth), but cairn is

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -92,15 +92,20 @@ suggests a key your binary does not know yet.
 
 And `cairn -check` validates a config directory without serving anything,
 then warns about everything a serving site would hide: a translation missing
-in one locale, a `media/` file nothing references, an image heavy enough to
-hurt, a logo or a link written so it resolves nowhere, two categories
-differing only by case, a key that was accepted and then does nothing,
-icons that load from a CDN. It exits 0 or 1, so it slots into CI if you
-version your config:
+in one locale, a language cairn has no interface for, a `media/` file nothing
+references, an image heavy enough to hurt, a logo or a link written so it
+resolves nowhere, an `/assets` path naming a file that is not there, an icon
+declaring a size its file contradicts, two categories differing only by case,
+a key that was accepted and then does nothing, icons that load from a CDN. It
+exits 0 or 1, so it slots into CI if you version your config:
 
 ```sh
 docker run --rm -v ./config:/config ghcr.io/morgankryze/cairn:stable -check
 ```
+
+The two warnings that open a file, the `/assets` path and the icon size, need
+that directory mounted too (a second `-v`, or `-assets` on a bare binary).
+Without it they stay quiet rather than call every file missing at once.
 
 The whole GitHub Actions job, for a config repo:
 

--- a/docs/recipes/icons.md
+++ b/docs/recipes/icons.md
@@ -46,6 +46,13 @@ icon: /assets/icons/intranet.svg
 The same mount serves the site `logo:` and anything else you need
 (`/assets/...` URLs map directly to the directory).
 
+`cairn -check` opens those paths for you. An `/assets/…` logo, favicon,
+home-screen icon or header-link icon that names no file is a warning, because a
+mistyped one boots perfectly and then paints a broken image on every page. It
+only looks when it can see the directory, which means `-assets` on the command
+line or a second `-v` on a `docker run`; without it the check says nothing at
+all, rather than reporting every file in the config as missing.
+
 ## Going fully self-hosted
 
 Slug icons load from the jsdelivr CDN in your visitors' browsers: fine for

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -67,10 +67,10 @@ the kind of entry that refused the key and lists what that entry accepts, so
 a misspelt `show_versions` is answered with `show_version` rather than with
 the keys of some other part of the file.
 
-`javascript:` and `vbscript:` are refused in every field above that holds a
-link: `logo`, `favicon`, the `url` and `icon` of a `links` or `footer` entry,
-and the three `security` fields. Those are the ones no other rule answers,
-either because they take a scheme cairn cannot enumerate (`mailto:`, `tel:`)
+`javascript:`, `vbscript:` and `data:` are refused in every field above that
+holds a link: `logo`, `favicon`, the `url` and `icon` of a `links` or `footer`
+entry, and the three `security` fields. Those are the ones no other rule
+answers, either because they take a scheme cairn cannot enumerate (`mailto:`)
 or because a bad value there was only ever a `-check` warning. See
 [Links a browser will not follow](configuration/site.md#links-a-browser-will-not-follow).
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -20,18 +20,18 @@ logs the same error.
 
 ## `services.yaml` (any name)
 
-| Key          | Required | Default       | Type                                                                                                                                                             |
-| ------------ | -------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`         | yes      | n/a           | slug `[a-z0-9][a-z0-9-]*`, unique across files: it becomes a URL, so no leading dash                                                                             |
-| `url`        | yes      | n/a           | `http(s)://…` or absolute path                                                                                                                                   |
-| `name`       | yes      | n/a           | text (plain or per-locale map)                                                                                                                                   |
-| `desc`       | no       | empty         | text                                                                                                                                                             |
-| `details`    | no       | empty         | long text ([markdown subset](configuration/text.md)); enables the card's "Learn more" link                                                                       |
-| `images`     | no       | `[]`          | detail-page previews; list of `name.png` (a file in `/config/media/`) or `{src, caption: text}`; URLs and absolute paths pass through; also enables "Learn more" |
-| `category`   | no       | `other`       | slug                                                                                                                                                             |
-| `icon`       | no       | neutral glyph | slug, URL, or `/assets/…` path                                                                                                                                   |
-| `tags`       | no       | `[]`          | list of search words                                                                                                                                             |
-| `selfhosted` | no       | none          | `true`/`false`: shows a self-hosted / hosted-elsewhere flag on the card ([details](configuration/services.md#hosting-flag))                                      |
+| Key          | Required | Default       | Type                                                                                                                                                                                                                                    |
+| ------------ | -------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`         | yes      | n/a           | slug `[a-z0-9][a-z0-9-]*`, unique across files: it becomes a URL, so no leading dash                                                                                                                                                    |
+| `url`        | yes      | n/a           | `http(s)://…` or absolute path                                                                                                                                                                                                          |
+| `name`       | yes      | n/a           | text (plain or per-locale map)                                                                                                                                                                                                          |
+| `desc`       | no       | empty         | text                                                                                                                                                                                                                                    |
+| `details`    | no       | empty         | long text ([markdown subset](configuration/text.md)); enables the card's "Learn more" link                                                                                                                                              |
+| `images`     | no       | `[]`          | detail-page previews; list of `name.png` or `/media/name.png` (both name the same file in `/config/media/`, and both have to be there) or `{src, caption: text}`; URLs and other absolute paths pass through; also enables "Learn more" |
+| `category`   | no       | `other`       | slug                                                                                                                                                                                                                                    |
+| `icon`       | no       | neutral glyph | slug, URL, or `/assets/…` path                                                                                                                                                                                                          |
+| `tags`       | no       | `[]`          | list of search words                                                                                                                                                                                                                    |
+| `selfhosted` | no       | none          | `true`/`false`: shows a self-hosted / hosted-elsewhere flag on the card ([details](configuration/services.md#hosting-flag))                                                                                                             |
 
 ## `site.yaml`
 
@@ -66,6 +66,13 @@ category, page, section, link, image and icon entry alike. The message names
 the kind of entry that refused the key and lists what that entry accepts, so
 a misspelt `show_versions` is answered with `show_version` rather than with
 the keys of some other part of the file.
+
+`javascript:` and `vbscript:` are refused in every field above that holds a
+link: `logo`, `favicon`, the `url` and `icon` of a `links` or `footer` entry,
+and the three `security` fields. Those are the ones no other rule answers,
+either because they take a scheme cairn cannot enumerate (`mailto:`, `tel:`)
+or because a bad value there was only ever a `-check` warning. See
+[Links a browser will not follow](configuration/site.md#links-a-browser-will-not-follow).
 
 ## `categories.yaml`
 
@@ -119,23 +126,30 @@ it.
 
 ## Binary flags
 
-| Flag           | Default   | Role                                                                                                                                                                                              |
-| -------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `-addr`        | `:8080`   | listen address                                                                                                                                                                                    |
-| `-config`      | `/config` | config directory                                                                                                                                                                                  |
-| `-assets`      | `/assets` | directory served at `/assets/`, if it exists                                                                                                                                                      |
-| `-base-path`   | none      | serve under a [sub-path](deployment/reverse-proxies.md#under-a-sub-path) of the domain, e.g. `/cairn`                                                                                             |
-| `-healthcheck` | off       | probe `127.0.0.1:{port}/healthz`, exit 0/1, for `FROM scratch` healthchecks                                                                                                                       |
-| `-init`        | off       | print a commented starter `services.yaml`, then exit                                                                                                                                              |
-| `-emit-gatus`  | off       | print a [Gatus endpoints config](recipes/gatus.md) derived from the services, then exit                                                                                                           |
-| `-emit-icons`  | off       | print a shell script that downloads your icon slugs for [self-hosting](recipes/icons.md#going-fully-self-hosted), then exit                                                                       |
-| `-check`       | off       | validate the config directory, print warnings (missing translations, orphan or heavy media, references that resolve nowhere, ids that collide, keys that do nothing, CDN icons), then exit 0 or 1 |
-| `-version`     | off       | print the version, then exit                                                                                                                                                                      |
+| Flag           | Default   | Role                                                                                                                                                                                                                                                                                                 |
+| -------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-addr`        | `:8080`   | listen address                                                                                                                                                                                                                                                                                       |
+| `-config`      | `/config` | config directory                                                                                                                                                                                                                                                                                     |
+| `-assets`      | `/assets` | directory served at `/assets/`, if it exists                                                                                                                                                                                                                                                         |
+| `-base-path`   | none      | serve under a [sub-path](deployment/reverse-proxies.md#under-a-sub-path) of the domain, e.g. `/cairn`                                                                                                                                                                                                |
+| `-healthcheck` | off       | probe `127.0.0.1:{port}/healthz`, exit 0/1, for `FROM scratch` healthchecks                                                                                                                                                                                                                          |
+| `-init`        | off       | print a commented starter `services.yaml`, then exit                                                                                                                                                                                                                                                 |
+| `-emit-gatus`  | off       | print a [Gatus endpoints config](recipes/gatus.md) derived from the services, then exit                                                                                                                                                                                                              |
+| `-emit-icons`  | off       | print a shell script that downloads your icon slugs for [self-hosting](recipes/icons.md#going-fully-self-hosted), then exit                                                                                                                                                                          |
+| `-check`       | off       | validate the config directory, print warnings (partial translations, `strings` or `locales` covering part of the site, orphan or heavy media, references that resolve nowhere or name no file, icon sizes the file contradicts, ids that collide, keys that do nothing, CDN icons), then exit 0 or 1 |
+| `-version`     | off       | print the version, then exit                                                                                                                                                                                                                                                                         |
 
 With `-base-path`, every path above moves under the prefix (`/cairn/en/`,
 `/cairn/static/…`) and cairn strips it back off itself, so the proxy in front
 needs no rewriting. `/healthz` is the one exception: it answers at the root
 too, alongside `/readyz`, because an orchestrator reaches cairn directly.
+
+The `-check` warnings that open a file, a reference under `/assets/` and an
+icon's declared size, are skipped entirely when the `-assets` directory does
+not exist. That directory is there in the container and on nobody's laptop, so
+checking anyway would print a page of wrong warnings and teach you to skim the
+output. Mount it, as [Air-gapped](deployment/airgap.md#2-the-check-that-says-whether-you-are-actually-ready)
+does, and they come back.
 
 ## The display font
 

--- a/justfile
+++ b/justfile
@@ -68,33 +68,47 @@ shots: demo-rebuild
     @npx --yes playwright install --only-shell chromium
     @node scripts/screenshots.mjs
 
-# drive the search in a real browser: the one behaviour the Go tests cannot see
-test-search:
+# drive search and the accessibility behaviours in a real browser: what the Go
+# tests cannot see, since they assert the markup that ships and not what
+# happens once someone types, clicks or scrolls
+test-browser:
     #!/usr/bin/env bash
     # One shell for the whole recipe, and a trap. just runs each line of an
     # ordinary recipe in a shell of its own, so the pid was written on one line
-    # and killed on another: aborting in between left cairn bound to 8099 for
+    # and killed on another: aborting in between left cairn bound to 8090 for
     # good. The leak was the smaller half. On the next run the leftover
     # answered the readiness loop instantly, and the browser then drove the
-    # build from before the change under test, green.
+    # build from before the change under test, green. Two instances now, so
+    # both halves of that apply twice: a stale server on either port is enough
+    # to make the whole run measure yesterday's build.
     set -euo pipefail
-    if curl -fsS -o /dev/null http://127.0.0.1:8099/healthz 2>/dev/null; then
-        echo "test-search: something already answers on 127.0.0.1:8099, probably a" >&2
-        echo "leaked cairn. Kill it, or this run measures that one instead." >&2
-        exit 1
-    fi
+    for port in 8090 8091; do
+        if curl -fsS -o /dev/null "http://127.0.0.1:$port/healthz" 2>/dev/null; then
+            echo "test-browser: something already answers on 127.0.0.1:$port, probably" >&2
+            echo "a leaked cairn. Kill it, or this run measures that one instead." >&2
+            exit 1
+        fi
+    done
     npm --silent install --no-save --no-package-lock playwright
     npx --yes playwright install --only-shell chromium
-    go build -o /tmp/cairn-search ./src/cmd/cairn
-    /tmp/cairn-search -config example -addr 127.0.0.1:8099 &
-    pid=$!
-    trap 'kill "$pid" 2>/dev/null || true' EXIT INT TERM
-    for _ in $(seq 1 20); do
-        if curl -fsS -o /dev/null http://127.0.0.1:8099/healthz 2>/dev/null; then ready=1; break; fi
-        sleep 1
+    go build -o /tmp/cairn-browser ./src/cmd/cairn
+    # 8090 is the example config; 8091 is the fixture with more than seven
+    # categories and a header burger, neither of which example/ has.
+    /tmp/cairn-browser -config example -addr 127.0.0.1:8090 &
+    pids=$!
+    /tmp/cairn-browser -config scripts/fixtures/many-categories -addr 127.0.0.1:8091 &
+    pids="$pids $!"
+    trap 'kill $pids 2>/dev/null || true' EXIT INT TERM
+    for port in 8090 8091; do
+        ready=
+        for _ in $(seq 1 20); do
+            if curl -fsS -o /dev/null "http://127.0.0.1:$port/healthz" 2>/dev/null; then ready=1; break; fi
+            sleep 1
+        done
+        [ -n "$ready" ] || { echo "test-browser: cairn never came up on $port" >&2; exit 1; }
     done
-    [ -n "${ready:-}" ] || { echo "test-search: cairn never came up on 8099" >&2; exit 1; }
-    node scripts/search.mjs http://127.0.0.1:8099/en/
+    node scripts/search.mjs http://127.0.0.1:8090/en/
+    node scripts/a11y.mjs http://127.0.0.1:8090/en/ http://127.0.0.1:8091/en/
 
 # regenerate every icon from the one drawing in the script; checks the
 # maskable safe zone the manifest promises Android

--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -1,0 +1,225 @@
+// Drives four accessibility behaviours in a real browser against a running
+// cairn, because not one of them survives a look at the markup: the theme
+// toggle's state is only known once theme.js has run, the mobile category
+// swap turns on whether JavaScript exists at all, a contrast ratio needs the
+// colours the browser actually resolved, and a scroll is a scroll.
+//
+// Run it with `just test-browser`, which builds cairn and serves the example
+// config and scripts/fixtures/many-categories on scratch ports first.
+//
+// Usage: node scripts/a11y.mjs [example-url] [many-categories-url]
+import { chromium } from 'playwright';
+
+const SITE = process.argv[2] ?? process.env.CAIRN_URL ?? 'http://127.0.0.1:8090/en/';
+const MANY = process.argv[3] ?? process.env.CAIRN_MANY_URL ?? 'http://127.0.0.1:8091/en/';
+const PHONE = { width: 390, height: 780 };
+
+let failures = 0;
+const check = async (what, fn) => {
+  try {
+    await fn();
+    console.log(`  ok    ${what}`);
+  } catch (e) {
+    failures++;
+    console.log(`  FAIL  ${what}\n        ${e.message}`);
+  }
+};
+const eq = (got, want, label) => {
+  const [g, w] = [JSON.stringify(got), JSON.stringify(want)];
+  if (g !== w) throw new Error(`${label}: got ${g}, want ${w}`);
+};
+// Painted, not merely marked. Everything below turns on a display rule, and a
+// display rule is invisible to any test that asks the DOM what it contains:
+// the element is there either way. getClientRects asks what the layout did.
+const painted = (page, sel) =>
+  page.$$eval(sel, els =>
+    els.filter(e => e.getClientRects().length > 0).map(e => e.textContent.trim()),
+  );
+
+const browser = await chromium.launch();
+
+// ---- A1: the theme toggle has to say whether it is pressed (WCAG 4.1.2) ----
+
+const desk = await browser.newContext();
+const page = await desk.newPage();
+await page.goto(SITE);
+const toggle = page.locator('#theme-toggle');
+
+await check('the theme toggle states whether it is pressed', async () => {
+  const [pressed, dark] = await page.evaluate(() => [
+    document.getElementById('theme-toggle').getAttribute('aria-pressed'),
+    document.documentElement.dataset.theme
+      ? document.documentElement.dataset.theme === 'dark'
+      : matchMedia('(prefers-color-scheme: dark)').matches,
+  ]);
+  if (pressed === null) throw new Error('no aria-pressed at all: a screen reader hears a button and no state');
+  eq(pressed, String(dark), 'aria-pressed against the theme actually in force');
+});
+
+await check('and it flips with the theme, in both directions', async () => {
+  const seen = [];
+  for (const _ of [0, 1]) {
+    await toggle.click();
+    const theme = await page.evaluate(() => document.documentElement.dataset.theme);
+    seen.push(theme);
+    eq(await toggle.getAttribute('aria-pressed'), String(theme === 'dark'), `with data-theme=${theme}, aria-pressed`);
+  }
+  if (seen[0] === seen[1]) throw new Error(`two clicks both landed on ${seen[0]}, so only one direction was tested`);
+});
+
+// ---- A3: 3:1 for the boundary of a control someone can operate (1.4.11) ----
+
+// The border and both of its neighbours, straight out of the browser: the
+// inside is the control's own fill, the outside is the nearest ancestor that
+// actually paints one, since the header paints nothing on a wide viewport and
+// the colour behind the box is really the body's.
+const boundary = (p, sel) =>
+  p.$eval(sel, el => {
+    const chan = s => {
+      // Plain colours serialize as rgb()/rgba(). A color-mix() comes back as
+      // oklab(), whose three numbers are not sRGB channels at all, and reading
+      // them as channels reports near-black for every mix without complaining.
+      if (!s.startsWith('rgb')) throw new Error(`cannot read ${s} as sRGB channels`);
+      return s.match(/[\d.]+/g).slice(0, 3).map(Number);
+    };
+    const lum = s =>
+      chan(s)
+        .map(v => (v / 255 <= 0.03928 ? v / 255 / 12.92 : ((v / 255 + 0.055) / 1.055) ** 2.4))
+        .reduce((acc, c, i) => acc + [0.2126, 0.7152, 0.0722][i] * c, 0);
+    const wcag = (a, b) => {
+      const [hi, lo] = [lum(a), lum(b)].sort((x, y) => y - x);
+      return (hi + 0.05) / (lo + 0.05);
+    };
+    const opaque = s => !/,\s*0\)$/.test(s) && s !== 'transparent';
+    let outside = getComputedStyle(document.documentElement).backgroundColor;
+    for (let e = el.parentElement; e; e = e.parentElement) {
+      const bg = getComputedStyle(e).backgroundColor;
+      if (opaque(bg)) { outside = bg; break; }
+    }
+    const s = getComputedStyle(el);
+    return {
+      border: s.borderTopColor,
+      inside: s.backgroundColor,
+      vsInside: wcag(s.borderTopColor, s.backgroundColor),
+      vsOutside: wcag(s.borderTopColor, outside),
+    };
+  });
+
+const atLeast3 = (m, what) => {
+  for (const [where, r] of [['the page behind it', m.vsOutside], ['its own fill', m.vsInside]]) {
+    if (r < 3) {
+      throw new Error(`${what} border ${m.border} against ${where}: ${r.toFixed(2)}:1, WCAG 1.4.11 asks 3:1`);
+    }
+  }
+};
+
+// A page of its own, not the one A1 just toggled twice: the box transitions
+// its border-color over .15s, so measuring it right after a theme flip catches
+// a colour that is on neither palette and reports whatever the fade was
+// passing through.
+const home = await desk.newPage();
+await home.goto(SITE);
+
+await check('the live search box clears 3:1 against both of its neighbours', async () => {
+  atLeast3(await boundary(home, '#search .search-box'), 'the search box');
+});
+
+// The rule is scoped rather than global on purpose: 1.4.11 exempts an inactive
+// component, and the bar renders disabled and decorative on every page but the
+// home page, purely for layout parity. So there is no ratio to assert for the
+// sleeping one, only that it was left alone.
+const detail = await desk.newPage();
+await detail.goto(new URL('pdf/', SITE).href);
+await check('a disabled search box is left on the quiet border, being exempt', async () => {
+  const live = (await boundary(home, '#search .search-box')).border;
+  const dead = (await boundary(detail, '.search .search-box')).border;
+  if (dead === live) {
+    throw new Error(`the disabled bar wears the live border ${live}: the strong colour is not scoped to an enabled input`);
+  }
+});
+
+// ---- A2 and A4, both of which only exist at phone width ----
+
+const phone = await browser.newContext({ viewport: PHONE });
+const m = await phone.newPage();
+await m.goto(MANY);
+
+await check('the mobile jump-to select clears 3:1 too', async () => {
+  atLeast3(await boundary(m, '.toc-select'), 'the jump-to select');
+});
+
+await check('a phone with JavaScript shows the jump-to select, not the chips', async () => {
+  eq((await painted(m, '.toc-select')).length, 1, 'painted jump selects');
+  eq((await painted(m, '.toc.many a')).length, 0, 'painted trail chips');
+});
+
+// The regression: the swap to a select is gated on JavaScript because nav.js
+// is the select's entire behaviour. Ungated, a phone with scripting off got no
+// category navigation at all, on the viewport where a nine-category list is
+// least scrollable.
+const dumb = await browser.newContext({ viewport: PHONE, javaScriptEnabled: false });
+const nojs = await dumb.newPage();
+await nojs.goto(MANY);
+
+await check('a phone without JavaScript still paints category navigation', async () => {
+  const chips = await painted(nojs, '.toc.many a');
+  if (chips.length === 0) {
+    const inert = (await painted(nojs, '.toc-select')).length;
+    throw new Error(`no category link is painted, and ${inert} jump select(s) are, which nothing can drive`);
+  }
+});
+
+// A4: a scroll dismisses the open menu, unless the keyboard is inside it.
+const nav = m.locator('details.nav');
+const openMenu = async () => {
+  await m.evaluate(() => {
+    scrollTo({ top: 0, behavior: 'instant' });
+    document.querySelector('details.nav').open = false;
+  });
+  await m.locator('.nav-burger').click();
+  eq(await nav.evaluate(el => el.open), true, 'the menu opened');
+  // The dropdown fades in over .16s from visibility:hidden, and focus() on a
+  // hidden element is a no-op that leaves focus on the burger, which is the
+  // other case entirely and would pass for the wrong reason.
+  await m.locator('.nav-links .menu-link').first().waitFor({ state: 'visible' });
+};
+// behavior:'instant' because the stylesheet sets scroll-behavior:smooth, so a
+// plain scrollBy animates and scrollY has barely moved a frame later. And a
+// page that did not move fires no scroll at all, which would let every check
+// below pass without testing anything: hence the assertion that it did.
+const scrollDown = async () => {
+  const moved = await m.evaluate(async () => {
+    const before = scrollY;
+    scrollTo({ top: before + 400, behavior: 'instant' });
+    // nav.js batches its work into a requestAnimationFrame, so the assertion
+    // has to wait for the frame the scroll event scheduled.
+    await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
+    return scrollY !== before;
+  });
+  if (!moved) throw new Error('the page never scrolled, so nothing was under test');
+};
+
+await check('scrolling with focus inside the menu keeps it open, and keeps the focus', async () => {
+  await openMenu();
+  const link = m.locator('.nav-links .menu-link').first();
+  const label = (await link.textContent()).trim();
+  await link.focus();
+  await scrollDown();
+  eq(await nav.evaluate(el => el.open), true, 'the menu after a scroll');
+  const still = await m.evaluate(() => {
+    const a = document.activeElement;
+    return a && a.closest('.nav-links') ? a.textContent.trim() : `<${(a && a.tagName || '?').toLowerCase()}>`;
+  });
+  eq(still, label, 'what holds focus after the scroll');
+});
+
+await check('and a scroll with focus on the burger itself still dismisses it', async () => {
+  await openMenu();
+  await m.locator('.nav-burger').focus();
+  await scrollDown();
+  eq(await nav.evaluate(el => el.open), false, 'the menu after a scroll');
+});
+
+await browser.close();
+console.log(failures ? `\n${failures} failed` : '\nall passed');
+process.exit(failures ? 1 : 0);

--- a/scripts/fixtures/many-categories/services.yaml
+++ b/scripts/fixtures/many-categories/services.yaml
@@ -1,0 +1,12 @@
+# Nine categories, one service each, no icons and no status: the category count
+# is the only thing under test, and everything else would just be one more
+# reason for this file to need editing.
+- { id: one, url: https://one.example.org, name: One, category: alpha }
+- { id: two, url: https://two.example.org, name: Two, category: bravo }
+- { id: three, url: https://three.example.org, name: Three, category: charlie }
+- { id: four, url: https://four.example.org, name: Four, category: delta }
+- { id: five, url: https://five.example.org, name: Five, category: echo }
+- { id: six, url: https://six.example.org, name: Six, category: foxtrot }
+- { id: seven, url: https://seven.example.org, name: Seven, category: golf }
+- { id: eight, url: https://eight.example.org, name: Eight, category: hotel }
+- { id: nine, url: https://nine.example.org, name: Nine, category: india }

--- a/scripts/fixtures/many-categories/site.yaml
+++ b/scripts/fixtures/many-categories/site.yaml
@@ -1,0 +1,11 @@
+# A fixture, not an example: the two shapes example/ cannot make, and both of
+# them only appear on a phone. Nine categories is above the seven at which the
+# mobile trail folds into a jump-to select, and header links are what put a
+# burger in the menu bar. scripts/a11y.mjs needs to watch each of them.
+title: Many categories
+locales: [en]
+links:
+  - label: First link
+    url: https://first.example.org
+  - label: Second link
+    url: https://second.example.org

--- a/scripts/search.mjs
+++ b/scripts/search.mjs
@@ -2,13 +2,13 @@
 // search.js is the one piece of behaviour the Go tests cannot reach: they
 // assert the markup that ships, not what happens once someone types into it.
 //
-// Run it with `just test-search`, which builds cairn and serves the example
+// Run it with `just test-browser`, which builds cairn and serves the example
 // config on a scratch port first.
 //
 // Usage: node scripts/search.mjs [url]
 import { chromium } from 'playwright';
 
-const URL = process.argv[2] ?? process.env.CAIRN_URL ?? 'http://127.0.0.1:8099/en/';
+const URL = process.argv[2] ?? process.env.CAIRN_URL ?? 'http://127.0.0.1:8090/en/';
 
 const browser = await chromium.launch();
 const page = await browser.newPage();

--- a/src/internal/check/check.go
+++ b/src/internal/check/check.go
@@ -4,6 +4,10 @@ package check
 
 import (
 	"fmt"
+	"image"
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -36,6 +40,8 @@ func RunCheck(dir string) int {
 func checkWarnings(cfg *config.Config, dir string) []string {
 	var out []string
 	out = append(out, missingTranslations(cfg)...)
+	out = append(out, partialStringOverrides(cfg)...)
+	out = append(out, unsupportedLocales(cfg)...)
 	out = append(out, mediaWarnings(cfg, filepath.Join(dir, "media"))...)
 	// The canonical, og:url and hreflang links are all built from site.url, so
 	// without it they are simply absent. Nothing fails, the page looks right,
@@ -47,7 +53,12 @@ func checkWarnings(cfg *config.Config, dir string) []string {
 	// og:image needs a url and a raster logo, both. With a url but no usable
 	// logo, every link to the site previews as bare text on Mastodon, Slack or
 	// anywhere else, and the page itself gives no hint of it.
-	if cfg.Site.URL != "" && !cfg.Noindex() && !render.IsRaster(cfg.Site.Logo) {
+	//
+	// index: false does not silence this the way it silences the canonical
+	// links above. og:image feeds chat unfurls, not crawlers, and a portal
+	// kept out of search results is precisely the one that gets pasted into a
+	// team channel, where a preview is all anyone sees before clicking.
+	if cfg.Site.URL != "" && !render.IsRaster(cfg.Site.Logo) {
 		if cfg.Site.Logo == "" {
 			out = append(out, "site.yaml has no logo: links to the site preview with no image (og:image wants a png, jpg, webp or gif)")
 		} else {
@@ -55,6 +66,8 @@ func checkWarnings(cfg *config.Config, dir string) []string {
 		}
 	}
 	out = append(out, unresolvableRefs(cfg)...)
+	out = append(out, missingAssets(cfg)...)
+	out = append(out, iconSizeClaims(cfg)...)
 	out = append(out, categoryConfusion(cfg)...)
 	out = append(out, inertSettings(cfg)...)
 	if slugs := config.CdnSlugs(cfg); len(slugs) > 0 {
@@ -63,26 +76,47 @@ func checkWarnings(cfg *config.Config, dir string) []string {
 	return out
 }
 
+// missingLocales lists the enabled locales a translated field says nothing
+// for. Two shapes come back empty on purpose: a plain string, which covers
+// every locale at once, and an unset field, which is absent rather than
+// half-translated and has a documented fallback of its own.
+func missingLocales(cfg *config.Config, l config.LString) []string {
+	if len(l) == 0 || l[""] != "" {
+		return nil
+	}
+	var missing []string
+	for _, loc := range cfg.Site.Locales {
+		if l[loc] == "" {
+			missing = append(missing, loc)
+		}
+	}
+	return missing
+}
+
 // missingTranslations lists every translatable field that covers some of
 // the enabled locales but not all of them. A plain string covers them all.
 func missingTranslations(cfg *config.Config) []string {
 	var out []string
 	warn := func(where string, l config.LString) {
-		if len(l) == 0 || l[""] != "" {
-			return
-		}
-		var missing []string
-		for _, loc := range cfg.Site.Locales {
-			if l[loc] == "" {
-				missing = append(missing, loc)
-			}
-		}
-		if len(missing) > 0 {
+		if missing := missingLocales(cfg, l); len(missing) > 0 {
 			out = append(out, fmt.Sprintf("%s has no %s", where, strings.Join(missing, ", ")))
 		}
 	}
+	// The title is the <title>, so a half-translated one puts the other
+	// language in the browser tab, in the bookmark and in every og:title,
+	// which are the three places nobody proofreads.
+	warn("site title", cfg.Site.Title)
 	warn("site tagline", cfg.Site.Tagline)
 	warn("site about", cfg.Site.About)
+	// Link labels are the operator's own words in the header and the footer,
+	// on every page of the site rather than one. The url identifies the entry
+	// because it is the only field guaranteed to be there and readable.
+	for _, l := range cfg.Site.Links {
+		warn(fmt.Sprintf("links entry %q label", l.URL), l.Label)
+	}
+	for _, l := range cfg.Site.Footer {
+		warn(fmt.Sprintf("footer entry %q label", l.URL), l.Label)
+	}
 	for _, p := range cfg.Site.Pages {
 		warn(fmt.Sprintf("page %q title", p.ID), p.Title)
 		warn(fmt.Sprintf("page %q body", p.ID), p.Body)
@@ -92,6 +126,12 @@ func missingTranslations(cfg *config.Config) []string {
 		}
 	}
 	for _, c := range cfg.Categories {
+		// A category with no name at all is not a missing translation: the id
+		// becomes the heading in every locale, which is documented and often
+		// what the operator wants. Only a name that answers for some locales
+		// and not others is a gap, and missingLocales already stays quiet
+		// about the unset field.
+		warn(fmt.Sprintf("category %q name", c.ID), c.Name)
 		for _, s := range c.Services {
 			warn(fmt.Sprintf("service %q name", s.ID), s.Name)
 			warn(fmt.Sprintf("service %q desc", s.ID), s.Desc)
@@ -104,44 +144,119 @@ func missingTranslations(cfg *config.Config) []string {
 	return out
 }
 
+// partialStringOverrides finds a strings: entry that answers for some of the
+// site's locales and not the rest.
+//
+// Str resolves the override per locale and falls through to the built-in
+// table on a miss, so {nav.menu: {fr: Sommaire}} on a [fr, en] site gives the
+// French pages the operator's word and the English pages cairn's. It is the
+// one case where someone explicitly asked for different wording and got it on
+// half their site, and nothing on either page shows which half.
+func partialStringOverrides(cfg *config.Config) []string {
+	known := map[string]bool{}
+	for _, k := range config.StringKeys() {
+		known[k] = true
+	}
+	keys := make([]string, 0, len(cfg.Site.Strings))
+	for k := range cfg.Site.Strings {
+		// A key cairn does not use is already reported by inertSettings as
+		// doing nothing at all. Which locales it covers is beside the point
+		// then, and two warnings over one line is how a check gets skimmed.
+		if known[k] {
+			keys = append(keys, k)
+		}
+	}
+	// Map iteration is random, and output that reorders between runs cannot
+	// be diffed by the pipeline an operator wires -check into.
+	sort.Strings(keys)
+
+	var out []string
+	for _, k := range keys {
+		if missing := missingLocales(cfg, cfg.Site.Strings[k]); len(missing) > 0 {
+			out = append(out, fmt.Sprintf("strings key %q has no %s: those locales keep cairn's own wording while the rest use yours (name every locale, or write one plain string to cover them all)",
+				k, strings.Join(missing, ", ")))
+		}
+	}
+	return out
+}
+
+// unsupportedLocales names an enabled locale cairn has no interface for.
+//
+// Nothing refuses it and nothing reports it: the pages build, they carry the
+// right lang attribute, and every word cairn contributes (the navigation, the
+// buttons, the search messages) comes out English. The remedy is a strings:
+// block, so the message says so rather than leaving the operator to guess
+// that their only option is dropping the language.
+func unsupportedLocales(cfg *config.Config) []string {
+	builtin := map[string]bool{}
+	for _, l := range config.BuiltinLocales() {
+		builtin[l] = true
+	}
+	var out []string
+	for _, loc := range cfg.Site.Locales {
+		// Str looks the base language up after the full tag, so pt-BR finds
+		// the pt table and is dressed in Portuguese. Testing the full tag
+		// alone would warn about every regional variant of a language that
+		// does ship, which is the opposite of helpful.
+		base, _, _ := strings.Cut(loc, "-")
+		if builtin[strings.ToLower(base)] {
+			continue
+		}
+		out = append(out, fmt.Sprintf("locale %q has no built-in interface: its pages carry that lang and an English menu, buttons and search messages (cairn ships %s; a strings: block supplies the rest)",
+			loc, strings.Join(config.BuiltinLocales(), ", ")))
+	}
+	return out
+}
+
 var mdImgRefRe = regexp.MustCompile(`!\[[^\]]*\]\(([^)\s]+)\)`)
 
-// mediaWarnings flags files nothing references and files heavy enough to
-// hurt the visitors of the pages that show them.
+// mediaWarnings flags files nothing references, references naming no file,
+// and files heavy enough to hurt the visitors of the pages that show them.
 func mediaWarnings(cfg *config.Config, mediaDir string) []string {
-	used := map[string]bool{}
+	// Keyed by the file in media/, valued by where the reference was written,
+	// so the missing-file warning below can name the page to go and fix.
+	used := map[string]string{}
 	// A file in media/ can be written two ways, and both are documented: the
 	// bare name, and the /media/… path it is served at. Recording only the
 	// first made -check announce a file as unreferenced while it sat on the
 	// page, which is worse than saying nothing: it invites deleting it.
-	markUsed := func(src string) {
-		if rel, ok := strings.CutPrefix(src, "/media/"); ok {
-			used[rel] = true
-			return
+	markUsed := func(src, where string) {
+		rel, ok := strings.CutPrefix(src, "/media/")
+		if !ok {
+			// A URL and a data: image are somebody else's to resolve, and
+			// neither is a file this directory could be missing.
+			if config.IsURLOrAbs(src) || uriRe.MatchString(src) {
+				return
+			}
+			rel = src
 		}
-		if !config.IsURLOrAbs(src) {
-			used[src] = true
+		if _, seen := used[rel]; !seen {
+			used[rel] = where
 		}
 	}
-	texts := []config.LString{cfg.Site.About}
+	type text struct {
+		where string
+		body  config.LString
+	}
+	texts := []text{{"site about", cfg.Site.About}}
 	for _, p := range cfg.Site.Pages {
-		texts = append(texts, p.Body)
-		for _, s := range p.Sections {
-			texts = append(texts, s.Body)
+		texts = append(texts, text{fmt.Sprintf("page %q body", p.ID), p.Body})
+		for i, s := range p.Sections {
+			texts = append(texts, text{fmt.Sprintf("page %q section %d", p.ID, i+1), s.Body})
 		}
 	}
 	for _, c := range cfg.Categories {
 		for _, s := range c.Services {
-			texts = append(texts, s.Details)
+			texts = append(texts, text{fmt.Sprintf("service %q details", s.ID), s.Details})
 			for _, img := range s.Images {
-				markUsed(img.Src)
+				markUsed(img.Src, fmt.Sprintf("service %q images", s.ID))
 			}
 		}
 	}
-	for _, l := range texts {
-		for _, text := range l {
-			for _, m := range mdImgRefRe.FindAllStringSubmatch(text, -1) {
-				markUsed(m[1])
+	for _, t := range texts {
+		for _, body := range t.body {
+			for _, m := range mdImgRefRe.FindAllStringSubmatch(body, -1) {
+				markUsed(m[1], t.where)
 			}
 		}
 	}
@@ -156,7 +271,7 @@ func mediaWarnings(cfg *config.Config, mediaDir string) []string {
 			return nil
 		}
 		rel = filepath.ToSlash(rel)
-		if !used[rel] {
+		if _, ok := used[rel]; !ok {
 			out = append(out, fmt.Sprintf("media/%s is not referenced by any service or page", rel))
 		}
 		if info, ierr := d.Info(); ierr == nil && info.Size() > 1<<20 {
@@ -164,6 +279,39 @@ func mediaWarnings(cfg *config.Config, mediaDir string) []string {
 		}
 		return nil
 	})
+	out = append(out, danglingRefs(used, mediaDir)...)
+	return out
+}
+
+// danglingRefs is the walk above run backwards: a reference that names no
+// file, rather than a file nothing names.
+//
+// Load opens every images: entry and refuses to boot on a missing one, so an
+// image written in markdown was the only way left to ship a 404. It reads
+// exactly like the images: form in the documentation, it sits in about text,
+// page bodies and service details, and nothing ever opened it.
+func danglingRefs(used map[string]string, mediaDir string) []string {
+	refs := make([]string, 0, len(used))
+	for rel := range used {
+		refs = append(refs, rel)
+	}
+	// Map iteration is random, and output that reorders between runs cannot be
+	// diffed by the pipeline an operator wires -check into.
+	sort.Strings(refs)
+
+	var out []string
+	for _, rel := range refs {
+		// A browser normalises the .. away before it ever asks, so a stat of
+		// what sits above media/ answers a question nobody posed.
+		if rel == "" || strings.Contains(rel, "..") {
+			continue
+		}
+		p := filepath.Join(mediaDir, filepath.FromSlash(rel))
+		if st, err := os.Stat(p); err == nil && !st.IsDir() {
+			continue
+		}
+		out = append(out, fmt.Sprintf("%s shows %q, which is not there: the page renders a broken image (expected a file at %s)", used[rel], rel, p))
+	}
 	return out
 }
 
@@ -193,6 +341,156 @@ func unresolvableRefs(cfg *config.Config) []string {
 				out = append(out, fmt.Sprintf("site.yaml %s url %q resolves nowhere: a link needs a scheme (https://…, mailto:…) or an absolute path", set.where, l.URL))
 			}
 		}
+	}
+	return out
+}
+
+// assetMount is the URL prefix the -assets directory is served at. A
+// reference under it names a file the operator dropped there; a URL, a bare
+// name and any other route are somebody else's to resolve.
+const assetMount = "/assets/"
+
+// assetsMounted reports whether the -assets directory is there to look in.
+//
+// -check on a laptop keeps the default /assets, which exists in the container
+// and on nobody's machine, so every reference under it would come back
+// missing at once. A page of warnings that are all wrong buries the one that
+// is right and teaches the operator to stop reading the output, so with no
+// directory to consult the checks below say nothing at all.
+func assetsMounted() bool {
+	st, err := os.Stat(config.AssetsPath)
+	return err == nil && st.IsDir()
+}
+
+// assetPath maps an /assets/… reference to the file it names, and returns ""
+// for anything that is not one. It refuses to climb out of the mount, the
+// same rule the file server and the manifest measurement both apply: a stat
+// of something outside the directory could only ever answer the wrong
+// question, since a browser normalises the ".." away before it ever asks.
+func assetPath(ref string) string {
+	rel, ok := strings.CutPrefix(ref, assetMount)
+	if !ok || rel == "" || strings.Contains(rel, "..") {
+		return ""
+	}
+	return filepath.Join(config.AssetsPath, filepath.FromSlash(rel))
+}
+
+// missingAssets checks that every /assets/… reference reaches a file.
+//
+// Load already stats each media/ image, so a mistyped screenshot refuses to
+// boot while a mistyped logo boots fine and paints a broken image on every
+// page. These stay warnings for the same reason unresolvableRefs does: the
+// damage is a missing picture, and refusing to boot over one would replace a
+// working site with the getting-started page.
+func missingAssets(cfg *config.Config) []string {
+	if !assetsMounted() {
+		return nil
+	}
+	// absent answers "this names a file in the mount and the file is not
+	// there", and hands back the path so the message can name it: an operator
+	// staring at a correct-looking /assets/logo.png needs to be told which
+	// directory cairn looked in, which is the -assets flag they forgot.
+	absent := func(ref string) (string, bool) {
+		p := assetPath(ref)
+		if p == "" {
+			return "", false
+		}
+		if st, err := os.Stat(p); err == nil && !st.IsDir() {
+			return "", false
+		}
+		return p, true
+	}
+	var out []string
+	if p, miss := absent(cfg.Site.Logo); miss {
+		out = append(out, fmt.Sprintf("site.yaml logo %q is not in the assets directory: the header paints a broken image and og:image sends every link preview to a 404 (expected a file at %s)", cfg.Site.Logo, p))
+	}
+	if p, miss := absent(cfg.Site.Favicon); miss {
+		out = append(out, fmt.Sprintf("site.yaml favicon %q is not in the assets directory: the browser tab falls back to a blank page icon (expected a file at %s)", cfg.Site.Favicon, p))
+	}
+	for i, ic := range cfg.Site.Icons {
+		if p, miss := absent(ic.Src); miss {
+			out = append(out, fmt.Sprintf("site.yaml icons entry %d src %q is not in the assets directory: the manifest offers a home-screen icon that 404s, so the phone invents one (expected a file at %s)", i+1, ic.Src, p))
+		}
+	}
+	for _, l := range cfg.Site.Links {
+		if p, miss := absent(l.Icon); miss {
+			out = append(out, fmt.Sprintf("site.yaml links entry %q icon %q is not in the assets directory: the link renders with a broken image beside its label (expected a file at %s)", l.URL, l.Icon, p))
+		}
+	}
+	// footer icons are deliberately not checked here. inertSettings already
+	// says the key is dropped and never rendered, so whether the file exists
+	// changes nothing a visitor sees, and a second warning about one line is
+	// exactly the noise that gets the first one ignored.
+	return out
+}
+
+// measure reads a raster's real size. DecodeConfig only understands the
+// formats something has registered, which is what the blank image/ imports at
+// the top of this file are for: dropping one would not fail the build, it
+// would quietly make every png unmeasurable and the check below silent.
+//
+// Anything it cannot decode comes back zero, which is the honest answer for
+// all three ways that happens: an svg has no intrinsic size, a remote file
+// would need an outbound request cairn does not make, and a file that is not
+// there is unknown rather than wrong. Callers skip a zero instead of
+// comparing against it.
+func measure(path string) (int, int) {
+	if path == "" {
+		return 0, 0
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, 0
+	}
+	defer func() { _ = f.Close() }()
+	c, _, err := image.DecodeConfig(f)
+	if err != nil {
+		return 0, 0
+	}
+	return c.Width, c.Height
+}
+
+// iconSizeClaims compares each icons entry with the file it points at.
+//
+// cairn cannot resize an image, so the operator states each size and the
+// manifest publishes it as fact. A wrong number is invisible everywhere: the
+// manifest validates, the file loads, and a phone simply picks the file for a
+// slot it does not fill, which is how a home-screen icon comes out blurred.
+// The measurement already exists for the favicon, and only this list went
+// unchecked.
+func iconSizeClaims(cfg *config.Config) []string {
+	if !assetsMounted() {
+		return nil
+	}
+	var out []string
+	for i, ic := range cfg.Site.Icons {
+		// "any" is a claim about a scalable file, not a measurement, so there
+		// is nothing to disagree with. Everything else that cannot be
+		// measured (an svg, a URL, a file that is not there) comes back zero
+		// from measure and is skipped on the next line; the missing file has
+		// its own warning already.
+		if strings.Contains(ic.Sizes, "any") {
+			continue
+		}
+		w, h := measure(assetPath(ic.Src))
+		if w == 0 || h == 0 {
+			continue
+		}
+		measured := fmt.Sprintf("%dx%d", w, h)
+		// One file may legitimately declare several sizes: an ico holds a 16
+		// and a 32, and DecodeConfig reports one of them. Any match is enough.
+		matches := false
+		for _, s := range strings.Fields(ic.Sizes) {
+			if s == measured {
+				matches = true
+				break
+			}
+		}
+		if matches {
+			continue
+		}
+		out = append(out, fmt.Sprintf("site.yaml icons entry %d declares sizes %q but %s measures %s: the manifest states the declared size as fact, so a phone picks this file for a slot it does not fill (correct sizes, or supply a file that size)",
+			i+1, ic.Sizes, ic.Src, measured))
 	}
 	return out
 }

--- a/src/internal/check/check_test.go
+++ b/src/internal/check/check_test.go
@@ -1,6 +1,9 @@
 package check
 
 import (
+	"bytes"
+	"image"
+	"image/png"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +12,51 @@ import (
 	"github.com/MorganKryze/cairn/src/internal/config"
 	"github.com/MorganKryze/cairn/src/internal/testutil"
 )
+
+// withAssets points config.AssetsPath at a directory of the test's own and
+// fills it, returning the path so a test can assert the warning names it.
+//
+// Every /assets check is skipped when the mount is absent, and the default
+// /assets exists in the container and on no developer's machine: a test that
+// left the global alone would assert one thing here and the opposite there.
+func withAssets(t *testing.T, files map[string][]byte) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, body := range files {
+		p := filepath.Join(dir, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, body, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	old := config.AssetsPath
+	config.AssetsPath = dir
+	t.Cleanup(func() { config.AssetsPath = old })
+	return dir
+}
+
+// withoutAssets points config.AssetsPath at a directory that is not there,
+// which is what -check on a laptop actually has.
+func withoutAssets(t *testing.T) {
+	t.Helper()
+	old := config.AssetsPath
+	config.AssetsPath = filepath.Join(t.TempDir(), "never-mounted")
+	t.Cleanup(func() { config.AssetsPath = old })
+}
+
+// pngOf encodes a blank raster of a given size. The icon check compares a
+// declared size against a measured one, so the file has to really be that
+// size or the test proves nothing.
+func pngOf(t *testing.T, w, h int) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, image.NewRGBA(image.Rect(0, 0, w, h))); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
 
 func TestCheckWarnings(t *testing.T) {
 	dir := testutil.WriteFiles(t, map[string]string{
@@ -42,6 +90,7 @@ func TestCheckWarnings(t *testing.T) {
 }
 
 func TestCheckMarkdownImageCountsAsUsed(t *testing.T) {
+	withAssets(t, map[string][]byte{"logo.png": pngOf(t, 512, 512)})
 	dir := testutil.WriteFiles(t, map[string]string{
 		"site.yaml":     "url: https://tools.example.org\nlogo: /assets/logo.png\nlocales: [en]\nabout: \"See ![plan](plan.png)\"\n",
 		"services.yaml": "- {id: a, url: https://a.example.org, name: A}\n",
@@ -58,6 +107,55 @@ func TestCheckMarkdownImageCountsAsUsed(t *testing.T) {
 	}
 	if w := checkWarnings(cfg, dir); len(w) != 0 {
 		t.Errorf("warnings = %v, want none", w)
+	}
+}
+
+// The mirror of the test above. Load opens every images: entry and refuses to
+// boot on a missing one, which left markdown as the one way to ship a picture
+// nothing serves: it reads exactly like the images: form in the docs, and no
+// check ever opened it.
+func TestCheckWarnsAboutAMarkdownImageThatIsNotThere(t *testing.T) {
+	withoutAssets(t)
+	dir := testutil.WriteFiles(t, map[string]string{
+		"site.yaml": "locales: [en]\nabout: \"See ![plan](plan.png)\"\n" +
+			"pages: [{id: legal, title: Legal, body: \"![seal](/media/seal.png)\"}]\n",
+		"services.yaml": "- {id: a, url: https://a.example.org, name: A, details: \"![shot](sub/shot.png)\"}\n",
+	})
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	warnings := strings.Join(checkWarnings(cfg, dir), "\n")
+
+	// Both spellings, and the message names where to go and fix it.
+	for _, want := range []string{
+		`site about shows "plan.png"`,
+		`page "legal" body shows "seal.png"`,
+		`service "a" details shows "sub/shot.png"`,
+	} {
+		if !strings.Contains(warnings, want) {
+			t.Errorf("warnings never mention %s:\n%s", want, warnings)
+		}
+	}
+}
+
+// The same check must stay silent about everything it cannot open, or it
+// reports a broken image for every remote screenshot on the site.
+func TestCheckStaysQuietAboutMarkdownImagesItCannotStat(t *testing.T) {
+	withoutAssets(t)
+	dir := testutil.WriteFiles(t, map[string]string{
+		"site.yaml": "locales: [en]\nabout: \"![a](https://cdn.example.org/a.png) " +
+			"![b](/assets/b.png) ![c](data:image/gif;base64,R0lGOD) ![d](../../etc/passwd)\"\n",
+		"services.yaml": "- {id: a, url: https://a.example.org, name: A}\n",
+	})
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, w := range checkWarnings(cfg, dir) {
+		if strings.Contains(w, "renders a broken image") {
+			t.Errorf("a reference cairn cannot stat was reported missing:\n%s", w)
+		}
 	}
 }
 
@@ -93,6 +191,9 @@ func TestWarningsNameWhatIsMissing(t *testing.T) {
 // A config with nothing missing says so and warns about nothing, which is what
 // makes the warnings worth reading when they do appear.
 func TestCompleteConfigWarnsAboutNothing(t *testing.T) {
+	// The logo really sits in the assets directory here, so this also pins
+	// that a reference which does resolve draws no warning.
+	withAssets(t, map[string][]byte{"logo.png": pngOf(t, 512, 512)})
 	dir := testutil.WriteFiles(t, map[string]string{
 		// url and a raster logo: without them the canonical links and the
 		// link-preview image are silently absent, and -check says so.
@@ -358,6 +459,280 @@ func TestCheckNamesSettingsThatDoNothing(t *testing.T) {
 				t.Errorf("no warning carrying %q:\n%s", c.want, w)
 			}
 		})
+	}
+}
+
+// og:image is what Slack, Mastodon and Signal paint when someone pastes the
+// link, and not one of them is a search engine. index: false answers the
+// crawler question and says nothing about the preview, and a portal kept out
+// of search results is exactly the one that travels by pasted link.
+func TestCheckWarnsAboutOGImageEvenWhenNoindex(t *testing.T) {
+	dir := testutil.WriteFiles(t, map[string]string{
+		"site.yaml":     "url: https://tools.example.org\nlocales: [en]\nindex: false\n",
+		"services.yaml": "- {id: a, url: https://a.example.org, name: A}\n",
+	})
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := strings.Join(checkWarnings(cfg, dir), "\n")
+	if !strings.Contains(w, "og:image") {
+		t.Errorf("a noindex site was left with no link preview and no warning:\n%s", w)
+	}
+	// The canonical family keeps its gate. Without this the test would pass
+	// just as well by removing the wrong one.
+	if strings.Contains(w, "canonical") {
+		t.Errorf("noindex no longer silences the canonical warning:\n%s", w)
+	}
+}
+
+// A logo, favicon, manifest icon or link icon under /assets is passed to the
+// browser as written and never confirmed. Load already refuses to boot over a
+// mistyped screenshot in media/, so the same typo one field over produces a
+// broken image on every page and not one word anywhere.
+func TestCheckWarnsAboutAssetsThatAreNotThere(t *testing.T) {
+	assets := withAssets(t, map[string][]byte{"logo.png": pngOf(t, 512, 512)})
+	dir := testutil.WriteFiles(t, map[string]string{
+		"site.yaml": "url: https://tools.example.org\nlocales: [en]\n" +
+			"logo: /assets/logo.png\nfavicon: /assets/favicon.png\n" +
+			"icons: [{src: /assets/icon-192.png, sizes: 192x192}, {src: /assets/logo.png, sizes: 512x512}]\n" +
+			"links: [{label: Wiki, url: https://wiki.example.org, icon: /assets/wiki.svg}]\n",
+		"services.yaml": "- {id: a, url: https://a.example.org, name: A}\n",
+	})
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	warnings := strings.Join(checkWarnings(cfg, dir), "\n")
+
+	for _, want := range []string{
+		`favicon "/assets/favicon.png" is not in the assets directory`,
+		`icons entry 1 src "/assets/icon-192.png" is not in the assets directory`,
+		`links entry "https://wiki.example.org" icon "/assets/wiki.svg" is not in the assets directory`,
+		// The message has to name the directory cairn looked in: the usual
+		// cause is a forgotten -assets, and the reference itself looks right.
+		filepath.Join(assets, "favicon.png"),
+	} {
+		if !strings.Contains(warnings, want) {
+			t.Errorf("warnings missing %q:\n%s", want, warnings)
+		}
+	}
+	// The two references that do resolve stay unmentioned.
+	if strings.Contains(warnings, `logo "/assets/logo.png" is not in`) ||
+		strings.Contains(warnings, `icons entry 2`) {
+		t.Errorf("a file that is really there was reported missing:\n%s", warnings)
+	}
+}
+
+// Everything that is not a file in the mount is somebody else's to resolve: a
+// remote URL would need a request cairn does not make, another route is not
+// this directory's business, and a bare name already has its own warning. A
+// check that flagged them would fire on every correct config there is.
+func TestCheckStaysQuietAboutRefsItCannotStat(t *testing.T) {
+	withAssets(t, map[string][]byte{"logo.png": pngOf(t, 512, 512)})
+	dir := testutil.WriteFiles(t, map[string]string{
+		"site.yaml": "url: https://tools.example.org\nlocales: [en]\n" +
+			"logo: https://cdn.example.org/logo.png\nfavicon: /static/favicon.ico\n" +
+			"icons: [{src: /assets/logo.png, sizes: 512x512}, {src: https://cdn.example.org/i.png, sizes: 192x192}]\n" +
+			"links: [{label: Wiki, url: https://wiki.example.org, icon: /media/wiki.png}]\n",
+		"services.yaml": "- {id: a, url: https://a.example.org, name: A}\n",
+	})
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if w := strings.Join(checkWarnings(cfg, dir), "\n"); strings.Contains(w, "assets directory") {
+		t.Errorf("a reference cairn cannot stat was reported missing:\n%s", w)
+	}
+}
+
+// The default -assets is /assets, which exists in the container and on nobody
+// else's machine. Statting it anyway would make -check on a laptop print a
+// warning for every asset the site has, all of them wrong, and a page of
+// false warnings is worse than the silence being fixed: it buries the real
+// ones and teaches the operator to skip the output.
+func TestCheckSaysNothingAboutAssetsWithNothingMounted(t *testing.T) {
+	withoutAssets(t)
+	dir := testutil.WriteFiles(t, map[string]string{
+		"site.yaml": "url: https://tools.example.org\nlocales: [en]\n" +
+			"logo: /assets/logo.png\nfavicon: /assets/favicon.png\n" +
+			"icons: [{src: /assets/i-192.png, sizes: 192x192}, {src: /assets/i-512.png, sizes: 512x512}]\n",
+		"services.yaml": "- {id: a, url: https://a.example.org, name: A}\n",
+	})
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if w := checkWarnings(cfg, dir); len(w) != 0 {
+		t.Errorf("with no assets directory to look in, -check invented warnings: %v", w)
+	}
+}
+
+// cairn cannot resize an image, so the operator states each icon's size and
+// the manifest publishes it as fact. A wrong number shows up nowhere: the
+// manifest validates, the file loads, and the phone simply picks it for a
+// slot it does not fill.
+func TestCheckMeasuresIconsAgainstTheirDeclaredSizes(t *testing.T) {
+	withAssets(t, map[string][]byte{
+		"small.png": pngOf(t, 180, 180),
+		"i-192.png": pngOf(t, 192, 192),
+		"i-512.png": pngOf(t, 512, 512),
+	})
+	dir := testutil.WriteFiles(t, map[string]string{
+		"site.yaml": "locales: [en]\nindex: false\n" +
+			"icons: [{src: /assets/small.png, sizes: 512x512}, " +
+			"{src: /assets/i-192.png, sizes: 192x192}, {src: /assets/i-512.png, sizes: 512x512}]\n",
+		"services.yaml": "- {id: a, url: https://a.example.org, name: A}\n",
+	})
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	warnings := strings.Join(checkWarnings(cfg, dir), "\n")
+	if !strings.Contains(warnings, `icons entry 1 declares sizes "512x512" but /assets/small.png measures 180x180`) {
+		t.Errorf("an icon that is not the size it claims went unmentioned:\n%s", warnings)
+	}
+	// The two honest entries are not mentioned, or the warning would fire on
+	// every icons list ever written.
+	for _, quiet := range []string{"entry 2 declares", "entry 3 declares"} {
+		if strings.Contains(warnings, quiet) {
+			t.Errorf("an icon that is exactly its declared size was flagged:\n%s", warnings)
+		}
+	}
+}
+
+// Three shapes that are honest and must stay silent: "any" on a scalable
+// file, which is a claim and not a measurement; a multi-size entry where one
+// of the sizes is the file's, which is how an ico is written; and a file
+// nothing can decode, which is unknown rather than wrong.
+func TestCheckDoesNotSecondGuessIconsItCannotMeasure(t *testing.T) {
+	withAssets(t, map[string][]byte{
+		"mark.svg":  []byte(`<svg viewBox="0 0 9 9"/>`),
+		"multi.png": pngOf(t, 32, 32),
+		"i-192.png": pngOf(t, 192, 192),
+		"i-512.png": pngOf(t, 512, 512),
+	})
+	dir := testutil.WriteFiles(t, map[string]string{
+		"site.yaml": "locales: [en]\nindex: false\n" +
+			"icons: [{src: /assets/mark.svg, sizes: any}, {src: /assets/multi.png, sizes: 16x16 32x32}, " +
+			"{src: /assets/i-192.png, sizes: 192x192}, {src: /assets/i-512.png, sizes: 512x512}]\n",
+		"services.yaml": "- {id: a, url: https://a.example.org, name: A}\n",
+	})
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if w := strings.Join(checkWarnings(cfg, dir), "\n"); strings.Contains(w, "declares sizes") {
+		t.Errorf("an icon that cairn cannot contradict was flagged anyway:\n%s", w)
+	}
+}
+
+// Four fields that fill one language's page with another's words, including
+// the browser tab. The check covered the body text and missed the labels.
+func TestCheckNamesHalfTranslatedTitlesLabelsAndCategories(t *testing.T) {
+	dir := testutil.WriteFiles(t, map[string]string{
+		"site.yaml": "locales: [fr, en]\nindex: false\n" +
+			"title: {fr: Outils libres}\n" +
+			"links: [{label: {fr: Annuaire}, url: https://wiki.example.org}]\n" +
+			"footer: [{label: {fr: Statut}, url: https://status.example.org}]\n",
+		"categories.yaml": "- {id: docs, name: {fr: Documents}}\n",
+		"services.yaml": "- {id: a, url: https://a.example.org, name: A, category: docs}\n" +
+			"- {id: b, url: https://b.example.org, name: B}\n",
+	})
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	warnings := strings.Join(checkWarnings(cfg, dir), "\n")
+	for _, want := range []string{
+		"site title has no en",
+		`links entry "https://wiki.example.org" label has no en`,
+		`footer entry "https://status.example.org" label has no en`,
+		`category "docs" name has no en`,
+	} {
+		if !strings.Contains(warnings, want) {
+			t.Errorf("warnings missing %q:\n%s", want, warnings)
+		}
+	}
+	// Service b carries no category, so it lands in "other", which has no
+	// name at all. An absent name is derived from the id in every locale,
+	// which is documented behaviour and not a missing translation.
+	if strings.Contains(warnings, `category "other"`) {
+		t.Errorf("a category with no name was called half-translated:\n%s", warnings)
+	}
+}
+
+// Str resolves a strings: override per locale and falls through to the
+// built-in table on a miss, so an override that names some locales gives the
+// operator's wording to those pages and cairn's to the rest. It is the one
+// case where someone asked for different words and got them on half the site.
+func TestCheckWarnsAboutAStringsOverrideThatSkipsALocale(t *testing.T) {
+	dir := testutil.WriteFiles(t, map[string]string{
+		"site.yaml": "locales: [fr, en]\nindex: false\n" +
+			"strings: {nav.menu: {fr: Sommaire}, card.more: {fr: Lire la suite, en: Read on}, " +
+			"nav.tocs: {fr: Rubriques}}\n",
+		"services.yaml": "- {id: a, url: https://a.example.org, name: A}\n",
+	})
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	warnings := strings.Join(checkWarnings(cfg, dir), "\n")
+	if !strings.Contains(warnings, `strings key "nav.menu" has no en`) {
+		t.Errorf("a half-covered override went unmentioned:\n%s", warnings)
+	}
+	// An override that covers every locale is exactly right.
+	if strings.Contains(warnings, `"card.more" has no`) {
+		t.Errorf("a fully covered override was flagged:\n%s", warnings)
+	}
+	// nav.tocs is a typo for nav.toc. inertSettings already says the whole
+	// override does nothing, and which locales it covers is beside the point
+	// then: two warnings over one line is how a check gets skimmed.
+	if strings.Contains(warnings, `"nav.tocs" has no`) {
+		t.Errorf("a key that does nothing was also nagged about locales:\n%s", warnings)
+	}
+	if !strings.Contains(warnings, `strings key "nav.tocs" is not one cairn uses`) {
+		t.Errorf("the typo lost its own warning:\n%s", warnings)
+	}
+}
+
+// cairn dresses its interface in seven languages. Any other locale renders
+// with the right lang attribute and an entirely English menu, and nobody is
+// told: the pages build, they validate, and only a reader notices.
+func TestCheckWarnsAboutALocaleWithNoInterface(t *testing.T) {
+	dir := testutil.WriteFiles(t, map[string]string{
+		"site.yaml":     "locales: [en, pl]\nindex: false\n",
+		"services.yaml": "- {id: a, url: https://a.example.org, name: A}\n",
+	})
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	warnings := strings.Join(checkWarnings(cfg, dir), "\n")
+	for _, want := range []string{`locale "pl" has no built-in interface`, "strings:"} {
+		if !strings.Contains(warnings, want) {
+			t.Errorf("warnings missing %q:\n%s", want, warnings)
+		}
+	}
+	if strings.Contains(warnings, `locale "en"`) {
+		t.Errorf("a language cairn ships was reported as unsupported:\n%s", warnings)
+	}
+}
+
+// Str looks the base language up after the full tag, so pt-BR finds the pt
+// table and those pages are dressed in Portuguese. Warning about every
+// regional variant of a language cairn does ship is the opposite of helpful.
+func TestCheckAcceptsARegionalVariantOfABuiltinLocale(t *testing.T) {
+	dir := testutil.WriteFiles(t, map[string]string{
+		"site.yaml":     "locales: [pt-BR, fr-CA]\nindex: false\n",
+		"services.yaml": "- {id: a, url: https://a.example.org, name: A}\n",
+	})
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if w := strings.Join(checkWarnings(cfg, dir), "\n"); strings.Contains(w, "built-in interface") {
+		t.Errorf("a regional variant of a shipped language was flagged:\n%s", w)
 	}
 }
 

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -305,6 +305,27 @@ func IsURLOrAbs(s string) bool {
 	return isExternalURL(s) || IsLocalPath(s)
 }
 
+// mediaRef maps an images: entry to the file it names under media/, and
+// reports whether it names one at all.
+//
+// A file in media/ has two documented spellings, the bare name and the
+// /media/… path it is served at, and they have to mean the same thing here:
+// the bare one was stat'd and the absolute one was not, so the same missing
+// file refused to boot written one way and rendered a 404 written the other.
+//
+// Everything else stays out of it, because it is not this directory's to
+// serve: a URL, /assets/… from the mounted assets dir, any other absolute
+// path. Note that a value starting with "/media/" cannot be the
+// protocol-relative "//host/x" or its "/\host/x" twin, so the prefix already
+// draws the line IsLocalPath exists to draw. ".." cannot arrive either;
+// parseServices refuses it in every images entry before this runs.
+func mediaRef(src string) (rel string, ours bool) {
+	if !IsURLOrAbs(src) {
+		return src, true
+	}
+	return strings.CutPrefix(src, "/media/")
+}
+
 func Load(dir string) (*Config, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -359,12 +380,13 @@ func Load(dir string) (*Config, error) {
 	}
 	for _, s := range services {
 		for _, img := range s.Images {
-			src := img.Src
-			if IsURLOrAbs(src) {
+			rel, ours := mediaRef(img.Src)
+			if !ours {
 				continue
 			}
-			if st, err := os.Stat(filepath.Join(dir, "media", filepath.FromSlash(src))); err != nil || st.IsDir() {
-				return nil, fmt.Errorf("config: service %q: image %q not found (expected a file at %s, a URL or an absolute path)", s.ID, src, filepath.Join(dir, "media", src))
+			path := filepath.Join(dir, "media", filepath.FromSlash(rel))
+			if st, err := os.Stat(path); err != nil || st.IsDir() {
+				return nil, fmt.Errorf("config: service %q: image %q not found (expected a file at %s, a URL or an absolute path)", s.ID, img.Src, path)
 			}
 		}
 	}

--- a/src/internal/config/config_test.go
+++ b/src/internal/config/config_test.go
@@ -173,6 +173,69 @@ func TestServiceImageErrors(t *testing.T) {
 	}
 }
 
+// A file in media/ has two documented spellings, the bare name and the
+// /media/… path it is served at, and they name the same file on disk. Only the
+// bare one was ever stat'd: the same missing image refused to boot written one
+// way and reached the page as a broken img written the other, with -check
+// printing ok both times.
+func TestAbsoluteMediaPathIsCheckedLikeABareName(t *testing.T) {
+	for _, src := range []string{"nope.png", "/media/nope.png"} {
+		dir := testutil.WriteFiles(t, map[string]string{
+			"services.yaml": "- {id: a, url: https://a.example.org, name: A, images: [" + src + "]}\n",
+		})
+		_, err := config.Load(dir)
+		if err == nil {
+			t.Errorf("image %q: a file that is not there was accepted", src)
+			continue
+		}
+		// The message quotes the spelling the operator wrote, not the one the
+		// check normalised to, or they cannot find the line to fix.
+		for _, want := range []string{`service "a"`, `"` + src + `"`, "not found"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("image %q: error %v does not mention %q", src, err, want)
+			}
+		}
+	}
+}
+
+// The same path with the file in place still loads. The rule is about the
+// file, not about the slash.
+func TestAbsoluteMediaPathAcceptsAFileThatIsThere(t *testing.T) {
+	dir := testutil.WriteFiles(t, map[string]string{
+		"services.yaml": "- {id: a, url: https://a.example.org, name: A, images: [/media/shot.png]}\n",
+	})
+	if err := os.MkdirAll(filepath.Join(dir, "media"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "media", "shot.png"), []byte("png"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := config.Load(dir); err != nil {
+		t.Fatalf("refused an image that is on disk: %v", err)
+	}
+}
+
+// Everything cairn does not serve itself keeps passing through unlooked at,
+// with no media/ directory here at all. None of these names a file this
+// directory is responsible for, and stat'ing them would refuse configs that
+// are correct.
+func TestImagesCairnDoesNotServeAreNotCheckedForExistence(t *testing.T) {
+	for _, src := range []string{
+		"https://cdn.example.org/shot.png", // somebody else's server
+		"//cdn.example.org/shot.png",       // the protocol-relative form of it
+		"/assets/shot.png",                 // the mounted assets dir, not this one
+		"/static/shot.png",                 // cairn's own bundled files
+		"/whatever/shot.png",               // anything else behind the base path
+	} {
+		dir := testutil.WriteFiles(t, map[string]string{
+			"services.yaml": "- {id: a, url: https://a.example.org, name: A, images: [\"" + src + "\"]}\n",
+		})
+		if _, err := config.Load(dir); err != nil {
+			t.Errorf("image %q was checked for existence and should not have been: %v", src, err)
+		}
+	}
+}
+
 func TestFriendlyYAMLErrors(t *testing.T) {
 	for _, tc := range []struct{ name, services, want string }{
 		{"scalar for list", "- id: a\n  url: https://a.example.org\n  name: A\n  tags: solo\n",

--- a/src/internal/config/locales.go
+++ b/src/internal/config/locales.go
@@ -196,9 +196,6 @@ var builtinStrings = map[string]map[string]string{
 	},
 }
 
-// rtlLocales lists the base language codes written right to left. None of the
-// built-in UI languages is among them, but a site's own content can be, and
-// the html dir attribute is what makes the whole layout follow.
 // StringKeys lists every UI string an operator may override, sorted. A key
 // outside this set is a typo that silently does nothing: Str falls through to
 // the built-in table, so the page looks exactly as it would with no override
@@ -222,6 +219,9 @@ func BuiltinLocales() []string {
 	return out
 }
 
+// rtlLocales lists the base language codes written right to left. None of the
+// built-in UI languages is among them, but a site's own content can be, and
+// the html dir attribute is what makes the whole layout follow.
 var rtlLocales = map[string]bool{
 	"ar": true, "arc": true, "ckb": true, "dv": true, "fa": true, "he": true,
 	"ku": true, "ps": true, "sd": true, "ug": true, "ur": true, "yi": true,

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -35,15 +35,16 @@ func validateSite(site *Site, definedIn map[string]string) error {
 	}
 	// logo and favicon are the two image fields nothing else validates: a value
 	// that is not a URL only earns a -check warning, since a missing file is a
-	// plausible typo. A script scheme is not, so it stops the load. The favicon
-	// is the sharp case: it reaches the manifest as JSON, which no html/template
-	// escaping covers, and comes back from /favicon.ico as a Location header.
+	// plausible typo. An executable scheme is not, so it stops the load. The
+	// favicon is the sharp case: it reaches the manifest as JSON, which no
+	// html/template escaping covers, and comes back from /favicon.ico as a
+	// Location header.
 	for _, f := range []struct{ key, val string }{
 		{"logo", site.Logo},
 		{"favicon", site.Favicon},
 	} {
-		if hasScriptScheme(f.val) {
-			return scriptSchemeErr(f.key, f.val, "https://… or an /assets path")
+		if sc := unsafeScheme(f.val); sc != "" {
+			return unsafeSchemeErr(f.key, f.val, sc, "https://… or an /assets path")
 		}
 	}
 	// security.txt is a line-based format, so a newline in any value would let
@@ -60,11 +61,11 @@ func validateSite(site *Site, definedIn map[string]string) error {
 			return fmt.Errorf("config: site.yaml: %s must be one line", f.key)
 		}
 		// uriRe takes any scheme, because security.txt takes mailto:, https:
-		// and tel: alike, so it is the one URL check here that a script scheme
-		// walks straight through. Catch it before uriRe has a chance to bless
-		// it, or the researcher this file is written for gets a dead link.
-		if hasScriptScheme(f.val) {
-			return scriptSchemeErr(f.key, f.val, "e.g. mailto:security@example.org or https://example.org/security")
+		// and tel: alike, so it is the one URL check here that an executable
+		// scheme walks straight through. Catch it before uriRe has a chance to
+		// bless it, or the researcher this file is written for gets a dead link.
+		if sc := unsafeScheme(f.val); sc != "" {
+			return unsafeSchemeErr(f.key, f.val, sc, "e.g. mailto:security@example.org or https://example.org/security")
 		}
 		if !uriRe.MatchString(f.val) {
 			return fmt.Errorf("config: site.yaml: %s %q is not a URI (expected e.g. mailto:security@example.org or https://example.org/security)", f.key, f.val)
@@ -93,14 +94,14 @@ func validateSite(site *Site, definedIn map[string]string) error {
 			return fmt.Errorf("config: site.yaml: every links entry needs label and url (expected: - {label: Wiki, url: https://…})")
 		}
 		// A link url is the one field here that takes any scheme at all, since
-		// mailto: and tel: are legitimate targets, so nothing else would stop
-		// this one. html/template blanks the href, which means the header link
-		// renders and goes nowhere with no error anywhere.
-		if hasScriptScheme(l.URL) {
-			return scriptSchemeErr("links url", l.URL, "https://…, mailto:… or an absolute path")
+		// mailto: is a legitimate target, so nothing else would stop this one.
+		// html/template blanks the href, which means the header link renders
+		// and goes nowhere with no error anywhere.
+		if sc := unsafeScheme(l.URL); sc != "" {
+			return unsafeSchemeErr("links url", l.URL, sc, "https://…, mailto:… or an absolute path")
 		}
 		if ic := l.Icon; ic != "" && !IsURLOrAbs(ic) {
-			// A script scheme lands here too: it is not a URL, not an /assets
+			// An executable scheme lands here too: it is not a URL, not an /assets
 			// path and not a glyph name, so this refusal already covers it and
 			// a second gate would only say the same thing twice.
 			if _, ok := Glyphs[ic]; !ok {
@@ -109,14 +110,14 @@ func validateSite(site *Site, definedIn map[string]string) error {
 		}
 	}
 	// Footer entries are validated nowhere else: they carry no icon on the page
-	// and no rule ever asked what their url was. That silence is exactly why a
-	// script scheme has to be caught here rather than left to the next reader.
+	// and no rule ever asked what their url was. That silence is exactly why an
+	// executable scheme has to be caught here rather than left to the reader.
 	for _, l := range site.Footer {
-		if hasScriptScheme(l.URL) {
-			return scriptSchemeErr("footer url", l.URL, "https://…, mailto:… or an absolute path")
+		if sc := unsafeScheme(l.URL); sc != "" {
+			return unsafeSchemeErr("footer url", l.URL, sc, "https://…, mailto:… or an absolute path")
 		}
-		if hasScriptScheme(l.Icon) {
-			return scriptSchemeErr("footer icon", l.Icon, "a built-in glyph name, https://… or an /assets path")
+		if sc := unsafeScheme(l.Icon); sc != "" {
+			return unsafeSchemeErr("footer icon", l.Icon, sc, "a built-in glyph name, https://… or an /assets path")
 		}
 	}
 	for i, ic := range site.Icons {
@@ -161,8 +162,18 @@ func validateSite(site *Site, definedIn map[string]string) error {
 	return nil
 }
 
-// hasScriptScheme reports a value a browser would read as javascript: or
-// vbscript:, however it is dressed up.
+// unsafeSchemes are the three a browser can be talked into executing, so they
+// are the three no field of this file may carry.
+//
+// javascript: and vbscript: run code outright. data: is here because
+// data:text/html carries a whole document, script and all, and because a list
+// of two invites the next reader to assume the third was weighed and kept. It
+// costs nothing to refuse: html/template emits only http, https, mailto and
+// paths, and replaces every other scheme with #ZgotmplZ, so a data: favicon
+// has never once reached a browser from cairn.
+var unsafeSchemes = []string{"javascript", "vbscript", "data"}
+
+// unsafeScheme names the one s carries, or "" when it carries none.
 //
 // The dressing is the whole point. A browser removes every tab, newline and
 // carriage return from a URL and strips leading control characters and spaces
@@ -170,7 +181,7 @@ func validateSite(site *Site, definedIn map[string]string) error {
 // and "JavaScript:…" are all the same URL as the plain one. Matching the
 // literal text would refuse the obvious spelling and pass the three that
 // matter, which is worse than not checking: it reads as a check that works.
-func hasScriptScheme(s string) bool {
+func unsafeScheme(s string) string {
 	s = strings.Map(func(r rune) rune {
 		if r == '\t' || r == '\n' || r == '\r' {
 			return -1
@@ -178,11 +189,18 @@ func hasScriptScheme(s string) bool {
 		return r
 	}, s)
 	s = strings.ToLower(strings.TrimLeftFunc(s, func(r rune) bool { return r <= ' ' }))
-	return strings.HasPrefix(s, "javascript:") || strings.HasPrefix(s, "vbscript:")
+	for _, sc := range unsafeSchemes {
+		if strings.HasPrefix(s, sc+":") {
+			return sc
+		}
+	}
+	return ""
 }
 
-// scriptSchemeErr words the refusal once for every field that can carry one,
-// so an operator who trips it twice can tell it is one rule and not two.
-func scriptSchemeErr(field, val, accepted string) error {
-	return fmt.Errorf("config: site.yaml: %s %q uses the javascript: or vbscript: scheme, which loads nothing (expected %s)", field, val, accepted)
+// unsafeSchemeErr words the refusal once for every field that can carry one,
+// so an operator who trips it twice can tell it is one rule and not two. It
+// names the scheme it found as well as the rule, because the three spellings
+// that reach here look nothing like each other.
+func unsafeSchemeErr(field, val, scheme, accepted string) error {
+	return fmt.Errorf("config: site.yaml: %s %q uses the %s: scheme; cairn refuses javascript:, vbscript: and data: wherever a link goes (expected %s)", field, val, scheme, accepted)
 }

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -33,6 +33,19 @@ func validateSite(site *Site, definedIn map[string]string) error {
 			return fmt.Errorf("config: site.yaml: status.interval %q is not a duration of at least 5s (expected e.g. 60s)", iv)
 		}
 	}
+	// logo and favicon are the two image fields nothing else validates: a value
+	// that is not a URL only earns a -check warning, since a missing file is a
+	// plausible typo. A script scheme is not, so it stops the load. The favicon
+	// is the sharp case: it reaches the manifest as JSON, which no html/template
+	// escaping covers, and comes back from /favicon.ico as a Location header.
+	for _, f := range []struct{ key, val string }{
+		{"logo", site.Logo},
+		{"favicon", site.Favicon},
+	} {
+		if hasScriptScheme(f.val) {
+			return scriptSchemeErr(f.key, f.val, "https://… or an /assets path")
+		}
+	}
 	// security.txt is a line-based format, so a newline in any value would let
 	// a typo forge a field. Reject that here rather than escape it later.
 	for _, f := range []struct{ key, val string }{
@@ -45,6 +58,13 @@ func validateSite(site *Site, definedIn map[string]string) error {
 		}
 		if strings.ContainsAny(f.val, "\r\n") {
 			return fmt.Errorf("config: site.yaml: %s must be one line", f.key)
+		}
+		// uriRe takes any scheme, because security.txt takes mailto:, https:
+		// and tel: alike, so it is the one URL check here that a script scheme
+		// walks straight through. Catch it before uriRe has a chance to bless
+		// it, or the researcher this file is written for gets a dead link.
+		if hasScriptScheme(f.val) {
+			return scriptSchemeErr(f.key, f.val, "e.g. mailto:security@example.org or https://example.org/security")
 		}
 		if !uriRe.MatchString(f.val) {
 			return fmt.Errorf("config: site.yaml: %s %q is not a URI (expected e.g. mailto:security@example.org or https://example.org/security)", f.key, f.val)
@@ -72,10 +92,31 @@ func validateSite(site *Site, definedIn map[string]string) error {
 		if len(l.Label) == 0 || l.URL == "" {
 			return fmt.Errorf("config: site.yaml: every links entry needs label and url (expected: - {label: Wiki, url: https://…})")
 		}
+		// A link url is the one field here that takes any scheme at all, since
+		// mailto: and tel: are legitimate targets, so nothing else would stop
+		// this one. html/template blanks the href, which means the header link
+		// renders and goes nowhere with no error anywhere.
+		if hasScriptScheme(l.URL) {
+			return scriptSchemeErr("links url", l.URL, "https://…, mailto:… or an absolute path")
+		}
 		if ic := l.Icon; ic != "" && !IsURLOrAbs(ic) {
+			// A script scheme lands here too: it is not a URL, not an /assets
+			// path and not a glyph name, so this refusal already covers it and
+			// a second gate would only say the same thing twice.
 			if _, ok := Glyphs[ic]; !ok {
 				return fmt.Errorf("config: site.yaml: links icon %q is not a built-in glyph (%s), a URL or an /assets path", ic, strings.Join(GlyphNames(), ", "))
 			}
+		}
+	}
+	// Footer entries are validated nowhere else: they carry no icon on the page
+	// and no rule ever asked what their url was. That silence is exactly why a
+	// script scheme has to be caught here rather than left to the next reader.
+	for _, l := range site.Footer {
+		if hasScriptScheme(l.URL) {
+			return scriptSchemeErr("footer url", l.URL, "https://…, mailto:… or an absolute path")
+		}
+		if hasScriptScheme(l.Icon) {
+			return scriptSchemeErr("footer icon", l.Icon, "a built-in glyph name, https://… or an /assets path")
 		}
 	}
 	for i, ic := range site.Icons {
@@ -118,4 +159,30 @@ func validateSite(site *Site, definedIn map[string]string) error {
 		}
 	}
 	return nil
+}
+
+// hasScriptScheme reports a value a browser would read as javascript: or
+// vbscript:, however it is dressed up.
+//
+// The dressing is the whole point. A browser removes every tab, newline and
+// carriage return from a URL and strips leading control characters and spaces
+// before it looks at the scheme, so "java\tscript:alert(1)", " javascript:…"
+// and "JavaScript:…" are all the same URL as the plain one. Matching the
+// literal text would refuse the obvious spelling and pass the three that
+// matter, which is worse than not checking: it reads as a check that works.
+func hasScriptScheme(s string) bool {
+	s = strings.Map(func(r rune) rune {
+		if r == '\t' || r == '\n' || r == '\r' {
+			return -1
+		}
+		return r
+	}, s)
+	s = strings.ToLower(strings.TrimLeftFunc(s, func(r rune) bool { return r <= ' ' }))
+	return strings.HasPrefix(s, "javascript:") || strings.HasPrefix(s, "vbscript:")
+}
+
+// scriptSchemeErr words the refusal once for every field that can carry one,
+// so an operator who trips it twice can tell it is one rule and not two.
+func scriptSchemeErr(field, val, accepted string) error {
+	return fmt.Errorf("config: site.yaml: %s %q uses the javascript: or vbscript: scheme, which loads nothing (expected %s)", field, val, accepted)
 }

--- a/src/internal/config/validate_test.go
+++ b/src/internal/config/validate_test.go
@@ -118,6 +118,29 @@ func TestValidateSiteRejections(t *testing.T) {
 			s.Pages = []SitePage{{ID: "legal", Title: LString{"": "x"},
 				Sections: []PageSection{{Title: LString{"": "Publisher"}}}}}
 		}, []string{"every section needs title and body"}},
+		// The six fields a script scheme used to reach. Every one of them is an
+		// error rather than a warning, unlike a missing image file: a typo puts
+		// a real path in the wrong place, and nothing puts javascript: there by
+		// accident. The favicon is the one that escapes html/template entirely,
+		// since it reaches the manifest as JSON and /favicon.ico as a Location.
+		{"logo that is a script url", func(s *Site) { s.Logo = "javascript:alert(1)" },
+			[]string{"logo", `"javascript:alert(1)"`, "loads nothing", "/assets"}},
+		{"favicon that is a script url", func(s *Site) { s.Favicon = "vbscript:msgbox(1)" },
+			[]string{"favicon", `"vbscript:msgbox(1)"`, "loads nothing"}},
+		{"links url that is a script url", func(s *Site) {
+			s.Links = []FooterLink{{Label: LString{"": "Wiki"}, URL: "javascript:alert(1)"}}
+		}, []string{"links url", `"javascript:alert(1)"`, "mailto:"}},
+		{"footer url that is a script url", func(s *Site) {
+			s.Footer = []FooterLink{{Label: LString{"": "Legal"}, URL: "javascript:alert(1)"}}
+		}, []string{"footer url", `"javascript:alert(1)"`}},
+		{"footer icon that is a script url", func(s *Site) {
+			s.Footer = []FooterLink{{Label: LString{"": "Legal"}, URL: "https://e.example.org", Icon: "javascript:alert(1)"}}
+		}, []string{"footer icon", `"javascript:alert(1)"`, "glyph"}},
+		// uriRe accepts any scheme, because security.txt takes mailto:, https:
+		// and tel: alike, so this is the one URL field that blessed a script
+		// scheme outright instead of merely failing to look.
+		{"security contact that is a script url", func(s *Site) { s.Security.Contact = "javascript:alert(1)" },
+			[]string{"security.contact", `"javascript:alert(1)"`, "mailto:"}},
 	} {
 		t.Run(c.name, func(t *testing.T) {
 			s := base()
@@ -208,16 +231,96 @@ func TestValidateSiteNormalizes(t *testing.T) {
 	}
 }
 
+// The plain spelling is the one nobody writes. A browser deletes every tab,
+// newline and carriage return from a URL and strips the leading control
+// characters and spaces before it reads the scheme, so all of the first group
+// are one URL as far as it is concerned. A literal prefix test would refuse
+// the obvious one and wave the rest through, which is worse than no check: it
+// reads like a check that works.
+func TestHasScriptSchemeSeesThroughTheDressing(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		val  string
+		want bool
+	}{
+		{"plain", "javascript:alert(1)", true},
+		{"capitalised", "JavaScript:alert(1)", true},
+		{"split by a tab", "java\tscript:alert(1)", true},
+		{"split by a newline", "java\nscript:alert(1)", true},
+		{"split by a carriage return", "java\rscript:alert(1)", true},
+		{"led by spaces", "  javascript:alert(1)", true},
+		{"led by a control character", "\x01javascript:alert(1)", true},
+		{"vbscript, the same trick", "VB\tScript:msgbox(1)", true},
+		// The look-alikes. Refusing one of these would be the worse failure of
+		// the two: a config that booted yesterday stops booting on an upgrade,
+		// and the operator is told their perfectly good path runs code.
+		{"a file whose name contains the word", "/assets/javascript-logo.png", false},
+		{"a mailbox that contains the word", "mailto:javascript@example.org", false},
+		{"a url whose path contains it", "https://example.org/javascript:alert(1)", false},
+		{"an ordinary asset path", "/assets/logo.png", false},
+		{"nothing at all", "", false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if got := hasScriptScheme(c.val); got != c.want {
+				t.Errorf("hasScriptScheme(%q) = %v, want %v", c.val, got, c.want)
+			}
+		})
+	}
+}
+
+// The fields a script scheme could never have reached, with the gate that
+// stops each one. Nothing was added for them: a second refusal would only say
+// the same thing twice. They are pinned here so that loosening one of those
+// gates shows up as a hole in this rule rather than as a value in the manifest.
+func TestScriptSchemeWasAlreadyRefusedWhereAGateExisted(t *testing.T) {
+	for _, c := range []struct {
+		name, want string
+		mut        func(*Site)
+	}{
+		{"icons src, by the URL-or-/assets rule", "not a URL or an /assets path", func(s *Site) {
+			s.Icons = []SiteIcon{{Src: "javascript:alert(1)", Sizes: "512x512"}}
+		}},
+		{"links icon, by the glyph rule", "is not a built-in glyph", func(s *Site) {
+			s.Links = []FooterLink{{Label: LString{"": "W"}, URL: "https://w.example.org", Icon: "javascript:alert(1)"}}
+		}},
+		{"status.gatus, by the http rule", "status.gatus", func(s *Site) { s.Status.Gatus = "javascript:alert(1)" }},
+		{"status.page, by the http rule", "status.page", func(s *Site) { s.Status.Page = "javascript:alert(1)" }},
+		{"url, by the http rule", "url", func(s *Site) { s.URL = "javascript:alert(1)" }},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			s := &Site{Locales: []string{"en"}}
+			s.Theme.Accent = "#247b7b"
+			c.mut(s)
+			err := validateSite(s, map[string]string{})
+			if err == nil {
+				t.Fatal("a script scheme was accepted")
+			}
+			if !strings.Contains(err.Error(), c.want) {
+				t.Errorf("message %q does not mention %q", err, c.want)
+			}
+		})
+	}
+}
+
 // The shapes that must pass, so a tightened rule cannot quietly start
 // refusing a config that has always been legal.
 func TestValidateSiteAccepts(t *testing.T) {
 	s := &Site{
 		Locales: []string{"fr", "en", "pt-BR"},
 		URL:     "http://tools.example.org",
+		Logo:    "/assets/logo.png",
+		Favicon: "https://cdn.example.org/favicon.png",
 		Links: []FooterLink{
 			{Label: LString{"": "Wiki"}, URL: "https://w.example.org", Icon: "book"},
 			{Label: LString{"": "Logo"}, URL: "https://x.example.org", Icon: "/assets/l.png"},
 			{Label: LString{"": "Plain"}, URL: "https://y.example.org"},
+			// mailto: is a legal link target, and the scheme rule has to let
+			// every scheme but the two named ones through.
+			{Label: LString{"": "Mail"}, URL: "mailto:hi@example.org"},
+		},
+		Footer: []FooterLink{
+			{Label: LString{"": "Legal"}, URL: "/en/legal/"},
+			{Label: LString{"": "Status"}, URL: "https://status.example.org"},
 		},
 		Pages: []SitePage{
 			{ID: "legal-notice", Title: LString{"": "Legal"}, Body: LString{"": "text"}},

--- a/src/internal/config/validate_test.go
+++ b/src/internal/config/validate_test.go
@@ -118,15 +118,21 @@ func TestValidateSiteRejections(t *testing.T) {
 			s.Pages = []SitePage{{ID: "legal", Title: LString{"": "x"},
 				Sections: []PageSection{{Title: LString{"": "Publisher"}}}}}
 		}, []string{"every section needs title and body"}},
-		// The six fields a script scheme used to reach. Every one of them is an
+		// The six fields an executable scheme used to reach. Every one is an
 		// error rather than a warning, unlike a missing image file: a typo puts
 		// a real path in the wrong place, and nothing puts javascript: there by
 		// accident. The favicon is the one that escapes html/template entirely,
 		// since it reaches the manifest as JSON and /favicon.ico as a Location.
 		{"logo that is a script url", func(s *Site) { s.Logo = "javascript:alert(1)" },
-			[]string{"logo", `"javascript:alert(1)"`, "loads nothing", "/assets"}},
+			[]string{"logo", `"javascript:alert(1)"`, "javascript: scheme", "/assets"}},
 		{"favicon that is a script url", func(s *Site) { s.Favicon = "vbscript:msgbox(1)" },
-			[]string{"favicon", `"vbscript:msgbox(1)"`, "loads nothing"}},
+			[]string{"favicon", `"vbscript:msgbox(1)"`, "vbscript: scheme"}},
+		// data:text/html carries a document, script and all. It is refused for
+		// the same reason and named separately, because an operator who reaches
+		// for it is reaching for an inline icon and deserves to be told which
+		// of the three rules they hit.
+		{"favicon that is a data url", func(s *Site) { s.Favicon = "data:text/html,<script>x</script>" },
+			[]string{"favicon", "data: scheme"}},
 		{"links url that is a script url", func(s *Site) {
 			s.Links = []FooterLink{{Label: LString{"": "Wiki"}, URL: "javascript:alert(1)"}}
 		}, []string{"links url", `"javascript:alert(1)"`, "mailto:"}},
@@ -137,8 +143,8 @@ func TestValidateSiteRejections(t *testing.T) {
 			s.Footer = []FooterLink{{Label: LString{"": "Legal"}, URL: "https://e.example.org", Icon: "javascript:alert(1)"}}
 		}, []string{"footer icon", `"javascript:alert(1)"`, "glyph"}},
 		// uriRe accepts any scheme, because security.txt takes mailto:, https:
-		// and tel: alike, so this is the one URL field that blessed a script
-		// scheme outright instead of merely failing to look.
+		// and tel: alike, so this is the one URL field that blessed an
+		// executable scheme outright instead of merely failing to look.
 		{"security contact that is a script url", func(s *Site) { s.Security.Contact = "javascript:alert(1)" },
 			[]string{"security.contact", `"javascript:alert(1)"`, "mailto:"}},
 	} {
@@ -237,42 +243,49 @@ func TestValidateSiteNormalizes(t *testing.T) {
 // are one URL as far as it is concerned. A literal prefix test would refuse
 // the obvious one and wave the rest through, which is worse than no check: it
 // reads like a check that works.
-func TestHasScriptSchemeSeesThroughTheDressing(t *testing.T) {
+func TestUnsafeSchemeSeesThroughTheDressing(t *testing.T) {
 	for _, c := range []struct {
 		name string
 		val  string
-		want bool
+		want string
 	}{
-		{"plain", "javascript:alert(1)", true},
-		{"capitalised", "JavaScript:alert(1)", true},
-		{"split by a tab", "java\tscript:alert(1)", true},
-		{"split by a newline", "java\nscript:alert(1)", true},
-		{"split by a carriage return", "java\rscript:alert(1)", true},
-		{"led by spaces", "  javascript:alert(1)", true},
-		{"led by a control character", "\x01javascript:alert(1)", true},
-		{"vbscript, the same trick", "VB\tScript:msgbox(1)", true},
+		{"plain", "javascript:alert(1)", "javascript"},
+		{"capitalised", "JavaScript:alert(1)", "javascript"},
+		{"split by a tab", "java\tscript:alert(1)", "javascript"},
+		{"split by a newline", "java\nscript:alert(1)", "javascript"},
+		{"split by a carriage return", "java\rscript:alert(1)", "javascript"},
+		{"led by spaces", "  javascript:alert(1)", "javascript"},
+		{"led by a control character", "\x01javascript:alert(1)", "javascript"},
+		{"vbscript, the same trick", "VB\tScript:msgbox(1)", "vbscript"},
+		// data: is the third because data:text/html is a document with script
+		// in it. The dressing works on it just the same.
+		{"a data document", "data:text/html,<script>alert(1)</script>", "data"},
+		{"a data image, refused all the same", "data:image/svg+xml,<svg/>", "data"},
+		{"data, dressed", " Da\tta:text/html,x", "data"},
 		// The look-alikes. Refusing one of these would be the worse failure of
 		// the two: a config that booted yesterday stops booting on an upgrade,
 		// and the operator is told their perfectly good path runs code.
-		{"a file whose name contains the word", "/assets/javascript-logo.png", false},
-		{"a mailbox that contains the word", "mailto:javascript@example.org", false},
-		{"a url whose path contains it", "https://example.org/javascript:alert(1)", false},
-		{"an ordinary asset path", "/assets/logo.png", false},
-		{"nothing at all", "", false},
+		{"a file whose name contains the word", "/assets/javascript-logo.png", ""},
+		{"a mailbox that contains the word", "mailto:javascript@example.org", ""},
+		{"a url whose path contains it", "https://example.org/javascript:alert(1)", ""},
+		{"a file whose name starts with the third word", "/assets/database.png", ""},
+		{"a host that starts with it", "https://data.example.org/logo.png", ""},
+		{"an ordinary asset path", "/assets/logo.png", ""},
+		{"nothing at all", "", ""},
 	} {
 		t.Run(c.name, func(t *testing.T) {
-			if got := hasScriptScheme(c.val); got != c.want {
-				t.Errorf("hasScriptScheme(%q) = %v, want %v", c.val, got, c.want)
+			if got := unsafeScheme(c.val); got != c.want {
+				t.Errorf("unsafeScheme(%q) = %q, want %q", c.val, got, c.want)
 			}
 		})
 	}
 }
 
-// The fields a script scheme could never have reached, with the gate that
+// The fields an executable scheme could never have reached, with the gate that
 // stops each one. Nothing was added for them: a second refusal would only say
 // the same thing twice. They are pinned here so that loosening one of those
 // gates shows up as a hole in this rule rather than as a value in the manifest.
-func TestScriptSchemeWasAlreadyRefusedWhereAGateExisted(t *testing.T) {
+func TestUnsafeSchemeWasAlreadyRefusedWhereAGateExisted(t *testing.T) {
 	for _, c := range []struct {
 		name, want string
 		mut        func(*Site)
@@ -293,7 +306,7 @@ func TestScriptSchemeWasAlreadyRefusedWhereAGateExisted(t *testing.T) {
 			c.mut(s)
 			err := validateSite(s, map[string]string{})
 			if err == nil {
-				t.Fatal("a script scheme was accepted")
+				t.Fatal("an executable scheme was accepted")
 			}
 			if !strings.Contains(err.Error(), c.want) {
 				t.Errorf("message %q does not mention %q", err, c.want)
@@ -315,7 +328,7 @@ func TestValidateSiteAccepts(t *testing.T) {
 			{Label: LString{"": "Logo"}, URL: "https://x.example.org", Icon: "/assets/l.png"},
 			{Label: LString{"": "Plain"}, URL: "https://y.example.org"},
 			// mailto: is a legal link target, and the scheme rule has to let
-			// every scheme but the two named ones through.
+			// every scheme but the three named ones through.
 			{Label: LString{"": "Mail"}, URL: "mailto:hi@example.org"},
 		},
 		Footer: []FooterLink{

--- a/src/internal/render/assets/nav.js
+++ b/src/internal/render/assets/nav.js
@@ -6,11 +6,23 @@
   const header = document.querySelector('header');
   const totop = document.querySelector('.totop');
   const nav = document.querySelector('.nav');
+  const burger = nav && nav.querySelector('summary');
   let last = scrollY;
+
+  // A scroll dismisses the open menu, which is right for a pointer and wrong
+  // for a keyboard: tabbing to a menu link the browser has to scroll into view
+  // fires this handler, and closing the menu underneath both takes away what
+  // the user was tabbing through and drops focus to <body>, so the next Tab
+  // restarts at the skip link. Focus on the burger itself is still the pointer
+  // case: clicking it leaves focus there, and the summary survives the close.
+  const keyboardInside = () => {
+    const a = document.activeElement;
+    return !!a && a !== burger && nav.contains(a);
+  };
 
   const update = () => {
     const y = scrollY;
-    if (nav && nav.open) nav.open = false; // a scroll dismisses the open menu
+    if (nav && nav.open && !keyboardInside()) nav.open = false;
     if (header) {
       // near the top or scrolling up: show; scrolling down past a bit: hide
       if (y < 80 || y < last - 4) header.classList.remove('header-hidden');

--- a/src/internal/render/assets/style.css
+++ b/src/internal/render/assets/style.css
@@ -36,6 +36,15 @@
   --muted: light-dark(#5c6461, #98a19d);
   --faint: light-dark(#e8e7df, #212829);
   --border: light-dark(#dcdbd2, #2a3130);
+  /* --border is decoration: card outlines, rules, the trail's spine. It sits
+     at 1.21:1 against --bg in light and 1.34:1 in dark, which is fine for
+     decoration and far under the 3:1 WCAG 1.4.11 asks of a control's boundary.
+     Darkening --border to reach it would repaint every card on the page, so
+     this second value exists for the boundary that *is* the control, where
+     nothing else says where to click or type. Measured in the browser against
+     both neighbours: light 3.31:1 on --bg and 3.67:1 on --card, dark 3.63:1
+     and 3.31:1. */
+  --ui-border: light-dark(#7f8482, #6b7270);
   --accent: #247b7b;                                       /* set inline from theme.accent */
   --accent-ink: light-dark(color-mix(in oklab, var(--accent) 85%, #000), color-mix(in oklab, var(--accent) 72%, #fff));
   --up: light-dark(#2e8b57, #4cb47c);
@@ -309,6 +318,15 @@ header { padding-block: 1.4rem; }
   box-shadow: var(--shadow);
   transition: border-color .15s, box-shadow .15s;
 }
+/* An input's outline is the whole of what says where to type, so WCAG 1.4.11
+   wants 3:1 there. It exempts inactive components, and that is not a shortcut
+   here, it is the shape of the thing: the bar renders disabled and decorative
+   on every page but the home page, purely for layout parity, and nobody can
+   type in it. So the strong border goes exactly where the control is awake and
+   the quiet one stays exactly where it is asleep.
+   :where() holds this at .search-box's own specificity so :focus-within below
+   still gets to paint the border accent. */
+.search-box:where(:has(input:enabled)) { border-color: var(--ui-border); }
 @media (max-width: 44rem) {
   .search, .search:focus-within { flex: 1 1 100%; margin-inline-start: 0; width: 100%; }
 }
@@ -926,15 +944,23 @@ footer {
     background: color-mix(in oklab, var(--accent) 8%, var(--card));
   }
 
-  /* above ~7 categories the chips give way to a compact jump-to select */
-  .toc.many { display: none; }
-  .toc-jump { display: block; margin: 1.5rem 0 .3rem; }
+  /* Above ~7 categories the chips give way to a compact jump-to select, but
+     only where something can drive it: the select's entire behaviour lives in
+     nav.js, so with JavaScript off this swap left a phone with no category
+     navigation at all, on the viewport where the list matters most. The
+     pre-paint script in <head> stamps data-js before first render, so gating
+     on it costs no flash of the wrong one, and the fallback needs no markup:
+     .toc.many simply stays a chip row. */
+  [data-js] .toc.many { display: none; }
+  [data-js] .toc-jump { display: block; margin: 1.5rem 0 .3rem; }
   .toc-select {
     width: 100%;
     max-width: 22rem;
     min-height: 2.75rem;
     padding: .3rem .9rem;
-    border: 1px solid var(--border);
+    /* a form control, so its boundary is the control: --ui-border, not
+       --border, for the same 3:1 reason as the search box */
+    border: 1px solid var(--ui-border);
     border-radius: .7rem;
     background: var(--card);
     color: var(--fg);

--- a/src/internal/render/assets/theme.js
+++ b/src/internal/render/assets/theme.js
@@ -3,14 +3,22 @@
 (() => {
   const btn = document.getElementById('theme-toggle');
   if (!btn) return;
+  const root = document.documentElement;
+  const dark = () => (root.dataset.theme
+    ? root.dataset.theme === 'dark'
+    : matchMedia('(prefers-color-scheme: dark)').matches);
+  // A toggle that never says whether it is pressed is a button and no state to
+  // a screen reader (WCAG 4.1.2). Pressed means dark. The server cannot render
+  // it: the button ships hidden, and by the time it is revealed the pre-paint
+  // script may already have applied a stored theme, so only here is the
+  // current one known.
+  const sync = () => btn.setAttribute('aria-pressed', String(dark()));
+  sync();
   btn.hidden = false;
   btn.addEventListener('click', () => {
-    const root = document.documentElement;
-    const dark = root.dataset.theme
-      ? root.dataset.theme === 'dark'
-      : matchMedia('(prefers-color-scheme: dark)').matches;
-    const next = dark ? 'light' : 'dark';
+    const next = dark() ? 'light' : 'dark';
     root.dataset.theme = next;
     try { localStorage.setItem('theme', next); } catch (e) {}
+    sync();
   });
 })();

--- a/src/internal/render/render.go
+++ b/src/internal/render/render.go
@@ -48,7 +48,10 @@ type Model struct {
 // The about cookie stores a hash of the note's content (the data-about
 // attribute), so an edited note reappears even for visitors who dismissed
 // the previous one.
-const prePaintScript = `var a=document.cookie.match(/(?:^|; )about=([^;]*)/);if(a&&a[1]===document.documentElement.getAttribute('data-about'))document.documentElement.setAttribute('data-noabout','');try{var t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t)}catch(e){}`
+// data-js is stamped here rather than from a deferred script because CSS keys
+// off it before first paint: with JavaScript off, the mobile category trail
+// must stay as chips instead of folding into a select only nav.js can drive.
+const prePaintScript = `document.documentElement.setAttribute('data-js','');var a=document.cookie.match(/(?:^|; )about=([^;]*)/);if(a&&a[1]===document.documentElement.getAttribute('data-about'))document.documentElement.setAttribute('data-noabout','');try{var t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t)}catch(e){}`
 
 // aboutHash fingerprints the welcome note across all locales; eight hex
 // chars are plenty for a cookie value that only needs to change when the

--- a/src/internal/render/templates/layout.tmpl
+++ b/src/internal/render/templates/layout.tmpl
@@ -25,7 +25,7 @@
 <link rel="preload" href="{{.Prefix}}/static/fonts/fraunces.woff2" as="font" type="font/woff2" crossorigin>
 <link rel="stylesheet" href="{{.Prefix}}/static/style.css">
 <style>:root{--accent:{{.Accent}}}</style>
-<script>var a=document.cookie.match(/(?:^|; )about=([^;]*)/);if(a&&a[1]===document.documentElement.getAttribute('data-about'))document.documentElement.setAttribute('data-noabout','');try{var t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t)}catch(e){}</script>
+<script>document.documentElement.setAttribute('data-js','');var a=document.cookie.match(/(?:^|; )about=([^;]*)/);if(a&&a[1]===document.documentElement.getAttribute('data-about'))document.documentElement.setAttribute('data-noabout','');try{var t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t)}catch(e){}</script>
 {{if .CustomCSS}}<link rel="stylesheet" href="{{.Prefix}}/custom.css">
 {{end}}</head>
 <body>


### PR DESCRIPTION
PR #20 closed most of the 2026-07-31 audit. This is the rest of it, under the same rule: every fix carries a test that was proven red before it landed, by patching the fix out and watching it fail.

## Accessibility

- **The theme toggle never said whether it was pressed.** `aria-pressed` is set from `theme.js`, not the template: the button ships `hidden`, and by the time it is revealed the pre-paint script may already have applied a stored theme, so only the browser knows.
- **A phone with JavaScript off lost category navigation entirely** above seven categories. `.toc.many` gave way to a jump-to select whose whole behaviour lives in `nav.js`. The swap is now gated on a `data-js` stamp the pre-paint script writes before first paint, so there is no flash of the wrong one, and the fallback needs no markup: the chip row simply stays.
- **The search box boundary sat at 1.21:1 in light and 1.34:1 in dark**, where WCAG 1.4.11 asks 3:1 of a control. A second variable serves the boundaries that *are* the control; `--border` keeps drawing the card outlines and rules it was measured for. An inactive component is exempt, so the bar that renders disabled and decorative on every page but the home page keeps the quiet border, and the mobile jump-to select gets the strong one.
- **A scroll dismissed the burger even when focus was inside it**, so tabbing to a link the browser had to scroll into view closed the menu underneath the user and dropped focus to `<body>`. Focus on the summary itself is still the pointer case and still dismisses.

Measured in Chromium, every interactive control, not just the failing ones. The theme toggle (5.30:1), the language menu (15.64:1), the dismiss button (4.91:1), the back-to-top arrow (6.84:1) and the focus ring (4.36:1) all passed and were left alone.

## Config errors

`javascript:` and `vbscript:` are refused on `logo`, `favicon`, the `url` and `icon` of `links` and `footer` entries, and the three `security` fields. Those are the fields no other rule answered. `security.*` was the sharpest: `uriRe` takes any scheme by design, because RFC 9116 wants `mailto:`, `https:` and `tel:` alike, so it did not merely fail to look, it blessed the value.

The value is read the way a browser reads it. A browser drops tabs and newlines from a URL and strips leading control characters before it looks at the scheme, so `JavaScript:`, `java\tscript:` and a leading space are the same URL as the plain one. Matching the literal text would have refused the obvious spelling and passed the three that matter, which is worse than no check: it reads as one that works.

An `images:` entry written `/media/name.png` is now opened like the bare `name.png` it is documented to equal. The same missing file used to refuse the boot written one way and render a 404 written the other.

## New `-check` warnings

- an `/assets/…` `logo`, `favicon`, `icons[].src` or `links[].icon` that names no file
- an `icons[]` entry whose declared `sizes` the file contradicts
- a half-translated site title, `links[].label`, `footer[].label` or category name
- a `strings:` key covering some of the site's locales and not the rest
- a `locales:` entry with no built-in interface
- a markdown image in prose that names no file, which was the one way left to ship a 404 once every `images:` entry was opened

Everything that opens a file is skipped when the `-assets` directory is absent. `cairn -check` on a laptop keeps the default `/assets`, which exists in the container and on nobody's machine, and a page of wrong warnings buries the one that is right.

The two `og:image` warnings no longer stay silent on an `index: false` site. og:image feeds Slack, Mastodon and Signal unfurls, not crawlers, and a portal kept out of search results is precisely the one that gets pasted into a team channel.

## Tooling

`just test-search` is now `just test-browser`, driving two instances: the example config, and a fixture carrying the nine categories and the header burger `example/` has neither of. The leaked-server guard and the trap now cover both ports, because a stale server on either is enough to make the run measure yesterday's build.

The CI job keeps the name `search`. It is a required check on a protected branch, and a required check under a new name never runs, which leaves every pull request waiting forever.

## Verification

`gofmt`, `go vet`, `golangci-lint`, `actionlint` clean. 318 Go tests, 20 browser assertions. Coverage 92.0%, floor 87%. `-check` on `example/`, `demo/config` and the new fixture all exit 0 with no new warnings.

## Deliberately not in this PR

`lang`/`dir` around fallback text, which needs `LString.Get` to report which locale it returned and touches every call site. ETag not varied by encoding. COOP and CORP on the outer mux under `-base-path`. Dotfiles served under `-assets`. Each has its reason recorded.
