### PR TITLE
Read the last two images through the mirror too

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,15 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
+      # buildx pulls its own builder image, and the default comes from Docker
+      # Hub, where an anonymous pull shares one rate limit with every other
+      # GitHub-hosted runner. It does not fail by saying so, it times out: this
+      # step is exactly where the image job of the build on main died after
+      # 1.13.2 shipped. Same mirror the base image and the demo already read
+      # through, and the same object behind it, checked rather than assumed.
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        with:
+          driver-opts: image=mirror.gcr.io/moby/buildkit:buildx-stable-1
 
       # A pull request builds the image but never publishes it, so a fork PR
       # needs no registry credentials.
@@ -168,10 +176,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      # Six images come from Docker Hub anonymously, sharing a rate limit
-      # across the whole runner pool, so a timed-out pull is routine rather
-      # than exceptional. Five tries with a flat 30s gap rides out the usual
-      # outage; the job is deliberately not a required check.
+      # The retry outlived its own reason and kept claiming it: nothing in this
+      # stack comes from Docker Hub any more, the compose file reads ghcr.io
+      # and Google's mirror, and the Dockerfile it builds now does too. It
+      # stays anyway. Six images and a build is a lot of registry to depend on,
+      # a mirror is still a network, and five tries with a flat 30s gap costs
+      # nothing on the runs where nothing goes wrong. The job is deliberately
+      # not a required check.
       - name: bring the demo up (retry past registry hiccups)
         run: |
           for i in 1 2 3 4 5; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,15 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
+      # buildx pulls its own builder image, and the default comes from Docker
+      # Hub, where an anonymous pull shares one rate limit with every other
+      # GitHub-hosted runner. It does not fail by saying so, it times out: this
+      # step is exactly where the image job of the build on main died after
+      # 1.13.2 shipped. Same mirror the base image and the demo already read
+      # through, and the same object behind it, checked rather than assumed.
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        with:
+          driver-opts: image=mirror.gcr.io/moby/buildkit:buildx-stable-1
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 

--- a/demo/compose.yaml
+++ b/demo/compose.yaml
@@ -6,7 +6,9 @@ name: cairn-demo
 # rate limit across the whole CI runner pool, which failed this stack twice in
 # one day. The three project images are their maintainers' own ghcr.io builds;
 # nginx and httpd exist only on Docker Hub, so they come through Google's
-# public mirror, which needs no account.
+# public mirror, which needs no account. The cairn service below is built from
+# docker/Dockerfile, whose base image reads through that same mirror, so this
+# whole stack now comes up without one anonymous Hub pull.
 networks:
   demo:
     internal: true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,19 @@
 # Pinned by digest, like every action in the workflows: the tag alone lets the
 # compiler that produces a released binary change under us between two builds
-# of the same commit. Dependabot watches /docker and moves it.
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS build
+# of the same commit. Dependabot watches /docker and moves it, and it can still
+# read the tag list through the mirror: 1513 tags, 1.26-alpine among them.
+#
+# Read through mirror.gcr.io rather than straight from Docker Hub, for the same
+# reason demo/compose.yaml is: an anonymous Hub pull shares one rate limit with
+# every other GitHub-hosted runner on the planet, and it does not fail by
+# saying so. It times out. That is what took down the image job of the build on
+# main after 1.13.2 shipped.
+#
+# The digest is the same object either way, verified rather than assumed: both
+# registries answer sha256:0178a641… for this reference. A digest is what the
+# content hashes to, so the mirror cannot serve a different image under it; the
+# registry in front is only the road taken to reach it.
+FROM --platform=$BUILDPLATFORM mirror.gcr.io/library/golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS build
 # The scratch image ships no CA bundle, so cairn cannot verify TLS on its own:
 # polling a public https Gatus fails with x509: unknown authority. Copy the
 # bundle in (below); install it here so the build never depends on the base


### PR DESCRIPTION
The demo left Docker Hub after anonymous pulls failed it twice in one day. The
image build never followed, and that is what broke the `image` job of the build
on `main` right after 1.13.2 shipped:

```
#1 ERROR: Error response from daemon: Get "https://registry-1.docker.io/v2/": context deadline exceeded
```

Not a refusal, a timeout, at the `setup-buildx-action` step. An anonymous Hub
pull shares one rate limit with every GitHub-hosted runner on the planet, so
this is routine rather than exceptional. Nothing shipped was affected that day:
that job only writes `:unstable` and the by-sha tag, and the `release` workflow
on the tag succeeded separately.

Two references were still going there:

| where | what | now |
| --- | --- | --- |
| `build.yml`, `release.yml` | `moby/buildkit`, pulled by `setup-buildx-action` | `mirror.gcr.io/moby/buildkit:buildx-stable-1` via `driver-opts` |
| `docker/Dockerfile` | the `golang:1.26-alpine` builder stage | `mirror.gcr.io/library/golang:…` |

## Checked, not assumed

**Same objects.** Both registries answer the same digest for each reference:

```
golang:1.26-alpine   hub sha256:0178a641…   mirror sha256:0178a641…
moby/buildkit        hub sha256:2f5adac4…   mirror sha256:2f5adac4…
```

A digest is what the content hashes to, so a mirror cannot serve something else
under it. The registry in front is only the road taken to reach it.

**Same image out.** Built from the old Dockerfile and the new one, then the
artefacts pulled out of both and compared:

```
binary   93da8e1711e34959  vs  93da8e1711e34959   IDENTICAL
ca store b8d837841b88bfaa  vs  b8d837841b88bfaa   IDENTICAL
```

**buildx really takes it.** A local builder created with the driver-opt, then
asked what it started from:

```
$ docker inspect buildx_buildkit_mirror-probe0 --format '{{.Config.Image}}'
mirror.gcr.io/moby/buildkit:buildx-stable-1
```

**Dependabot keeps working.** This was the one thing that could have made the
change a bad trade: swapping CI flakiness for a base image nobody bumps. It
does not. `dependabot.yml` reads `/docker`, and the mirror serves a tag list of
1513 entries with `1.26-alpine` among them.

## Two comments that had gone stale

The `demo` job's retry loop explained itself with "six images come from Docker
Hub anonymously", which stopped being true when the demo moved. The loop stays,
for the reason it is actually worth keeping, and now says so. `demo/compose.yaml`
gains the other half: with the Dockerfile moved too, the whole stack comes up
without one anonymous Hub pull.

## Not done

The buildkit image is referenced by tag, not digest, which is what it already
was: `setup-buildx-action` picks `buildx-stable-1` when nothing says otherwise.
Pinning it would be more consistent with how every action here is pinned, but it
would also be a digest nothing watches and nobody bumps, so it belongs in its own
change with that argument made properly rather than smuggled into this one.
