### PR TITLE
Refuse a footer icon instead of accepting and dropping it

### DIFF
--- a/docs/configuration/site.md
+++ b/docs/configuration/site.md
@@ -199,9 +199,9 @@ characters before it looks at the scheme. `JavaScript:`, a leading space and a
 tab inside the word are all the same URL as the plain one, so they all get the
 same answer.
 
-## Every footer entry needs a label and a url
+## A footer entry is a label and a url, and only those
 
-`footer` now asks for both, which `links` has always done:
+Both are now required, which `links` has always done:
 
 ```console
 config: site.yaml: every footer entry needs label and url (expected: - {label: Legal, url: /legal})
@@ -211,6 +211,19 @@ An entry missing its `url` used to render an empty `href`, which is a link that
 looks live and silently reloads the page the visitor is already on. One missing
 its `label` rendered as nothing visible at all: an anchor with no text, which a
 screen reader announces as a link and reads out its address.
+
+`icon` is a `links` key and a footer entry carrying one is refused:
+
+```console
+config: site.yaml: footer entry "https://status.example.org" has an icon: only header links render one (move the entry to links, or drop the icon)
+```
+
+The footer is a row of plain text links by design, so the key was accepted and
+then dropped, and `cairn -check` reported it as doing nothing. Meanwhile
+`schema/site.json` had never listed it, so an editor with the schema wired up
+underlined the key while cairn started happily. Refusing it is what makes the
+two agree, and the message says the useful half: there is a list where the icon
+does work.
 
 ## The icon set
 

--- a/src/internal/check/check.go
+++ b/src/internal/check/check.go
@@ -593,12 +593,8 @@ func inertSettings(cfg *config.Config) []string {
 		}
 	}
 
-	// The struct says icon is for header links; footer entries take it without
-	// complaint and it is never rendered.
-	for _, l := range cfg.Site.Footer {
-		if l.Icon != "" {
-			out = append(out, fmt.Sprintf("footer entry %q has an icon: only header links render one, so it is dropped", l.URL))
-		}
-	}
+	// A footer icon used to be reported here. It is a load error now: the key
+	// never rendered and schema/site.json never listed it, so a warning about a
+	// value that cannot exist is one more line to read past.
 	return out
 }

--- a/src/internal/check/check_test.go
+++ b/src/internal/check/check_test.go
@@ -441,9 +441,6 @@ func TestCheckNamesSettingsThatDoNothing(t *testing.T) {
 		{"an icons list that drops the install pair",
 			"locales: [en]\nindex: false\nicons: [{src: /assets/a.png, sizes: 180x180}]\n",
 			"stop offering to install"},
-		{"an icon on a footer entry",
-			"locales: [en]\nindex: false\nfooter: [{label: C, url: https://c.example.org, icon: mail}]\n",
-			"only header links render one"},
 	} {
 		t.Run(c.name, func(t *testing.T) {
 			dir := testutil.WriteFiles(t, map[string]string{

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -67,7 +67,7 @@ func (l LString) Get(locale, fallback string) string {
 type FooterLink struct {
 	Label LString `yaml:"label"`
 	URL   string  `yaml:"url"`
-	Icon  string  `yaml:"icon"` // header links only: a built-in glyph name, URL or /assets path
+	Icon  string  `yaml:"icon"` // links only: a built-in glyph name, URL or /assets path; a footer entry carrying one is refused
 }
 
 // SitePage is a page cairn serves itself (legal notice, privacy…), linked

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -119,10 +119,15 @@ func validateSite(site *Site, definedIn map[string]string) error {
 		if len(l.Label) == 0 || l.URL == "" {
 			return fmt.Errorf("config: site.yaml: every footer entry needs label and url (expected: - {label: Legal, url: /legal})")
 		}
-		if err := checkLinkScheme("footer url", l.URL, linkSchemes, "https://…, mailto:… or an absolute path"); err != nil {
-			return err
+		// icon is a header-link key. A footer entry took it without complaint
+		// and never rendered it, which -check reported as inert; schema/site.json
+		// has never listed it at all, so the editor said one thing and the
+		// loader another. Refusing it is what makes those two agree, and it says
+		// the useful half out loud: there is a list where the icon does work.
+		if l.Icon != "" {
+			return fmt.Errorf("config: site.yaml: footer entry %q has an icon: only header links render one (move the entry to links, or drop the icon)", l.URL)
 		}
-		if err := checkLinkScheme("footer icon", l.Icon, imageSchemes, "a built-in glyph name, https://… or an /assets path"); err != nil {
+		if err := checkLinkScheme("footer url", l.URL, linkSchemes, "https://…, mailto:… or an absolute path"); err != nil {
 			return err
 		}
 	}

--- a/src/internal/config/validate_test.go
+++ b/src/internal/config/validate_test.go
@@ -139,9 +139,16 @@ func TestValidateSiteRejections(t *testing.T) {
 		{"footer url that is a script url", func(s *Site) {
 			s.Footer = []FooterLink{{Label: LString{"": "Legal"}, URL: "javascript:alert(1)"}}
 		}, []string{"footer url", `"javascript:alert(1)"`}},
-		{"footer icon that is a script url", func(s *Site) {
+		// icon is a links key. A footer entry accepted it and never rendered
+		// it, and schema/site.json has never listed it, so the editor refused
+		// what the loader waved through. The value does not matter: any icon
+		// at all is refused, hostile or not, because none of them render.
+		{"footer entry with an icon", func(s *Site) {
+			s.Footer = []FooterLink{{Label: LString{"": "Legal"}, URL: "https://e.example.org", Icon: "mail"}}
+		}, []string{"footer entry", "has an icon", "move the entry to links"}},
+		{"footer entry with a hostile icon, refused by the same rule", func(s *Site) {
 			s.Footer = []FooterLink{{Label: LString{"": "Legal"}, URL: "https://e.example.org", Icon: "javascript:alert(1)"}}
-		}, []string{"footer icon", `"javascript:alert(1)"`, "glyph"}},
+		}, []string{"footer entry", "has an icon"}},
 		// uriRe accepts any scheme, because security.txt takes mailto:, https:
 		// and tel: alike, so this is the one URL field that blessed an
 		// executable scheme outright instead of merely failing to look.


### PR DESCRIPTION
The last disagreement between `schema/site.json` and the loader.

`icon` has never been listed among a footer entry's keys in the schema, so an editor with the schema wired up underlined it in red. cairn meanwhile accepted it, dropped it, and `-check` reported it as inert. Three components, two answers, and the one an operator sees first was the one that said the key was fine.

The footer is a row of plain text links by design, so the key never had a meaning there. It is a load error now:

```console
config: site.yaml: footer entry "https://status.example.org" has an icon: only header links render one (move the entry to links, or drop the icon)
```

The message points at the list where an icon does work rather than just saying no.

The `-check` warning goes with it. A warning about a configuration that no longer loads is one more line to read past, and thinning that output is the whole reason the other warnings are worth reading.

## Verification

Proven red by removing the rule: both new subtests fail with "accepted a config that should have been refused", including the hostile-value case, which is now caught by the same rule rather than by the scheme check.

`gofmt`, `go vet`, `golangci-lint` clean. 332 tests, coverage 92.1%. `-check` on `example/`, `demo/config` and the browser fixture all exit 0, unchanged.

## For the release notes

Like the two refusals in #22, this can stop a config that boots today. Anyone it affects was already being told by `-check` that the key does nothing.
