### PR TITLE
Pin what a Gatus site renders today, before adding providers beside it

### DIFF
--- a/src/internal/render/golden_test.go
+++ b/src/internal/render/golden_test.go
@@ -1,0 +1,165 @@
+package render
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MorganKryze/cairn/src/internal/config"
+	"github.com/MorganKryze/cairn/src/internal/status"
+	"github.com/MorganKryze/cairn/src/internal/testutil"
+)
+
+// update rewrites the golden files instead of comparing against them:
+//
+//	go test ./src/internal/render -run TestAGatusSiteRendersWhatItAlwaysDid -update
+//
+// Rewriting is the point at which a diff has to be read line by line and
+// justified in the pull request. That is the whole ceremony this file exists
+// to impose, so it is deliberately not automatic.
+var update = flag.Bool("update", false, "rewrite the golden files")
+
+// goldenSite is one site exercising everything a Gatus deployment touches on
+// the way to bytes: two locales so the fallback marking is in play, a service
+// with a detail page, a service Gatus does not monitor, an uncategorised one,
+// a host flag, a footer, a logo, markdown prose, and a status page the pills
+// link to. Anything that changes the shape of a page changes this file.
+const goldenSite = `title: Golden
+tagline:
+  en: Everything that must not move.
+  fr: Tout ce qui ne doit pas bouger.
+locales: [en, fr]
+url: https://golden.example.org
+theme:
+  accent: "#247b7b"
+about:
+  en: |
+    A welcome note, with *emphasis* and a [link](https://example.org).
+show_version: true
+status:
+  gatus: https://status.example.org
+  interval: 30s
+footer:
+  - label: { en: Status, fr: Statut }
+    url: https://status.example.org
+`
+
+const goldenServices = `- id: pdf
+  url: https://pdf.example.org
+  category: documents
+  name: { en: PDF toolbox, fr: Boîte à outils PDF }
+  desc: { en: Merge and split PDFs., fr: Fusionner et découper vos PDF. }
+  selfhosted: true
+  tags: [pdf, convert]
+  details:
+    en: |
+      ## What it does
+
+      1. Drop a file
+      2. Pick an action
+
+      | Format | In | Out |
+      | --- | --- | --- |
+      | pdf | yes | yes |
+- id: pad
+  url: https://pad.example.org
+  category: documents
+  name: Shared notepad
+  desc: Write together.
+- id: wiki
+  url: /wiki
+  name: Wiki
+`
+
+// A Gatus site is what every cairn deployment with status pills runs today.
+// The multi-source work adds providers beside it; this pins that "beside" is
+// what it stays. A byte that moves here is a byte that moved on somebody's
+// running site, and it has to be argued for rather than noticed later.
+func TestAGatusSiteRendersWhatItAlwaysDid(t *testing.T) {
+	prev := Version
+	Version = "1.14.0" // pinned: the footer prints it, and the build stamps it
+	t.Cleanup(func() { Version = prev })
+
+	cfg, err := config.Load(testutil.WriteFiles(t, map[string]string{
+		"site.yaml":     goldenSite,
+		"services.yaml": goldenServices,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Gatus has answered: pdf up, pad down, and it says nothing about wiki,
+	// which is the third of the three states a card can be in.
+	m, err := BuildModel(cfg, map[string]status.State{
+		"pdf": {Up: true, Key: "documents_pdf"},
+		"pad": {Up: false, Key: "documents_pad"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, page := range []string{"en", "fr", "en/pdf", "fr/pdf"} {
+		name := filepath.Join("testdata", "golden", filepath.FromSlash(page)+".html")
+		compare(t, name, m.Pages[page].HTML)
+	}
+	compare(t, filepath.Join("testdata", "golden", "csp.txt"), []byte(BuildCSP(cfg)))
+
+	// And the pill hrefs, called out separately: they are the one thing the
+	// provider work is most likely to move, and a diff in a 30 KB page is easy
+	// to skim past.
+	for _, want := range []string{
+		`href="https://status.example.org/endpoints/documents_pdf"`,
+		`href="https://status.example.org/endpoints/documents_pad"`,
+	} {
+		if !contains(m.Pages["en"].HTML, want) {
+			t.Errorf("the home page no longer carries %s", want)
+		}
+	}
+}
+
+func compare(t *testing.T, name string, got []byte) {
+	t.Helper()
+	if *update {
+		if err := os.MkdirAll(filepath.Dir(name), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(name, got, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("rewrote %s (%d bytes)", name, len(got))
+		return
+	}
+	want, err := os.ReadFile(name) // #nosec G304 -- a path this test built
+	if err != nil {
+		t.Fatalf("%v (run with -update to create it)", err)
+	}
+	if string(got) == string(want) {
+		return
+	}
+	t.Errorf("%s changed: %d bytes now, %d before.\n%s", name, len(got), len(want), firstDiff(want, got))
+}
+
+// firstDiff points at the byte that moved, with a little either side. A
+// unified diff of a whole page buries the one line that matters.
+func firstDiff(want, got []byte) string {
+	i := 0
+	for i < len(want) && i < len(got) && want[i] == got[i] {
+		i++
+	}
+	from := max(0, i-90)
+	return "  before: …" + string(want[from:min(len(want), i+90)]) +
+		"…\n  after:  …" + string(got[from:min(len(got), i+90)]) + "…"
+}
+
+func contains(hay []byte, needle string) bool {
+	return len(needle) <= len(hay) && indexOf(string(hay), needle) >= 0
+}
+
+func indexOf(hay, needle string) int {
+	for i := 0; i+len(needle) <= len(hay); i++ {
+		if hay[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}

--- a/src/internal/render/testdata/golden/csp.txt
+++ b/src/internal/render/testdata/golden/csp.txt
@@ -1,0 +1,1 @@
+default-src 'none'; img-src 'self' https: data:; style-src 'self' 'sha256-oS+1nVCdDv1KLfShDUYMSPLTLLZUgOkyKpL7hUUtrao='; script-src 'self' 'sha256-qabBnlwaeZnbksXMHOKCX32niaC/QZOGphPO3G7ri2Q='; font-src 'self'; manifest-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; connect-src 'self'

--- a/src/internal/render/testdata/golden/en.html
+++ b/src/internal/render/testdata/golden/en.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="en" dir="ltr" data-about="f3ce492b">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<title>Golden</title>
+<meta name="description" content="Everything that must not move.">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Golden">
+<meta property="og:description" content="Everything that must not move.">
+<meta property="og:locale" content="en">
+<link rel="canonical" href="https://golden.example.org/en/">
+<meta property="og:url" content="https://golden.example.org/en/">
+<link rel="alternate" hreflang="en" href="https://golden.example.org/en/">
+<link rel="alternate" hreflang="fr" href="https://golden.example.org/fr/">
+<link rel="alternate" hreflang="x-default" href="https://golden.example.org/">
+
+<link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
+<link rel="icon" href="/static/favicon.ico" sizes="32x32">
+<link rel="apple-touch-icon" href="/static/touch-icon.png">
+<link rel="manifest" href="/manifest.webmanifest">
+
+<link rel="preload" href="/static/fonts/fraunces.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="stylesheet" href="/static/style.css">
+<style>:root{--accent:#247b7b}</style>
+<script>document.documentElement.setAttribute('data-js','');var a=document.cookie.match(/(?:^|; )about=([^;]*)/);if(a&&a[1]===document.documentElement.getAttribute('data-about'))document.documentElement.setAttribute('data-noabout','');try{var t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t)}catch(e){}</script>
+</head>
+<body>
+<a class="skip" href="#main">Skip to content</a>
+<header><div class="wrap topbar">
+  <a class="brand" href="/en/">Golden</a>
+  <div class="topbar-tools">
+    <button class="theme-toggle" id="theme-toggle" hidden aria-label="Theme">
+      <svg class="moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
+      <svg class="sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2m7.07-17.07-1.41 1.41M6.34 17.66l-1.41 1.41M22 12h-2M4 12H2m17.07 7.07-1.41-1.41M6.34 6.34 4.93 4.93"/></svg>
+    </button>
+    <nav class="langs" aria-label="Language">
+      <a href="/en/?choose" aria-current="page">EN</a>
+      <a href="/fr/?choose">FR</a>
+    </nav>
+  </div>
+</div>
+<div class="wrap menu">
+  <div class="search" id="search">
+    <div class="search-box">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.8-3.8"/></svg>
+      <label class="visually-hidden" for="q">Search</label>
+      <input id="q" type="search" placeholder="Search for a tool…" autocomplete="off" enterkeyhint="go" disabled>
+      <kbd class="search-kbd" hidden>⌘K</kbd>
+    </div>
+  </div>
+  </div>
+</header>
+<main id="main"><div class="wrap">
+
+<h1 class="visually-hidden">Golden</h1>
+<p class="tagline">Everything that must not move.</p>
+<section class="about">
+  
+  <button class="about-x" id="about-x" hidden><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12"/></svg><span>Dismiss</span></button>
+  <p>A welcome note, with <em>emphasis</em> and a <a href="https://example.org">link</a>.</p>
+</section>
+<nav class="toc" aria-label="Categories">
+  <ul>
+    <li><a href="#cat-documents"><span class="toc-mark" aria-hidden="true"></span><span class="toc-name">Documents</span></a></li>
+    <li><a href="#cat-other"><span class="toc-mark" aria-hidden="true"></span><span class="toc-name">Other</span></a></li>
+    
+  </ul>
+</nav>
+
+<section class="cat" aria-labelledby="cat-documents">
+  <div class="way">
+    <span class="way-mark" aria-hidden="true"></span>
+    <h2 id="cat-documents" class="way-name">Documents</h2>
+    <span class="way-rule" aria-hidden="true"></span>
+  </div>
+  <ul class="cards">
+    <li class="card" data-tags="pdf convert">
+      <div class="card-main">
+        <span class="tile"><svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg></span>
+        <div class="card-text">
+          <a class="card-name" href="https://pdf.example.org">PDF toolbox</a>
+          
+          <span class="card-desc">Merge and split PDFs. <a class="card-more" href="/en/pdf/">Learn more</a></span>
+          
+        </div>
+      </div>
+      <div class="card-foot"><span class="flag flag-self"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"/><path d="M3 10a2 2 0 0 1 .709-1.528l7-6a2 2 0 0 1 2.582 0l7 6A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg><span class="flag-label">Self-hosted</span></span><span class="status-slot" data-status="pdf"><a class="status-pill status-up" href="https://status.example.org/endpoints/documents_pdf" target="_blank" rel="noopener" aria-label="PDF toolbox, Online, view status"><span class="dot" aria-hidden="true"></span>Online</a></span></div>
+      </li>
+    <li class="card">
+      <div class="card-main">
+        <span class="tile"><svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg></span>
+        <div class="card-text">
+          <a class="card-name" href="https://pad.example.org">Shared notepad</a>
+          
+          <span class="card-desc">Write together.</span>
+          
+        </div>
+      </div>
+      <div class="card-foot"><span class="status-slot" data-status="pad"><a class="status-pill status-down" href="https://status.example.org/endpoints/documents_pad" target="_blank" rel="noopener" aria-label="Shared notepad, Offline, view status"><span class="dot" aria-hidden="true"></span>Offline</a></span></div>
+      </li>
+    
+  </ul>
+</section>
+<section class="cat" aria-labelledby="cat-other">
+  <div class="way">
+    <span class="way-mark" aria-hidden="true"></span>
+    <h2 id="cat-other" class="way-name">Other</h2>
+    <span class="way-rule" aria-hidden="true"></span>
+  </div>
+  <ul class="cards">
+    <li class="card">
+      <div class="card-main">
+        <span class="tile"><svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg></span>
+        <div class="card-text">
+          <a class="card-name" href="/wiki">Wiki</a>
+          
+          
+        </div>
+      </div>
+      <div class="card-foot"><span class="status-slot" data-status="wiki"></span></div>
+      </li>
+    
+  </ul>
+</section>
+<p id="empty" class="empty" role="status" hidden>No results. Try another word.</p>
+<p id="count" class="visually-hidden" role="status" aria-live="polite" data-single="1 result" data-plural="%d results"></p>
+</div></main>
+<footer><div class="wrap foot">
+  <div class="foot-links"><a href="https://status.example.org">Status</a></div>
+  <span class="powered"><span class="foot-mark"><svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg></span>powered by <a href="https://github.com/MorganKryze/cairn" title="cairn 1.14.0">cairn</a> <a class="foot-version" href="https://github.com/MorganKryze/cairn/releases/tag/v1.14.0">1.14.0</a></span>
+  </div></footer>
+<a class="totop" href="#top" aria-label="Back to top"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 19V5M5 12l7-7 7 7"/></svg></a>
+<script src="/static/search.js" defer></script>
+<script src="/static/toc.js" defer></script>
+<script src="/static/nav.js" defer></script>
+<script src="/static/about.js" defer></script>
+<script src="/static/theme.js" defer></script>
+<script src="/static/status.js" defer data-poll="30"></script>
+</body>
+</html>
+

--- a/src/internal/render/testdata/golden/en/pdf.html
+++ b/src/internal/render/testdata/golden/en/pdf.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html lang="en" dir="ltr" data-about="f3ce492b">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<title>PDF toolbox · Golden</title>
+<meta name="description" content="Merge and split PDFs.">
+<meta property="og:type" content="website">
+<meta property="og:title" content="PDF toolbox · Golden">
+<meta property="og:description" content="Merge and split PDFs.">
+<meta property="og:locale" content="en">
+<link rel="canonical" href="https://golden.example.org/en/pdf/">
+<meta property="og:url" content="https://golden.example.org/en/pdf/">
+<link rel="alternate" hreflang="en" href="https://golden.example.org/en/pdf/">
+<link rel="alternate" hreflang="fr" href="https://golden.example.org/fr/pdf/">
+<link rel="alternate" hreflang="x-default" href="https://golden.example.org/">
+
+<link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
+<link rel="icon" href="/static/favicon.ico" sizes="32x32">
+<link rel="apple-touch-icon" href="/static/touch-icon.png">
+<link rel="manifest" href="/manifest.webmanifest">
+
+<link rel="preload" href="/static/fonts/fraunces.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="stylesheet" href="/static/style.css">
+<style>:root{--accent:#247b7b}</style>
+<script>document.documentElement.setAttribute('data-js','');var a=document.cookie.match(/(?:^|; )about=([^;]*)/);if(a&&a[1]===document.documentElement.getAttribute('data-about'))document.documentElement.setAttribute('data-noabout','');try{var t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t)}catch(e){}</script>
+</head>
+<body>
+<a class="skip" href="#main">Skip to content</a>
+<header><div class="wrap topbar">
+  <a class="brand" href="/en/">Golden</a>
+  <div class="topbar-tools">
+    <button class="theme-toggle" id="theme-toggle" hidden aria-label="Theme">
+      <svg class="moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
+      <svg class="sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2m7.07-17.07-1.41 1.41M6.34 17.66l-1.41 1.41M22 12h-2M4 12H2m17.07 7.07-1.41-1.41M6.34 6.34 4.93 4.93"/></svg>
+    </button>
+    <nav class="langs" aria-label="Language">
+      <a href="/en/pdf/?choose" aria-current="page">EN</a>
+      <a href="/fr/pdf/?choose">FR</a>
+    </nav>
+  </div>
+</div>
+<div class="wrap menu">
+  <div class="search" aria-hidden="true">
+    <div class="search-box">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.8-3.8"/></svg>
+      <input type="search" placeholder="Search for a tool…" disabled tabindex="-1">
+    </div>
+  </div>
+  </div>
+</header>
+<main id="main"><div class="wrap">
+
+<article class="detail">
+  <p><a class="back" href="/en/">Back</a></p>
+  <div class="detail-head">
+    <span class="tile"><svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg></span>
+    <div class="detail-title">
+      <h1>PDF toolbox</h1>
+      <span class="status-slot" data-status="pdf"><a class="status-pill status-up" href="https://status.example.org/endpoints/documents_pdf" target="_blank" rel="noopener" aria-label="PDF toolbox, Online, view status"><span class="dot" aria-hidden="true"></span>Online</a></span>
+    </div>
+  </div>
+  <p class="lead">Merge and split PDFs.</p>
+  <h2>What it does</h2>
+<ol>
+<li>Drop a file</li>
+<li>Pick an action</li>
+</ol>
+<div class="table-wrap" tabindex="0"><table><thead>
+<tr>
+<th>Format</th>
+<th>In</th>
+<th>Out</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>pdf</td>
+<td>yes</td>
+<td>yes</td>
+</tr>
+</tbody>
+</table></div>
+<p><a class="btn" href="https://pdf.example.org">Open the tool</a></p>
+</article>
+</div></main>
+<footer><div class="wrap foot">
+  <div class="foot-links"><a href="https://status.example.org">Status</a></div>
+  <span class="powered"><span class="foot-mark"><svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg></span>powered by <a href="https://github.com/MorganKryze/cairn" title="cairn 1.14.0">cairn</a> <a class="foot-version" href="https://github.com/MorganKryze/cairn/releases/tag/v1.14.0">1.14.0</a></span>
+  </div></footer>
+<a class="totop" href="#top" aria-label="Back to top"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 19V5M5 12l7-7 7 7"/></svg></a>
+<script src="/static/search.js" defer></script>
+<script src="/static/toc.js" defer></script>
+<script src="/static/nav.js" defer></script>
+<script src="/static/about.js" defer></script>
+<script src="/static/theme.js" defer></script>
+<script src="/static/status.js" defer data-poll="30"></script>
+</body>
+</html>
+

--- a/src/internal/render/testdata/golden/fr.html
+++ b/src/internal/render/testdata/golden/fr.html
@@ -1,0 +1,144 @@
+<!doctype html>
+<html lang="fr" dir="ltr" data-about="f3ce492b">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<title>Golden</title>
+<meta name="description" content="Tout ce qui ne doit pas bouger.">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Golden">
+<meta property="og:description" content="Tout ce qui ne doit pas bouger.">
+<meta property="og:locale" content="fr">
+<link rel="canonical" href="https://golden.example.org/fr/">
+<meta property="og:url" content="https://golden.example.org/fr/">
+<link rel="alternate" hreflang="en" href="https://golden.example.org/en/">
+<link rel="alternate" hreflang="fr" href="https://golden.example.org/fr/">
+<link rel="alternate" hreflang="x-default" href="https://golden.example.org/">
+
+<link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
+<link rel="icon" href="/static/favicon.ico" sizes="32x32">
+<link rel="apple-touch-icon" href="/static/touch-icon.png">
+<link rel="manifest" href="/manifest.webmanifest">
+
+<link rel="preload" href="/static/fonts/fraunces.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="stylesheet" href="/static/style.css">
+<style>:root{--accent:#247b7b}</style>
+<script>document.documentElement.setAttribute('data-js','');var a=document.cookie.match(/(?:^|; )about=([^;]*)/);if(a&&a[1]===document.documentElement.getAttribute('data-about'))document.documentElement.setAttribute('data-noabout','');try{var t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t)}catch(e){}</script>
+</head>
+<body>
+<a class="skip" href="#main">Aller au contenu</a>
+<header><div class="wrap topbar">
+  <a class="brand" href="/fr/">Golden</a>
+  <div class="topbar-tools">
+    <button class="theme-toggle" id="theme-toggle" hidden aria-label="Thème">
+      <svg class="moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
+      <svg class="sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2m7.07-17.07-1.41 1.41M6.34 17.66l-1.41 1.41M22 12h-2M4 12H2m17.07 7.07-1.41-1.41M6.34 6.34 4.93 4.93"/></svg>
+    </button>
+    <nav class="langs" aria-label="Langue">
+      <a href="/en/?choose">EN</a>
+      <a href="/fr/?choose" aria-current="page">FR</a>
+    </nav>
+  </div>
+</div>
+<div class="wrap menu">
+  <div class="search" id="search">
+    <div class="search-box">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.8-3.8"/></svg>
+      <label class="visually-hidden" for="q">Rechercher</label>
+      <input id="q" type="search" placeholder="Chercher un outil…" autocomplete="off" enterkeyhint="go" disabled>
+      <kbd class="search-kbd" hidden>⌘K</kbd>
+    </div>
+  </div>
+  </div>
+</header>
+<main id="main"><div class="wrap">
+
+<h1 class="visually-hidden">Golden</h1>
+<p class="tagline">Tout ce qui ne doit pas bouger.</p>
+<section class="about">
+  
+  <button class="about-x" id="about-x" hidden><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12"/></svg><span>Masquer</span></button>
+  <div lang="en"><p>A welcome note, with <em>emphasis</em> and a <a href="https://example.org">link</a>.</p>
+</div>
+</section>
+<nav class="toc" aria-label="Catégories">
+  <ul>
+    <li><a href="#cat-documents"><span class="toc-mark" aria-hidden="true"></span><span class="toc-name">Documents</span></a></li>
+    <li><a href="#cat-other"><span class="toc-mark" aria-hidden="true"></span><span class="toc-name">Autres</span></a></li>
+    
+  </ul>
+</nav>
+
+<section class="cat" aria-labelledby="cat-documents">
+  <div class="way">
+    <span class="way-mark" aria-hidden="true"></span>
+    <h2 id="cat-documents" class="way-name">Documents</h2>
+    <span class="way-rule" aria-hidden="true"></span>
+  </div>
+  <ul class="cards">
+    <li class="card" data-tags="pdf convert">
+      <div class="card-main">
+        <span class="tile"><svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg></span>
+        <div class="card-text">
+          <a class="card-name" href="https://pdf.example.org">Boîte à outils PDF</a>
+          
+          <span class="card-desc">Fusionner et découper vos PDF. <a class="card-more" href="/fr/pdf/">En savoir plus</a></span>
+          
+        </div>
+      </div>
+      <div class="card-foot"><span class="flag flag-self"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"/><path d="M3 10a2 2 0 0 1 .709-1.528l7-6a2 2 0 0 1 2.582 0l7 6A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg><span class="flag-label">Auto-hébergé</span></span><span class="status-slot" data-status="pdf"><a class="status-pill status-up" href="https://status.example.org/endpoints/documents_pdf" target="_blank" rel="noopener" aria-label="Boîte à outils PDF, En ligne, voir le statut"><span class="dot" aria-hidden="true"></span>En ligne</a></span></div>
+      </li>
+    <li class="card">
+      <div class="card-main">
+        <span class="tile"><svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg></span>
+        <div class="card-text">
+          <a class="card-name" href="https://pad.example.org">Shared notepad</a>
+          
+          <span class="card-desc">Write together.</span>
+          
+        </div>
+      </div>
+      <div class="card-foot"><span class="status-slot" data-status="pad"><a class="status-pill status-down" href="https://status.example.org/endpoints/documents_pad" target="_blank" rel="noopener" aria-label="Shared notepad, Hors ligne, voir le statut"><span class="dot" aria-hidden="true"></span>Hors ligne</a></span></div>
+      </li>
+    
+  </ul>
+</section>
+<section class="cat" aria-labelledby="cat-other">
+  <div class="way">
+    <span class="way-mark" aria-hidden="true"></span>
+    <h2 id="cat-other" class="way-name">Autres</h2>
+    <span class="way-rule" aria-hidden="true"></span>
+  </div>
+  <ul class="cards">
+    <li class="card">
+      <div class="card-main">
+        <span class="tile"><svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg></span>
+        <div class="card-text">
+          <a class="card-name" href="/wiki">Wiki</a>
+          
+          
+        </div>
+      </div>
+      <div class="card-foot"><span class="status-slot" data-status="wiki"></span></div>
+      </li>
+    
+  </ul>
+</section>
+<p id="empty" class="empty" role="status" hidden>Aucun résultat. Essayez un autre mot.</p>
+<p id="count" class="visually-hidden" role="status" aria-live="polite" data-single="1 résultat" data-plural="%d résultats"></p>
+</div></main>
+<footer><div class="wrap foot">
+  <div class="foot-links"><a href="https://status.example.org">Statut</a></div>
+  <span class="powered"><span class="foot-mark"><svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg></span>propulsé par <a href="https://github.com/MorganKryze/cairn" title="cairn 1.14.0">cairn</a> <a class="foot-version" href="https://github.com/MorganKryze/cairn/releases/tag/v1.14.0">1.14.0</a></span>
+  </div></footer>
+<a class="totop" href="#top" aria-label="Haut de page"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 19V5M5 12l7-7 7 7"/></svg></a>
+<script src="/static/search.js" defer></script>
+<script src="/static/toc.js" defer></script>
+<script src="/static/nav.js" defer></script>
+<script src="/static/about.js" defer></script>
+<script src="/static/theme.js" defer></script>
+<script src="/static/status.js" defer data-poll="30"></script>
+</body>
+</html>
+

--- a/src/internal/render/testdata/golden/fr/pdf.html
+++ b/src/internal/render/testdata/golden/fr/pdf.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html lang="fr" dir="ltr" data-about="f3ce492b">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<title>Boîte à outils PDF · Golden</title>
+<meta name="description" content="Fusionner et découper vos PDF.">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Boîte à outils PDF · Golden">
+<meta property="og:description" content="Fusionner et découper vos PDF.">
+<meta property="og:locale" content="fr">
+<link rel="canonical" href="https://golden.example.org/fr/pdf/">
+<meta property="og:url" content="https://golden.example.org/fr/pdf/">
+<link rel="alternate" hreflang="en" href="https://golden.example.org/en/pdf/">
+<link rel="alternate" hreflang="fr" href="https://golden.example.org/fr/pdf/">
+<link rel="alternate" hreflang="x-default" href="https://golden.example.org/">
+
+<link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
+<link rel="icon" href="/static/favicon.ico" sizes="32x32">
+<link rel="apple-touch-icon" href="/static/touch-icon.png">
+<link rel="manifest" href="/manifest.webmanifest">
+
+<link rel="preload" href="/static/fonts/fraunces.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="stylesheet" href="/static/style.css">
+<style>:root{--accent:#247b7b}</style>
+<script>document.documentElement.setAttribute('data-js','');var a=document.cookie.match(/(?:^|; )about=([^;]*)/);if(a&&a[1]===document.documentElement.getAttribute('data-about'))document.documentElement.setAttribute('data-noabout','');try{var t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t)}catch(e){}</script>
+</head>
+<body>
+<a class="skip" href="#main">Aller au contenu</a>
+<header><div class="wrap topbar">
+  <a class="brand" href="/fr/">Golden</a>
+  <div class="topbar-tools">
+    <button class="theme-toggle" id="theme-toggle" hidden aria-label="Thème">
+      <svg class="moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
+      <svg class="sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2m7.07-17.07-1.41 1.41M6.34 17.66l-1.41 1.41M22 12h-2M4 12H2m17.07 7.07-1.41-1.41M6.34 6.34 4.93 4.93"/></svg>
+    </button>
+    <nav class="langs" aria-label="Langue">
+      <a href="/en/pdf/?choose">EN</a>
+      <a href="/fr/pdf/?choose" aria-current="page">FR</a>
+    </nav>
+  </div>
+</div>
+<div class="wrap menu">
+  <div class="search" aria-hidden="true">
+    <div class="search-box">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.8-3.8"/></svg>
+      <input type="search" placeholder="Chercher un outil…" disabled tabindex="-1">
+    </div>
+  </div>
+  </div>
+</header>
+<main id="main"><div class="wrap">
+
+<article class="detail">
+  <p><a class="back" href="/fr/">Retour</a></p>
+  <div class="detail-head">
+    <span class="tile"><svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg></span>
+    <div class="detail-title">
+      <h1>Boîte à outils PDF</h1>
+      <span class="status-slot" data-status="pdf"><a class="status-pill status-up" href="https://status.example.org/endpoints/documents_pdf" target="_blank" rel="noopener" aria-label="Boîte à outils PDF, En ligne, voir le statut"><span class="dot" aria-hidden="true"></span>En ligne</a></span>
+    </div>
+  </div>
+  <p class="lead">Fusionner et découper vos PDF.</p>
+  <div lang="en"><h2>What it does</h2>
+<ol>
+<li>Drop a file</li>
+<li>Pick an action</li>
+</ol>
+<div class="table-wrap" tabindex="0"><table><thead>
+<tr>
+<th>Format</th>
+<th>In</th>
+<th>Out</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>pdf</td>
+<td>yes</td>
+<td>yes</td>
+</tr>
+</tbody>
+</table></div>
+</div>
+<p><a class="btn" href="https://pdf.example.org">Ouvrir l’outil</a></p>
+</article>
+</div></main>
+<footer><div class="wrap foot">
+  <div class="foot-links"><a href="https://status.example.org">Statut</a></div>
+  <span class="powered"><span class="foot-mark"><svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg></span>propulsé par <a href="https://github.com/MorganKryze/cairn" title="cairn 1.14.0">cairn</a> <a class="foot-version" href="https://github.com/MorganKryze/cairn/releases/tag/v1.14.0">1.14.0</a></span>
+  </div></footer>
+<a class="totop" href="#top" aria-label="Haut de page"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 19V5M5 12l7-7 7 7"/></svg></a>
+<script src="/static/search.js" defer></script>
+<script src="/static/toc.js" defer></script>
+<script src="/static/nav.js" defer></script>
+<script src="/static/about.js" defer></script>
+<script src="/static/theme.js" defer></script>
+<script src="/static/status.js" defer data-poll="30"></script>
+</body>
+</html>
+


### PR DESCRIPTION
Groundwork, and nothing else: no behaviour changes here.

Multi-source status support is about to add providers beside Gatus. The
constraint on that work is that a site running today keeps rendering exactly
what it renders now. A constraint nobody can check is a hope, so this is the
check, and it lands before the work rather than alongside it. Landing it
afterwards would mean regenerating the golden files in the same commit that
broke them, which proves nothing.

## What is pinned

Four pages and the CSP, byte for byte, from one site chosen to touch every
part a status deployment reaches:

- **Two locales**, so the language-fallback marking is in play rather than
  dormant.
- **A detail page with markdown** that reaches the heading, ordered-list and
  table renderers, all three of which the goldmark work made load-bearing.
- **Three card states**: a service Gatus reports up, one it reports down, and
  one it says nothing about, which is the card that gets a slot and no pill.
- A host flag, a footer, a welcome note, `show_version`, an accent.

The two pill `href`s are asserted separately from the byte comparison. They
are what the provider work is most likely to move, and an href drowns in nine
kilobytes of diff.

## What it looks like when it catches something

Renaming one class in `home.tmpl`, on purpose, to check the net is a net:

```
--- FAIL: TestAGatusSiteRendersWhatItAlwaysDid
    testdata/golden/en.html changed: 9029 bytes now, 9026 before.
      before: …<span class="tile"><svg viewBox="0 0 32 32"…
      after:  …<span class="thumb"><svg viewBox="0 0 32 32"…
```

It names the file, counts the bytes and points at the one that moved with
context either side, rather than printing a diff of the whole page.

## Regenerating

```sh
go test ./src/internal/render -run TestAGatusSiteRendersWhatItAlwaysDid -update
```

Deliberately manual, and deliberately the only way. Rewriting these files is
the moment a diff has to be read line by line and justified in the pull request
that rewrites them. That ceremony is what the files are for; automate it and
they become four kilobytes of noise that always agrees with whatever was just
built.

## What this does not cover

Said plainly, because a net people trust more than it deserves is worse than
none.

- `style.css` and `status.js` are not pinned. The maintenance pill will move
  both, legitimately. The browser tests hold their behaviour.
- The `-emit-gatus` YAML is covered by its existing assertions, not by bytes.
- The version string is pinned inside the test, since the build stamps it and
  an unpinned one would fail on every release.
