### PR TITLE
Refuse every scheme cairn cannot emit, and make footer entries whole

### DIFF
--- a/docs/configuration/site.md
+++ b/docs/configuration/site.md
@@ -150,47 +150,67 @@ More on the sub-path in [Reverse proxies](../deployment/reverse-proxies.md#under
 
 ## Links a browser will not follow
 
-`javascript:`, `vbscript:` and `data:` are a config error in every field of
-this file that holds a link: `logo`, `favicon`, the `url` and `icon` of a
-`links` or `footer` entry, and the three `security` fields.
+Every field of this file that becomes a link accepts `https://`, `http://`, an
+absolute path, and for `links` and `footer` entries `mailto:`. Anything else is
+a config error:
 
 ```console
-config: site.yaml: footer url "javascript:alert(1)" uses the javascript: scheme; cairn refuses javascript:, vbscript: and data: wherever a link goes (expected https://…, mailto:… or an absolute path)
+config: site.yaml: footer url "tel:+33123456789" uses the tel: scheme, which cairn does not emit: the link would render dead and nothing would say why (expected https://…, mailto:… or an absolute path)
 ```
 
-The first two run code. `data:` is refused with them because `data:text/html`
-carries a whole document, script and all, and because a list of two invites the
-next reader to assume the third was weighed and kept. It costs nothing: an
-inline `data:` favicon has never once reached a browser from cairn, for the
-reason below.
+That list is not a matter of taste. `html/template`, which writes every page,
+puts exactly those schemes in an `href` or a `src` and replaces every other one
+with a placeholder that goes nowhere. So a `tel:` link and a `javascript:` link
+fail in precisely the same way, and always have: the link renders in the footer
+of every page, it looks live, clicking it does nothing, and no log line
+anywhere mentions it. The only difference between the two is intent.
 
-The rest of the file was already answered: a service `url` has to be a URL or
-a path, an unknown `links` icon is met with the list of glyphs. These fields
-are the ones where nothing else would have spoken. A header link takes
-`mailto:` besides `https://`, and `security.contact` takes any URI at all,
-which is what [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) asks of it;
-`logo` and `favicon` are checked by nothing at boot, since a missing file there
-is a plausible typo and earns a `cairn -check` warning rather than a refusal.
+This is why the rule is a list of what is accepted rather than a list of what
+is dangerous. A list of dangerous schemes is only ever as current as the last
+time somebody thought about it, and the question that decides this one is not
+which schemes are hostile but which ones cairn can actually write.
 
-What the refusal buys is an error instead of a silence. Nothing here would have
-run: `html/template` emits only `http`, `https`, `mailto` and paths, and
-replaces every other scheme with a dead placeholder, so the link renders in the
-header of every page and goes nowhere, with nothing in the log to say why. The
-favicon is the sharper case, since it reaches the web manifest as JSON, which
-template escaping does not cover, and comes back from `/favicon.ico` as a
-`Location` header.
+**If you were linking a phone number**, put it in the label and point the link
+at a page: `{label: "Support: +33 1 23 45 67 89", url: /contact}`. A hosted page
+is one entry in `pages`.
 
-That same rule is worth knowing for its own sake: a `tel:` link is blanked
-exactly like these three. It is not refused, because it is nobody's attack and
-refusing it would stop a site from loading over a link that merely does
-nothing, but it will not work either. Write the number in the label and point
-the link at a page.
+The rest of the file was already answered elsewhere: a service `url` has to be
+a URL or a path, an unknown `links` icon is met with the list of glyphs. These
+fields are the ones where nothing else would have spoken. `logo` and `favicon`
+are still checked by nothing at boot beyond their scheme, since a missing file
+there is a plausible typo and earns a `cairn -check` warning rather than a
+refusal.
+
+The favicon is the sharpest of them, and the reason this is an error rather
+than a warning: it is the one value that escapes the template entirely, since
+it reaches the web manifest as JSON, which no template escaping covers, and
+comes back from `/favicon.ico` as a `Location` header.
+
+`security.contact`, `security.policy` and `security.encryption` are the
+exception, and they keep `tel:`. That file is plain text rather than markup, so
+nothing blanks anything on the way out, and
+[RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) names `tel:` itself. Only
+`javascript:`, `vbscript:` and `data:` are refused there, on the grounds that
+no researcher can act on one.
 
 The value is read the way a browser reads it, not the way it is written: a
 browser drops tabs and newlines from a URL and strips leading control
 characters before it looks at the scheme. `JavaScript:`, a leading space and a
 tab inside the word are all the same URL as the plain one, so they all get the
 same answer.
+
+## Every footer entry needs a label and a url
+
+`footer` now asks for both, which `links` has always done:
+
+```console
+config: site.yaml: every footer entry needs label and url (expected: - {label: Legal, url: /legal})
+```
+
+An entry missing its `url` used to render an empty `href`, which is a link that
+looks live and silently reloads the page the visitor is already on. One missing
+its `label` rendered as nothing visible at all: an anchor with no text, which a
+screen reader announces as a link and reads out its address.
 
 ## The icon set
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -48,7 +48,7 @@ logs the same error.
 | `theme.accent`        | `#247b7b`      | hex color                                                                                                                                                                                                          |
 | `about`               | empty          | dismissable welcome note under the hero, long text ([markdown subset](configuration/text.md))                                                                                                                      |
 | `links`               | `[]`           | header nav links, list of `{label: text, url: string, icon: [glyph](configuration/site.md#header-links)/URL/path}`                                                                                                 |
-| `footer`              | `[]`           | list of `{label: text, url: string}`                                                                                                                                                                               |
+| `footer`              | `[]`           | list of `{label: text, url: string}`; both required, as in `links`                                                                                                                                                 |
 | `pages`               | `[]`           | [hosted pages](configuration/site.md#hosted-pages): `{id: slug, title: text, body: long text, sections: [{title, body}]}`; body and/or sections required; bodies take the [markdown subset](configuration/text.md) |
 | `credit`              | `true`         | bool; `false` removes the footer "powered by cairn"                                                                                                                                                                |
 | `show_version`        | `false`        | bool; `true` shows the running version next to the credit, linked to its release or commit                                                                                                                         |
@@ -67,11 +67,12 @@ the kind of entry that refused the key and lists what that entry accepts, so
 a misspelt `show_versions` is answered with `show_version` rather than with
 the keys of some other part of the file.
 
-`javascript:`, `vbscript:` and `data:` are refused in every field above that
-holds a link: `logo`, `favicon`, the `url` and `icon` of a `links` or `footer`
-entry, and the three `security` fields. Those are the ones no other rule
-answers, either because they take a scheme cairn cannot enumerate (`mailto:`)
-or because a bad value there was only ever a `-check` warning. See
+Every field above that becomes a link takes `https://`, `http://`, an absolute
+path, and for `links` and `footer` entries `mailto:`. Every other scheme is
+refused, `tel:` included: `html/template` writes only those in an `href`, and
+replaces anything else with a placeholder that goes nowhere, so the link would
+render dead with nothing in the log to say why. `security.*` is the exception
+and keeps `tel:`, because that file is plain text rather than markup. See
 [Links a browser will not follow](configuration/site.md#links-a-browser-will-not-follow).
 
 ## `categories.yaml`

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 )
@@ -43,8 +44,8 @@ func validateSite(site *Site, definedIn map[string]string) error {
 		{"logo", site.Logo},
 		{"favicon", site.Favicon},
 	} {
-		if sc := unsafeScheme(f.val); sc != "" {
-			return unsafeSchemeErr(f.key, f.val, sc, "https://… or an /assets path")
+		if err := checkLinkScheme(f.key, f.val, imageSchemes, "https://… or an /assets path"); err != nil {
+			return err
 		}
 	}
 	// security.txt is a line-based format, so a newline in any value would let
@@ -63,9 +64,11 @@ func validateSite(site *Site, definedIn map[string]string) error {
 		// uriRe takes any scheme, because security.txt takes mailto:, https:
 		// and tel: alike, so it is the one URL check here that an executable
 		// scheme walks straight through. Catch it before uriRe has a chance to
-		// bless it, or the researcher this file is written for gets a dead link.
-		if sc := unsafeScheme(f.val); sc != "" {
-			return unsafeSchemeErr(f.key, f.val, sc, "e.g. mailto:security@example.org or https://example.org/security")
+		// bless it, or the researcher this file is written for gets a dead
+		// link. tel: stays legal here and nowhere else: this file is plain
+		// text, so nothing blanks it, and RFC 9116 names it.
+		if err := checkContactScheme(f.key, f.val); err != nil {
+			return err
 		}
 		if !uriRe.MatchString(f.val) {
 			return fmt.Errorf("config: site.yaml: %s %q is not a URI (expected e.g. mailto:security@example.org or https://example.org/security)", f.key, f.val)
@@ -93,31 +96,34 @@ func validateSite(site *Site, definedIn map[string]string) error {
 		if len(l.Label) == 0 || l.URL == "" {
 			return fmt.Errorf("config: site.yaml: every links entry needs label and url (expected: - {label: Wiki, url: https://…})")
 		}
-		// A link url is the one field here that takes any scheme at all, since
-		// mailto: is a legitimate target, so nothing else would stop this one.
-		// html/template blanks the href, which means the header link renders
-		// and goes nowhere with no error anywhere.
-		if sc := unsafeScheme(l.URL); sc != "" {
-			return unsafeSchemeErr("links url", l.URL, sc, "https://…, mailto:… or an absolute path")
+		// mailto: is a legitimate target here, which is why this field gets the
+		// link list rather than the image one.
+		if err := checkLinkScheme("links url", l.URL, linkSchemes, "https://…, mailto:… or an absolute path"); err != nil {
+			return err
 		}
 		if ic := l.Icon; ic != "" && !IsURLOrAbs(ic) {
-			// An executable scheme lands here too: it is not a URL, not an /assets
-			// path and not a glyph name, so this refusal already covers it and
-			// a second gate would only say the same thing twice.
+			// Any scheme at all lands here: it is not a URL, not an /assets path
+			// and not a glyph name, so this refusal already covers the ones
+			// above and a second gate would only say the same thing twice.
 			if _, ok := Glyphs[ic]; !ok {
 				return fmt.Errorf("config: site.yaml: links icon %q is not a built-in glyph (%s), a URL or an /assets path", ic, strings.Join(GlyphNames(), ", "))
 			}
 		}
 	}
-	// Footer entries are validated nowhere else: they carry no icon on the page
-	// and no rule ever asked what their url was. That silence is exactly why an
-	// executable scheme has to be caught here rather than left to the reader.
+	// Footer entries used to be validated nowhere at all: an entry with no url
+	// rendered an empty href, which is a footer link that looks live and
+	// reloads the page, and one with no label rendered as nothing visible at
+	// all. links has always demanded both, and there was never a reason for
+	// the two lists to disagree.
 	for _, l := range site.Footer {
-		if sc := unsafeScheme(l.URL); sc != "" {
-			return unsafeSchemeErr("footer url", l.URL, sc, "https://…, mailto:… or an absolute path")
+		if len(l.Label) == 0 || l.URL == "" {
+			return fmt.Errorf("config: site.yaml: every footer entry needs label and url (expected: - {label: Legal, url: /legal})")
 		}
-		if sc := unsafeScheme(l.Icon); sc != "" {
-			return unsafeSchemeErr("footer icon", l.Icon, sc, "a built-in glyph name, https://… or an /assets path")
+		if err := checkLinkScheme("footer url", l.URL, linkSchemes, "https://…, mailto:… or an absolute path"); err != nil {
+			return err
+		}
+		if err := checkLinkScheme("footer icon", l.Icon, imageSchemes, "a built-in glyph name, https://… or an /assets path"); err != nil {
+			return err
 		}
 	}
 	for i, ic := range site.Icons {
@@ -162,45 +168,72 @@ func validateSite(site *Site, definedIn map[string]string) error {
 	return nil
 }
 
-// unsafeSchemes are the three a browser can be talked into executing, so they
-// are the three no field of this file may carry.
+// The schemes cairn will actually emit. html/template puts http, https,
+// mailto and paths in an href or a src, and replaces every other scheme with
+// #ZgotmplZ, so a value carrying one renders as a link that goes nowhere and
+// says nothing. tel: fails exactly the way javascript: does, and just as
+// quietly; the only difference between them is intent.
 //
-// javascript: and vbscript: run code outright. data: is here because
-// data:text/html carries a whole document, script and all, and because a list
-// of two invites the next reader to assume the third was weighed and kept. It
-// costs nothing to refuse: html/template emits only http, https, mailto and
-// paths, and replaces every other scheme with #ZgotmplZ, so a data: favicon
-// has never once reached a browser from cairn.
-var unsafeSchemes = []string{"javascript", "vbscript", "data"}
+// An allow-list rather than a list of the dangerous ones. A deny-list is only
+// as current as the last time somebody thought about it, and the question that
+// decides this is not which schemes are hostile but which ones cairn can emit.
+var (
+	linkSchemes = []string{"http", "https", "mailto"}
+	// An image is a file, so mailto: has no business naming one.
+	imageSchemes = []string{"http", "https"}
+	// security.txt is the exception, and the reason the allow-list above is
+	// scoped to links rather than applied to the whole file: that file is
+	// plain text, never markup, so nothing blanks anything on the way out and
+	// RFC 9116 names tel: itself. Only the schemes a browser can be talked
+	// into executing are refused there, and data: is among them because
+	// data:text/html carries a whole document, script and all.
+	unsafeSchemes = []string{"javascript", "vbscript", "data"}
+)
 
-// unsafeScheme names the one s carries, or "" when it carries none.
+// urlScheme returns the scheme a browser would read from s, lowercased, and ""
+// when there is none, which is every relative and root-absolute path.
 //
-// The dressing is the whole point. A browser removes every tab, newline and
-// carriage return from a URL and strips leading control characters and spaces
-// before it looks at the scheme, so "java\tscript:alert(1)", " javascript:…"
-// and "JavaScript:…" are all the same URL as the plain one. Matching the
-// literal text would refuse the obvious spelling and pass the three that
-// matter, which is worse than not checking: it reads as a check that works.
-func unsafeScheme(s string) string {
+// It reads the value the way a browser does rather than the way it is written.
+// A browser removes every tab, newline and carriage return from a URL and
+// strips leading control characters and spaces before it looks at the scheme,
+// so "java\tscript:alert(1)", " javascript:…" and "JavaScript:…" are all the
+// same URL as the plain one. Matching the literal text would refuse the
+// obvious spelling and pass the three that matter, which is worse than not
+// checking: it reads as a check that works.
+func urlScheme(s string) string {
 	s = strings.Map(func(r rune) rune {
 		if r == '\t' || r == '\n' || r == '\r' {
 			return -1
 		}
 		return r
 	}, s)
-	s = strings.ToLower(strings.TrimLeftFunc(s, func(r rune) bool { return r <= ' ' }))
-	for _, sc := range unsafeSchemes {
-		if strings.HasPrefix(s, sc+":") {
-			return sc
-		}
+	s = strings.TrimLeftFunc(s, func(r rune) bool { return r <= ' ' })
+	i := strings.IndexByte(s, ':')
+	// A colon past a slash, a question mark or a hash belongs to the path or
+	// the query: "/assets/a:b.png" is a path and always was.
+	if i < 0 || strings.ContainsAny(s[:i], "/?#") {
+		return ""
 	}
-	return ""
+	return strings.ToLower(s[:i])
 }
 
-// unsafeSchemeErr words the refusal once for every field that can carry one,
-// so an operator who trips it twice can tell it is one rule and not two. It
-// names the scheme it found as well as the rule, because the three spellings
-// that reach here look nothing like each other.
-func unsafeSchemeErr(field, val, scheme, accepted string) error {
-	return fmt.Errorf("config: site.yaml: %s %q uses the %s: scheme; cairn refuses javascript:, vbscript: and data: wherever a link goes (expected %s)", field, val, scheme, accepted)
+// checkLinkScheme refuses a value cairn cannot put in an href or a src.
+//
+// It is an error rather than a warning because the alternative is what this
+// replaces: the page renders, the link is there, it does nothing when clicked,
+// and no log line anywhere mentions it.
+func checkLinkScheme(field, val string, allowed []string, accepted string) error {
+	sc := urlScheme(val)
+	if sc == "" || slices.Contains(allowed, sc) {
+		return nil
+	}
+	return fmt.Errorf("config: site.yaml: %s %q uses the %s: scheme, which cairn does not emit: the link would render dead and nothing would say why (expected %s)", field, val, sc, accepted)
+}
+
+// checkContactScheme is the security.txt half: any URI but an executable one.
+func checkContactScheme(field, val string) error {
+	if sc := urlScheme(val); slices.Contains(unsafeSchemes, sc) {
+		return fmt.Errorf("config: site.yaml: %s %q uses the %s: scheme, which no researcher can act on (expected e.g. mailto:security@example.org, https://example.org/security or tel:+33…)", field, val, sc)
+	}
+	return nil
 }

--- a/src/internal/config/validate_test.go
+++ b/src/internal/config/validate_test.go
@@ -147,6 +147,16 @@ func TestValidateSiteRejections(t *testing.T) {
 		// executable scheme outright instead of merely failing to look.
 		{"security contact that is a script url", func(s *Site) { s.Security.Contact = "javascript:alert(1)" },
 			[]string{"security.contact", `"javascript:alert(1)"`, "mailto:"}},
+		// footer entries were validated nowhere at all. An entry with no url
+		// renders an empty href, which is a footer link that looks live and
+		// silently reloads the page; one with no label renders as nothing
+		// visible. links has always demanded both.
+		{"footer entry with no url", func(s *Site) {
+			s.Footer = []FooterLink{{Label: LString{"": "Legal"}}}
+		}, []string{"every footer entry needs label and url"}},
+		{"footer entry with no label", func(s *Site) {
+			s.Footer = []FooterLink{{URL: "/legal"}}
+		}, []string{"every footer entry needs label and url"}},
 	} {
 		t.Run(c.name, func(t *testing.T) {
 			s := base()
@@ -239,11 +249,11 @@ func TestValidateSiteNormalizes(t *testing.T) {
 
 // The plain spelling is the one nobody writes. A browser deletes every tab,
 // newline and carriage return from a URL and strips the leading control
-// characters and spaces before it reads the scheme, so all of the first group
-// are one URL as far as it is concerned. A literal prefix test would refuse
-// the obvious one and wave the rest through, which is worse than no check: it
-// reads like a check that works.
-func TestUnsafeSchemeSeesThroughTheDressing(t *testing.T) {
+// characters and spaces before it reads the scheme, so every dressed spelling
+// below is one URL as far as it is concerned. A literal prefix test would
+// refuse the obvious one and wave the rest through, which is worse than no
+// check: it reads like a check that works.
+func TestURLSchemeReadsWhatABrowserReads(t *testing.T) {
 	for _, c := range []struct {
 		name string
 		val  string
@@ -257,27 +267,70 @@ func TestUnsafeSchemeSeesThroughTheDressing(t *testing.T) {
 		{"led by spaces", "  javascript:alert(1)", "javascript"},
 		{"led by a control character", "\x01javascript:alert(1)", "javascript"},
 		{"vbscript, the same trick", "VB\tScript:msgbox(1)", "vbscript"},
-		// data: is the third because data:text/html is a document with script
-		// in it. The dressing works on it just the same.
 		{"a data document", "data:text/html,<script>alert(1)</script>", "data"},
-		{"a data image, refused all the same", "data:image/svg+xml,<svg/>", "data"},
 		{"data, dressed", " Da\tta:text/html,x", "data"},
-		// The look-alikes. Refusing one of these would be the worse failure of
-		// the two: a config that booted yesterday stops booting on an upgrade,
-		// and the operator is told their perfectly good path runs code.
-		{"a file whose name contains the word", "/assets/javascript-logo.png", ""},
-		{"a mailbox that contains the word", "mailto:javascript@example.org", ""},
-		{"a url whose path contains it", "https://example.org/javascript:alert(1)", ""},
-		{"a file whose name starts with the third word", "/assets/database.png", ""},
-		{"a host that starts with it", "https://data.example.org/logo.png", ""},
-		{"an ordinary asset path", "/assets/logo.png", ""},
+		{"the one this rule was tightened for", "tel:+33123456789", "tel"},
+		// The schemes cairn does emit read the same way; the allow-list, not
+		// this function, is what decides.
+		{"https", "https://tools.example.org", "https"},
+		{"mailto", "mailto:hi@example.org", "mailto"},
+		// A path has no scheme, and neither has a colon that arrives after the
+		// path has started. Reading one of these as a scheme would refuse a
+		// config that has always been legal and tell the operator their file
+		// name is a protocol.
+		{"a root-absolute path", "/assets/logo.png", ""},
+		{"a path whose name contains a colon", "/assets/a:b.png", ""},
+		{"a bare file name", "logo.png", ""},
+		{"a url whose path contains a scheme", "https://example.org/javascript:alert(1)", "https"},
+		{"a query that contains one", "https://example.org/?to=mailto:x@y.org", "https"},
+		{"a fragment that contains one", "/legal#tel:0", ""},
 		{"nothing at all", "", ""},
 	} {
 		t.Run(c.name, func(t *testing.T) {
-			if got := unsafeScheme(c.val); got != c.want {
-				t.Errorf("unsafeScheme(%q) = %q, want %q", c.val, got, c.want)
+			if got := urlScheme(c.val); got != c.want {
+				t.Errorf("urlScheme(%q) = %q, want %q", c.val, got, c.want)
 			}
 		})
+	}
+}
+
+// tel: is the case that made this an allow-list rather than a list of the
+// dangerous ones. It is nobody's attack, and it has never worked: html/template
+// blanks it into a dead link exactly the way it blanks javascript:. The one
+// field that keeps it is security.txt, which is plain text rather than markup,
+// so nothing blanks anything and RFC 9116 names tel: itself.
+func TestTelIsRefusedInLinksAndKeptInSecurityTxt(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		mut  func(*Site)
+	}{
+		{"a header link", func(s *Site) {
+			s.Links = []FooterLink{{Label: LString{"": "Call"}, URL: "tel:+33123456789"}}
+		}},
+		{"a footer link", func(s *Site) {
+			s.Footer = []FooterLink{{Label: LString{"": "Call"}, URL: "tel:+33123456789"}}
+		}},
+		{"a logo", func(s *Site) { s.Logo = "tel:+33123456789" }},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			s := &Site{Locales: []string{"en"}}
+			s.Theme.Accent = "#247b7b"
+			c.mut(s)
+			err := validateSite(s, map[string]string{})
+			if err == nil {
+				t.Fatal("a tel: link was accepted, and it would have rendered dead")
+			}
+			if !strings.Contains(err.Error(), "tel: scheme") {
+				t.Errorf("message %q does not name the scheme", err)
+			}
+		})
+	}
+
+	s := &Site{Locales: []string{"en"}}
+	s.Theme.Accent = "#247b7b"
+	s.Security.Contact = "tel:+33123456789"
+	if err := validateSite(s, map[string]string{}); err != nil {
+		t.Errorf("security.contact refused a scheme RFC 9116 names: %v", err)
 	}
 }
 


### PR DESCRIPTION
Two tightenings, both of which refuse configurations that load today. That is the point of each: they replace a silence with an error.

## `tel:` is gone, because it never worked

`html/template` writes exactly `http`, `https`, `mailto` and paths into an `href` or a `src`, and replaces every other scheme with a placeholder that goes nowhere. A `tel:` footer link therefore renders, looks live, does nothing when clicked, and no log line anywhere mentions it. It failed in precisely the way `javascript:` failed. The only difference between the two was intent.

Checked rather than assumed:

```
<a href="https://a.example.org">   <- https://a.example.org
<a href="mailto:a@b.org">          <- mailto:a@b.org
<a href="#ZgotmplZ">               <- tel:+33123456789
<a href="#ZgotmplZ">               <- data:image/svg+xml,<svg/>
<a href="#ZgotmplZ">               <- javascript:alert(1)
```

So the rule is now a list of what cairn accepts rather than a list of what is dangerous. A deny-list is only as current as the last time somebody thought about it, and the question that decides this one is not which schemes are hostile but which ones cairn can actually write. Links take http, https, mailto and paths; images drop `mailto:`, which names a person and not a file.

`security.contact`, `security.policy` and `security.encryption` keep `tel:`, and they are the reason the allow-list is scoped to links instead of applied to the whole file. `/.well-known/security.txt` is plain text rather than markup, so nothing blanks anything on the way out, and [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) names `tel:` itself. Only `javascript:`, `vbscript:` and `data:` are refused there, on the grounds that no researcher can act on one.

Operators who were linking a phone number are told what to write instead: the number in the label, the link at a hosted page.

## `footer` entries need a label and a url

`links` has always demanded both. An entry missing its `url` rendered an empty `href`, which is a link that looks live and silently reloads the page the visitor is already on. One missing its `label` rendered as an anchor with no text, which a screen reader announces as a link and then reads out its address.

`schema/site.json` has listed both as required all along, so this is the loader catching up with what the editor already told people.

## Verification

Every new rule proven red before the fix, by patching it out:

- `tel:` allowed again in `linkSchemes` and `imageSchemes`: three subtests fail with "a tel: link was accepted, and it would have rendered dead".
- the footer requirement removed: "accepted a config that should have been refused", twice.

`gofmt`, `go vet`, `golangci-lint` clean. 332 tests, coverage 92.1%. `-check` on `example/`, `demo/config` and the browser fixture all exit 0, unchanged.

## For the release notes

Both refusals can stop a config that boots today. cairn does not exit on a bad config: a fresh start serves the getting-started page with the reason logged, and a reload keeps the previous pages. Still worth saying out loud when this ships.
