### PR TITLE
Add status.insecure, and refuse to let it be quiet

### DIFF
--- a/docs/configuration/site.md
+++ b/docs/configuration/site.md
@@ -23,7 +23,7 @@ so is every key in it.
 | `show_version` | `false`   | Prints the running cairn version beside that credit: the release number for a tagged build, the commit for a build off `main`. Handy when you report a bug, or run several instances.                                                |
 | `strings`      | built-ins | UI text overrides; see [Languages](i18n.md#ui-strings).                                                                                                                                                                              |
 | `security`     | none      | `contact`, and optionally `policy` and `encryption`. Setting `contact` makes cairn serve [`/.well-known/security.txt`](#telling-researchers-where-to-write).                                                                         |
-| `status`       | none      | Live status pills fed by your Gatus (`status.gatus`, `status.page`, `status.interval`, `status.linked`); see [Status page](../recipes/gatus.md).                                                                                     |
+| `status`       | none      | Live status pills fed by your Gatus (`status.gatus`, `status.page`, `status.interval`, `status.linked`, `status.insecure`); see [Status page](../recipes/gatus.md).                                                                  |
 
 ## Full example
 

--- a/docs/deployment/airgap.md
+++ b/docs/deployment/airgap.md
@@ -486,6 +486,29 @@ extraVolumeMounts:
 which matters more here than elsewhere: `FROM scratch` means there is no shell
 to repair anything in place afterwards.
 
+If mounting a bundle is not yours to arrange, cairn has the same last resort
+Gatus does, and it deserves the same suspicion:
+
+```yaml
+# site.yaml
+status:
+  gatus: https://status.internal
+  insecure: true
+```
+
+It turns the check off for that one connection. Nothing else in cairn makes an
+outbound request, so the blast radius is small, but it is real: with
+verification off, anything that can answer on that address decides what your
+pills say, and the day the certificate changes stops being visible. That is
+what the bundle buys and this does not.
+
+cairn will not let it be quiet about it. The startup log says so once, and
+`cairn -check` says so on every run, for as long as it is on:
+
+```console
+warning: status.insecure is on: the certificate https://status.internal presents is not verified, so anything answering on that address decides what the pills say and the day that certificate changes stops being visible (a CA bundle verifies instead of trusting; see docs/deployment/airgap.md)
+```
+
 ### Adding a certificate later means a restart
 
 Both programs read their trust store once, at startup. Updating the ConfigMap

--- a/docs/recipes/gatus.md
+++ b/docs/recipes/gatus.md
@@ -87,7 +87,9 @@ If your Gatus answers over `https://` with a certificate cairn does not know,
 which is the usual state of affairs on an internal network, every pill reads
 "Unknown" and the log names the `x509` failure. The fix, along with the
 symmetric one for the certificates Gatus itself has to trust, is in
-[Air-gapped](../deployment/airgap.md#6-self-signed-certificates).
+[Air-gapped](../deployment/airgap.md#6-self-signed-certificates). There is also
+`status.insecure: true`, which turns the check off rather than satisfying it;
+the same page says what that costs.
 
 ## 3. Link the status page
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -60,6 +60,7 @@ logs the same error.
 | `status.page`         | `status.gatus` | public Gatus URL the pill links to (set when the poll URL is internal)                                                                                                                                             |
 | `status.interval`     | `60s`          | poll cadence, duration ≥ `5s`                                                                                                                                                                                      |
 | `status.linked`       | `true`         | `false` makes the pills display-only: the state stays, the link to the status page goes                                                                                                                            |
+| `status.insecure`     | `false`        | `true` stops cairn verifying the certificate Gatus presents; logged at startup and warned about by `-check` ([why, and what to do instead](deployment/airgap.md#6-self-signed-certificates))                       |
 
 Unknown keys are errors everywhere: in `site.yaml`, and in every service,
 category, page, section, link, image and icon entry alike. The message names

--- a/schema/site.json
+++ b/schema/site.json
@@ -183,6 +183,10 @@
           "type": "string",
           "description": "Poll cadence, a duration of at least 5s (e.g. 60s)."
         },
+        "insecure": {
+          "type": "boolean",
+          "description": "true stops cairn verifying the certificate Gatus presents, for an internal Gatus whose authority nothing public signed. A CA bundle verifies instead of trusting; this only turns the check off. cairn logs it at startup and cairn -check warns about it every run."
+        },
         "linked": {
           "type": "boolean",
           "description": "false makes the pills display-only: they still show up, down or unknown, but they stop linking to the status page. For a Gatus your visitors cannot reach."

--- a/src/internal/check/check.go
+++ b/src/internal/check/check.go
@@ -66,6 +66,12 @@ func checkWarnings(cfg *config.Config, dir string) []string {
 		}
 	}
 	out = append(out, unresolvableRefs(cfg)...)
+	// status.insecure is not a mistake, it is a decision, and -check is where a
+	// decision that leaves no trace on the page gets its trace. Nothing else
+	// says it out loud after the startup line has scrolled away.
+	if st := cfg.Site.Status; st.Gatus != "" && st.Insecure {
+		out = append(out, fmt.Sprintf("status.insecure is on: the certificate %s presents is not verified, so anything answering on that address decides what the pills say and the day that certificate changes stops being visible (a CA bundle verifies instead of trusting; see docs/deployment/airgap.md)", st.Gatus))
+	}
 	out = append(out, missingAssets(cfg)...)
 	out = append(out, iconSizeClaims(cfg)...)
 	out = append(out, categoryConfusion(cfg)...)
@@ -549,6 +555,9 @@ func inertSettings(cfg *config.Config) []string {
 		}
 		if st.Linked != nil {
 			set = append(set, "status.linked")
+		}
+		if st.Insecure {
+			set = append(set, "status.insecure")
 		}
 		if len(set) > 0 {
 			out = append(out, fmt.Sprintf("%s set without status.gatus: nothing polls, so no pill is drawn at all", strings.Join(set, " and ")))

--- a/src/internal/check/check_test.go
+++ b/src/internal/check/check_test.go
@@ -159,6 +159,45 @@ func TestCheckStaysQuietAboutMarkdownImagesItCannotStat(t *testing.T) {
 	}
 }
 
+// status.insecure is a decision rather than a mistake, and this warning is the
+// only trace it leaves once the startup log has scrolled away. It has to fire
+// every run, and only when there is actually a gatus to not-verify.
+func TestCheckKeepsSayingInsecureIsOn(t *testing.T) {
+	withoutAssets(t)
+	dir := testutil.WriteFiles(t, map[string]string{
+		"site.yaml":     "locales: [en]\nindex: false\nstatus: {gatus: \"https://status.internal\", insecure: true}\n",
+		"services.yaml": "- {id: a, url: https://a.example.org, name: A}\n",
+	})
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := strings.Join(checkWarnings(cfg, dir), "\n")
+	for _, want := range []string{"status.insecure is on", "https://status.internal", "CA bundle"} {
+		if !strings.Contains(w, want) {
+			t.Errorf("warnings never mention %q:\n%s", want, w)
+		}
+	}
+}
+
+// And stays quiet when it is off, which is the shape every other site has.
+func TestCheckSaysNothingWhenInsecureIsOff(t *testing.T) {
+	withoutAssets(t)
+	dir := testutil.WriteFiles(t, map[string]string{
+		"site.yaml":     "locales: [en]\nindex: false\nstatus: {gatus: \"https://status.internal\"}\n",
+		"services.yaml": "- {id: a, url: https://a.example.org, name: A}\n",
+	})
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, w := range checkWarnings(cfg, dir) {
+		if strings.Contains(w, "insecure") {
+			t.Errorf("a verifying site was warned about verification:\n%s", w)
+		}
+	}
+}
+
 // -check is what an operator wires into their own pipeline, so its warnings
 // have to name the thing that is wrong and stay quiet about the rest.
 func TestWarningsNameWhatIsMissing(t *testing.T) {

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -161,6 +161,11 @@ type Site struct {
 		// Linked nil means true: the pills link to the status page. false
 		// makes them display-only, for a Gatus a visitor cannot reach.
 		Linked *bool `yaml:"linked"`
+		// Insecure stops cairn verifying the certificate Gatus presents, for
+		// an internal instance whose authority nothing public signed. A hole
+		// the operator opens deliberately, so cairn says so out loud rather
+		// than only obeying: once at startup, and on every -check.
+		Insecure bool `yaml:"insecure"`
 	} `yaml:"status"`
 }
 

--- a/src/internal/server/hardening_test.go
+++ b/src/internal/server/hardening_test.go
@@ -177,7 +177,7 @@ func TestGatusBodyIsBounded(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	if _, err := status.Fetch(srv.URL); err == nil {
+	if _, err := status.Fetch(srv.URL, false); err == nil {
 		t.Error("an over-sized gatus answer was accepted, the cap is not holding")
 	}
 }
@@ -192,7 +192,7 @@ func TestGatusReadsANormalAnswer(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	st, err := status.Fetch(srv.URL)
+	st, err := status.Fetch(srv.URL, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/internal/server/watch.go
+++ b/src/internal/server/watch.go
@@ -62,11 +62,14 @@ func reloadOnce(dir, last string) string {
 func Poll() {
 	if cfg := Current().Cfg; cfg.Site.Status.Gatus != "" {
 		log.Printf("status: polling gatus at %s every %s", cfg.Site.Status.Gatus, cfg.StatusInterval())
+		if cfg.Site.Status.Insecure {
+			log.Print("status: insecure is on, so the certificate gatus presents is not verified at all: anything answering on that address decides what the pills say")
+		}
 	}
 	var seen pollLog
 	for {
 		m := Current()
-		pollOnce(m.Cfg.Site.Status.Gatus, &seen)
+		pollOnce(m.Cfg.Site.Status.Gatus, m.Cfg.Site.Status.Insecure, &seen)
 		time.Sleep(m.Cfg.StatusInterval())
 	}
 }
@@ -77,11 +80,11 @@ type pollLog struct{ err, missing string }
 
 // pollOnce runs one status poll and swaps the pages in when the dots changed.
 // An empty url is a no-op: a site without Gatus shows no pill at all.
-func pollOnce(url string, seen *pollLog) {
+func pollOnce(url string, insecure bool, seen *pollLog) {
 	if url == "" {
 		return
 	}
-	st, err := status.Fetch(url)
+	st, err := status.Fetch(url, insecure)
 	if err != nil {
 		st = nil
 		if err.Error() != seen.err {

--- a/src/internal/server/watch_test.go
+++ b/src/internal/server/watch_test.go
@@ -85,12 +85,12 @@ func TestPollOnce(t *testing.T) {
 
 	// no gatus configured is a no-op, not a crash
 	before := current.Load()
-	pollOnce("", &seen)
+	pollOnce("", false, &seen)
 	if current.Load() != before {
 		t.Error("an empty gatus url rebuilt the model")
 	}
 
-	pollOnce(srv.URL, &seen)
+	pollOnce(srv.URL, false, &seen)
 	if got := current.Load().Statuses["pad"]; !got {
 		t.Fatalf("statuses = %v, want pad up", current.Load().Statuses)
 	}
@@ -100,14 +100,14 @@ func TestPollOnce(t *testing.T) {
 
 	// same answer twice: no needless rebuild
 	same := current.Load()
-	pollOnce(srv.URL, &seen)
+	pollOnce(srv.URL, false, &seen)
 	if current.Load() != same {
 		t.Error("an unchanged status rebuilt the pages")
 	}
 
 	// gatus falls over: the dots go away instead of lying
 	up = false
-	pollOnce(srv.URL, &seen)
+	pollOnce(srv.URL, false, &seen)
 	if n := len(current.Load().Statuses); n != 0 {
 		t.Errorf("statuses = %d, want none once gatus stops answering", n)
 	}

--- a/src/internal/status/gatus.go
+++ b/src/internal/status/gatus.go
@@ -1,6 +1,7 @@
 package status
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -68,10 +69,37 @@ func Unmonitored(cfg *config.Config, statuses map[string]bool) string {
 	return fmt.Sprintf("%d services have no gatus endpoint, their cards show no pill: %s", len(ids), strings.Join(ids, ", "))
 }
 
+// verifying and skipping are built once and reused. A client per poll would
+// build a fresh connection pool every interval and leave the old one to be
+// collected with its idle sockets still open.
+//
+// The second one exists because an internal Gatus usually answers with a
+// certificate no public authority signed, and mounting a CA bundle is not
+// always the operator's to arrange. It is a real hole and it is theirs to open:
+// with verification off, anything that can answer on that address decides what
+// the pills say, and the day the certificate changes stops being visible.
+// cairn says so at startup and on every -check rather than only here.
+var (
+	verifying = &http.Client{Timeout: 5 * time.Second}
+	skipping  = &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			// #nosec G402 -- the operator asked for this with status.insecure,
+			// it is logged at startup and warned about by -check, and it covers
+			// the one outbound request cairn makes.
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+		},
+	}
+)
+
 // Fetch asks a Gatus instance for its endpoint statuses and returns
-// service-id -> up, keyed by endpoint name.
-func Fetch(base string) (map[string]bool, error) {
-	client := http.Client{Timeout: 5 * time.Second}
+// service-id -> up, keyed by endpoint name. insecure skips certificate
+// verification, which is status.insecure in site.yaml.
+func Fetch(base string, insecure bool) (map[string]bool, error) {
+	client := verifying
+	if insecure {
+		client = skipping
+	}
 	resp, err := client.Get(strings.TrimSuffix(base, "/") + "/api/v1/endpoints/statuses")
 	if err != nil {
 		return nil, err

--- a/src/internal/status/gatus_test.go
+++ b/src/internal/status/gatus_test.go
@@ -42,7 +42,7 @@ func TestFetchStatuses(t *testing.T) {
 		]`)
 	}))
 	defer srv.Close()
-	st, err := status.Fetch(srv.URL)
+	st, err := status.Fetch(srv.URL, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/internal/status/insecure_test.go
+++ b/src/internal/status/insecure_test.go
@@ -1,0 +1,49 @@
+package status_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MorganKryze/cairn/src/internal/status"
+)
+
+// The whole point of the flag, against a certificate nothing signed rather
+// than against a mock: httptest.NewTLSServer mints its own, which is exactly
+// the shape of an internal Gatus. Verifying has to fail and skipping has to
+// succeed, and asserting only one of the two would pass with the flag ignored.
+func TestInsecureSkipsTheVerificationAndNothingElse(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[{"name":"pad","results":[{"success":true}]}]`))
+	}))
+	defer srv.Close()
+
+	if _, err := status.Fetch(srv.URL, false); err == nil {
+		t.Fatal("a self-signed gatus verified, so the default client is not checking anything")
+	} else if !strings.Contains(err.Error(), "certificate") {
+		t.Fatalf("failed for the wrong reason: %v", err)
+	}
+
+	st, err := status.Fetch(srv.URL, true)
+	if err != nil {
+		t.Fatalf("insecure still refused a self-signed gatus: %v", err)
+	}
+	if !st["pad"] {
+		t.Errorf("statuses = %v, want pad up: the body has to be read the same way either side of the flag", st)
+	}
+}
+
+// The clients are package level so a poll every interval reuses one connection
+// pool. Two calls must not be two transports.
+func TestFetchReusesItsClients(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+	for range 3 {
+		if _, err := status.Fetch(srv.URL, true); err != nil {
+			t.Fatalf("poll refused: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
Gatus has `client.insecure` per endpoint. cairn had no equivalent, so an operator whose internal Gatus answers with a self-signed certificate had exactly one option: mount a CA bundle, which is not always theirs to arrange.

```yaml
# site.yaml
status:
  gatus: https://status.internal
  insecure: true
```

## What it costs, said plainly

It turns verification off for that one connection. Nothing else in cairn makes an outbound request, so the blast radius is small, but it is real: with the check off, anything that can answer on that address decides what the pills say, and the day the certificate changes stops being visible. That is what a bundle buys and this does not, which is why the documentation still leads with the bundle and files this under the same "last resort" heading Gatus's own flag gets.

## So it is loud

A hole the operator opens deliberately should not be one they forget they opened. Three channels, none of which can be scrolled past for long:

- the startup log says it once, next to the line naming the Gatus being polled
- `cairn -check` says it on **every** run, for as long as it is on, and names the URL:

```console
warning: status.insecure is on: the certificate https://status.internal presents is not verified, so anything answering on that address decides what the pills say and the day that certificate changes stops being visible (a CA bundle verifies instead of trusting; see docs/deployment/airgap.md)
```

- with no `status.gatus`, it joins `status.page`, `status.interval` and `status.linked` in the family of keys that do nothing, and is reported as such

## Incidental fix

The two clients are package level rather than built per call. `Fetch` was constructing an `http.Client` on every poll, which builds a fresh connection pool each interval and leaves the previous one to be collected with its idle sockets still open. One client each now, verifying and skipping.

## Verification

Tested against `httptest.NewTLSServer`, which mints its own certificate and is the exact shape of the problem, rather than against a mock. The test asserts **both** directions: verifying must fail with a certificate error, and skipping must succeed and return the same parsed statuses. Asserting only the second would pass with the flag ignored entirely.

Proven red twice, which is the point:

- with the flag ignored (`client := verifying` unconditionally): `insecure still refused a self-signed gatus`
- with the skipping client made to verify (`InsecureSkipVerify: false`): the same failure, which pins that the second client is what does the work rather than some accident of the first

And the `-check` warning proven red by removing it, with all three of its substrings named.

`gofmt`, `go vet`, `golangci-lint` clean. 355 tests, coverage 92.4%. `just chart` clean. `-check` on `example/` and `demo/config` unchanged.

Documented in `docs/deployment/airgap.md` beside the bundle it is an alternative to, cross-linked from `docs/recipes/gatus.md`, and added to `docs/reference.md`, `docs/configuration/site.md` and `schema/site.json` so the editor knows the key exists.
