### PR TITLE
status: give a state a level and a provider a name

### DIFF
--- a/src/internal/render/golden_test.go
+++ b/src/internal/render/golden_test.go
@@ -91,8 +91,8 @@ func TestAGatusSiteRendersWhatItAlwaysDid(t *testing.T) {
 	// Gatus has answered: pdf up, pad down, and it says nothing about wiki,
 	// which is the third of the three states a card can be in.
 	m, err := BuildModel(cfg, map[string]status.State{
-		"pdf": {Up: true, Key: "documents_pdf"},
-		"pad": {Up: false, Key: "documents_pad"},
+		"pdf": {Level: status.LevelUp, Key: "documents_pdf"},
+		"pad": {Level: status.LevelDown, Key: "documents_pad"},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/src/internal/render/render.go
+++ b/src/internal/render/render.go
@@ -348,9 +348,12 @@ func statusOf(cfg *config.Config, statuses map[string]status.State, id string) s
 	switch {
 	case !ok:
 		return ""
-	case st.Up:
+	case st.Level == status.LevelUp:
 		return "up"
 	default:
+		// Every other level, including one no version of cairn has heard of,
+		// reads as down. That is the safe direction: a source that grows a word
+		// must not be able to paint a broken service green.
 		return "down"
 	}
 }

--- a/src/internal/render/statuspill_test.go
+++ b/src/internal/render/statuspill_test.go
@@ -19,7 +19,7 @@ func pages(t *testing.T, site string) (home, detail string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	m, err := BuildModel(cfg, map[string]status.State{"pad": {Up: true}})
+	m, err := BuildModel(cfg, map[string]status.State{"pad": {Level: status.LevelUp}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +56,7 @@ func TestEveryServiceHasAPillSlot(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Gatus has answered and monitors pad only: wiki ends up with no pill.
-	m, err := BuildModel(cfg, map[string]status.State{"pad": {Up: true}})
+	m, err := BuildModel(cfg, map[string]status.State{"pad": {Level: status.LevelUp}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +157,7 @@ func TestStatusLinkedFalseChangesNothingElse(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Gatus has answered, and knows nothing about this service.
-	m, err := BuildModel(cfg, map[string]status.State{"elsewhere": {Up: true}})
+	m, err := BuildModel(cfg, map[string]status.State{"elsewhere": {Level: status.LevelUp}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/internal/server/hardening_test.go
+++ b/src/internal/server/hardening_test.go
@@ -196,7 +196,7 @@ func TestGatusReadsANormalAnswer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !st["pad"].Up {
+	if st["pad"].Level != status.LevelUp {
 		t.Errorf("statuses = %v, want pad up (the last result wins)", st)
 	}
 }

--- a/src/internal/server/watch_test.go
+++ b/src/internal/server/watch_test.go
@@ -92,7 +92,7 @@ func TestPollOnce(t *testing.T) {
 	}
 
 	pollOnce(status.Source{URL: srv.URL}, &seen)
-	if got := current.Load().Statuses["pad"]; !got.Up {
+	if got := current.Load().Statuses["pad"]; got.Level != status.LevelUp {
 		t.Fatalf("statuses = %v, want pad up", current.Load().Statuses)
 	}
 	if !strings.Contains(string(current.Load().Pages["en"].HTML), "status-up") {

--- a/src/internal/status/ca_test.go
+++ b/src/internal/status/ca_test.go
@@ -82,7 +82,7 @@ func TestCABundleVerifiesWhatTheSystemRootsCannot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("a bundle holding the server's own authority still failed: %v", err)
 	}
-	if !st["pad"].Up {
+	if st["pad"].Level != status.LevelUp {
 		t.Errorf("statuses = %v, want pad up: the body is read the same either side of the bundle", st)
 	}
 }
@@ -100,7 +100,7 @@ func TestCABundleCanBeFetched(t *testing.T) {
 	if err != nil {
 		t.Fatalf("a fetched bundle failed: %v", err)
 	}
-	if !st["pad"].Up {
+	if st["pad"].Level != status.LevelUp {
 		t.Errorf("statuses = %v, want pad up", st)
 	}
 }

--- a/src/internal/status/gatus.go
+++ b/src/internal/status/gatus.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -68,13 +70,30 @@ func Emit(cfg *config.Config, hide bool) ([]byte, error) {
 	return yaml.Marshal(map[string]any{"endpoints": eps})
 }
 
-// State is what Gatus says about one endpoint: whether its last check passed,
-// and the key it uses for its own endpoint page. The key is reported rather
+// Level is what a source says about one service. Four values, counted from
+// what the sources actually declare rather than chosen: up and down are
+// universal, degraded and maintenance are each drawn by four monitors of the
+// eight surveyed. Anything else a source says reads as down, which is the safe
+// direction: a word added to a vendor's API next year cannot make a broken
+// service look green.
+//
+// Gatus reaches only two of them. Its results carry a success bool and nothing
+// else, which is why giving the other sources more states cannot move what a
+// Gatus site renders.
+const (
+	LevelUp          = "up"
+	LevelDegraded    = "degraded"
+	LevelMaintenance = "maintenance"
+	LevelDown        = "down"
+)
+
+// State is what a source says about one service: the level, and the key of the
+// source's own page for it, empty when it has none. The key is reported rather
 // than derived because only the operator's Gatus config decides how endpoints
 // are grouped, and cairn's categories are not that config.
 type State struct {
-	Up  bool
-	Key string
+	Level string
+	Key   string
 }
 
 // Key builds the key Gatus uses in its endpoint page URLs
@@ -129,12 +148,13 @@ var (
 	}
 )
 
-// Source is where the pills come from: the Gatus API cairn polls, and how much
+// Source is where the pills come from: the monitor cairn polls, and how much
 // it is willing to trust on the way there. It mirrors the status block in
-// site.yaml, and exists so the two trust settings travel together with the
-// address they apply to rather than as loose parameters.
+// site.yaml, and exists so the trust settings travel together with the address
+// they apply to rather than as loose parameters.
 type Source struct {
 	URL      string
+	Provider string // status.provider: empty means gatus, which is what every config written before providers existed says
 	Insecure bool   // status.insecure: verify nothing
 	CA       string // status.ca: verify against this too, a URL or an /assets path
 }
@@ -217,13 +237,40 @@ func bundle(ref string) ([]byte, error) {
 	return io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 }
 
-// Fetch asks a Gatus instance for its endpoint statuses and returns
-// service-id -> up, keyed by endpoint name.
+// fetcher is one way of asking a monitor what it knows. The client is chosen
+// once, by Fetch, so every provider inherits the same timeout and the same
+// answer to status.insecure and status.ca.
+type fetcher func(*http.Client, Source) (map[string]State, error)
+
+// providers is the whole list, and the error below reads it, so a provider
+// registered here is one the message already names without being told.
+var providers = map[string]fetcher{"gatus": fetchGatus}
+
+func providerNames() string {
+	return strings.Join(slices.Sorted(maps.Keys(providers)), ", ")
+}
+
+// Fetch asks the source's monitor what it knows and returns service-id ->
+// state.
 func Fetch(src Source) (map[string]State, error) {
+	name := src.Provider
+	if name == "" {
+		name = "gatus"
+	}
+	f, ok := providers[name]
+	if !ok {
+		return nil, fmt.Errorf("status.provider %q is not one cairn reads (expected one of %s)", name, providerNames())
+	}
 	client, err := clientFor(src)
 	if err != nil {
 		return nil, err
 	}
+	return f(client, src)
+}
+
+// fetchGatus reads the endpoint statuses of a Gatus instance, keyed by
+// endpoint name, which is the service id.
+func fetchGatus(client *http.Client, src Source) (map[string]State, error) {
 	resp, err := client.Get(strings.TrimSuffix(src.URL, "/") + "/api/v1/endpoints/statuses")
 	if err != nil {
 		return nil, err
@@ -248,7 +295,11 @@ func Fetch(src Source) (map[string]State, error) {
 	out := make(map[string]State, len(list))
 	for _, e := range list {
 		if len(e.Results) > 0 {
-			out[e.Name] = State{Up: e.Results[len(e.Results)-1].Success, Key: e.Key}
+			level := LevelDown
+			if e.Results[len(e.Results)-1].Success {
+				level = LevelUp
+			}
+			out[e.Name] = State{Level: level, Key: e.Key}
 		}
 	}
 	return out, nil

--- a/src/internal/status/gatus_test.go
+++ b/src/internal/status/gatus_test.go
@@ -81,10 +81,10 @@ func TestFetchStatuses(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if up, ok := st["pdf"]; !ok || !up.Up {
+	if up, ok := st["pdf"]; !ok || up.Level != status.LevelUp {
 		t.Errorf("pdf = %v,%v, want up (last result wins)", up, ok)
 	}
-	if up, ok := st["pad"]; !ok || up.Up {
+	if up, ok := st["pad"]; !ok || up.Level == status.LevelUp {
 		t.Errorf("pad = %v,%v, want down", up, ok)
 	}
 	if _, ok := st["empty"]; ok {
@@ -131,7 +131,7 @@ func TestPillLinksToTheKeyGatusReports(t *testing.T) {
 // service that could be anything answering on that address.
 func TestReportedKeyCannotEscapeItsPathSegment(t *testing.T) {
 	m, err := render.BuildModel(sample(t), map[string]status.State{
-		"pdf": {Up: true, Key: "../../../admin"},
+		"pdf": {Level: status.LevelUp, Key: "../../../admin"},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -143,7 +143,7 @@ func TestReportedKeyCannotEscapeItsPathSegment(t *testing.T) {
 
 func TestStatusDots(t *testing.T) {
 	cfg := sample(t)
-	m, err := render.BuildModel(cfg, map[string]status.State{"pdf": {Up: true}, "pad": {}})
+	m, err := render.BuildModel(cfg, map[string]status.State{"pdf": {Level: status.LevelUp}, "pad": {}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +169,7 @@ func TestStatusDots(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	pm, err := render.BuildModel(pub, map[string]status.State{"a": {Up: true}})
+	pm, err := render.BuildModel(pub, map[string]status.State{"a": {Level: status.LevelUp}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -187,7 +187,7 @@ func TestStatusDots(t *testing.T) {
 		t.Error("gatus configured but silent: every pill should be unknown")
 	}
 
-	partial, err := render.BuildModel(cfg, map[string]status.State{"pdf": {Up: true}})
+	partial, err := render.BuildModel(cfg, map[string]status.State{"pdf": {Level: status.LevelUp}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -230,10 +230,10 @@ func TestStatusConfigValidation(t *testing.T) {
 
 func TestUnmonitored(t *testing.T) {
 	cfg := &config.Config{Categories: []config.Category{{ID: "t", Services: []config.Service{{ID: "seen"}, {ID: "ghost"}}}}}
-	if got := status.Unmonitored(cfg, map[string]status.State{"seen": {Up: true}}); !strings.Contains(got, "ghost") || strings.Contains(got, "seen,") {
+	if got := status.Unmonitored(cfg, map[string]status.State{"seen": {Level: status.LevelUp}}); !strings.Contains(got, "ghost") || strings.Contains(got, "seen,") {
 		t.Errorf("Unmonitored = %q, want it to name only ghost", got)
 	}
-	if got := status.Unmonitored(cfg, map[string]status.State{"seen": {Up: true}, "ghost": {}}); got != "" {
+	if got := status.Unmonitored(cfg, map[string]status.State{"seen": {Level: status.LevelUp}, "ghost": {}}); got != "" {
 		t.Errorf("Unmonitored = %q, want empty when all endpoints exist", got)
 	}
 }

--- a/src/internal/status/insecure_test.go
+++ b/src/internal/status/insecure_test.go
@@ -29,7 +29,7 @@ func TestInsecureSkipsTheVerificationAndNothingElse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("insecure still refused a self-signed gatus: %v", err)
 	}
-	if !st["pad"].Up {
+	if st["pad"].Level != status.LevelUp {
 		t.Errorf("statuses = %v, want pad up: the body has to be read the same way either side of the flag", st)
 	}
 }

--- a/src/internal/status/provider_test.go
+++ b/src/internal/status/provider_test.go
@@ -1,0 +1,51 @@
+package status_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MorganKryze/cairn/src/internal/status"
+)
+
+// A Source that names no provider is the one every config produces today, and
+// it has to keep meaning Gatus. The zero value is the shape a future caller
+// will reach for by accident, so it is the one worth pinning.
+func TestAnUnnamedProviderIsGatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/endpoints/statuses" {
+			t.Errorf("an unnamed provider asked for %q, which is not the gatus path", r.URL.Path)
+		}
+		io.WriteString(w, `[{"name":"pad","key":"_pad","results":[{"success":true}]}]`)
+	}))
+	defer srv.Close()
+
+	st, err := status.Fetch(status.Source{URL: srv.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st["pad"].Level != status.LevelUp {
+		t.Errorf("pad = %q, want %q", st["pad"].Level, status.LevelUp)
+	}
+	if st["pad"].Key != "_pad" {
+		t.Errorf("the reported key was dropped: %q", st["pad"].Key)
+	}
+}
+
+// A provider nobody wrote is an error naming the ones that exist, not a silent
+// fall back to Gatus against an address that is not one. The list comes from
+// the registry, so a provider added later is one the message already knows
+// about; until then gatus is the whole list, and this test says so.
+func TestAnUnknownProviderSaysWhichExist(t *testing.T) {
+	_, err := status.Fetch(status.Source{URL: "https://example.org", Provider: "nagios"})
+	if err == nil {
+		t.Fatal("an unknown provider was accepted")
+	}
+	for _, want := range []string{"nagios", "gatus"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not carry %q", err, want)
+		}
+	}
+}


### PR DESCRIPTION
A status is a level now, not a bool, and the thing that fetches it has a name.
Nothing is visible: no config key reads a provider yet, and no source can
produce a level that is not up or down.

## What changes

`State.Up bool` becomes `State.Level string`, one of four constants declared in
one block: `up`, `degraded`, `maintenance`, `down`. The last two are unused
until the pills exist; they are here because the four values are one vocabulary
and splitting the declaration would put half of it out of sight.

`Fetch` keeps its signature. It picks the client exactly as before, then
dispatches on `Source.Provider` through a `providers` map holding one entry. An
empty provider means gatus, which is what every config written before this says,
so the poll path for an existing site is the one it was yesterday.

The unknown-provider error reads that map rather than a list written by hand, so
a provider registered later is one the message already names.

## Why a level and not a second bool

Two bools would admit `Up && Maintenance`, which means nothing. A string is
also what `statusOf` already returns and what the CSS class already spells, so
the value travels from the monitor to the markup without translation.

## What proves this changed nothing

`TestAGatusSiteRendersWhatItAlwaysDid` compares four rendered pages and the CSP
byte for byte. It passes untouched, and `-update` was not run.

That is not luck. Gatus reports `Success bool` and nothing else, so no Gatus
site can reach a level this branch added. The check that the golden net would
have caught a mistake was made by inverting the level sense in `statusOf`: all
four pages moved, `status-down` where the file has `status-up`.

Both new tests were red-proven twice: as a build failure before the type
existed, then by patching the behaviour out. Without the default to gatus an
unnamed provider errors; with an unknown provider silently accepted, the message
test fails.
