### PR TITLE
ui: turn the back link into a chip with an inline arrow

### DIFF
--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -269,6 +269,32 @@ for (const theme of ["light", "dark"]) {
   );
 }
 
+// The way back out of a detail page: the same two duties as the card glyph,
+// since it was the other control under 24 by 24.
+await check("the back link is a real target on a detail page", async () => {
+  const m = await detail.$eval(".back", (el) => {
+    const r = el.getBoundingClientRect();
+    const s = getComputedStyle(el);
+    return {
+      w: r.width,
+      h: r.height,
+      colour: s.color,
+      behind: s.backgroundColor,
+    };
+  });
+  if (m.w < 24 || m.h < 24) {
+    throw new Error(
+      `${Math.round(m.w)} by ${Math.round(m.h)}, WCAG 2.2 asks 24 by 24 of a target`,
+    );
+  }
+  const r = ratio(m.colour, m.behind);
+  if (r < 4.5) {
+    throw new Error(
+      `its words are ${r.toFixed(2)}:1 against the chip, and text asks 4.5:1`,
+    );
+  }
+});
+
 // ---- A6: 3:1 for a dot that carries meaning, on both themes (1.4.11) ----
 
 // The fixture's monitor is a port nothing listens on, so every pill on that

--- a/src/internal/render/assets/style.css
+++ b/src/internal/render/assets/style.css
@@ -674,17 +674,28 @@ a.status-pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 
 /* ---- detail page ---- */
 
 .detail { max-width: 44rem; margin-inline: auto; padding-block: 1.4rem 1rem; }
-.back::before { content: "\2190"; }
+/* The way back out of a detail page. It was a bare text link 51 by 23, under
+   the 24 by 24 WCAG 2.2 asks of a target, and its arrow was a CSS ::before,
+   which some screen readers read out and a stylesheet that fails to load takes
+   with it. It is a chip now, the same rounded outline the pills and the flag
+   already wear, with the arrow inline in the markup as decoration. */
 .back {
   display: inline-flex;
   align-items: center;
   gap: .35rem;
-  font-size: .9rem;
+  padding: .3rem .7rem .3rem .55rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--card);
+  font-size: .82rem;
+  font-weight: 500;
   color: var(--muted);
   text-decoration: none;
+  transition: color .16s, border-color .16s;
 }
-.back:hover { color: var(--fg); }
-.back:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 3px; }
+.back-glyph { width: .85rem; height: .85rem; flex: none; }
+.back:hover { color: var(--fg); border-color: color-mix(in oklab, var(--accent) 40%, var(--border)); }
+.back:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
 .detail-head { display: flex; align-items: center; gap: 1rem; margin-top: 1.6rem; }
 .detail-head .tile { width: 3.6rem; height: 3.6rem; }
@@ -1204,4 +1215,5 @@ footer {
 
 /* Right-to-left: the layout follows from the logical properties above, only
    the two literal arrows have to be turned around by hand. */
-[dir="rtl"] .back::before { content: "\2192"; }
+/* One glyph, mirrored, rather than a second character to keep in step. */
+[dir="rtl"] .back-glyph { transform: scaleX(-1); }

--- a/src/internal/render/back_test.go
+++ b/src/internal/render/back_test.go
@@ -1,0 +1,78 @@
+package render
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MorganKryze/cairn/src/internal/config"
+	"github.com/MorganKryze/cairn/src/internal/status"
+	"github.com/MorganKryze/cairn/src/internal/testutil"
+)
+
+func backPages(t *testing.T) map[string]string {
+	t.Helper()
+	cfg, err := config.Load(testutil.WriteFiles(t, map[string]string{
+		"site.yaml":     "locales: [en, ar]\npages:\n  - id: legal\n    title: {en: Legal, ar: قانوني}\n    body: {en: Text., ar: نص.}\n",
+		"services.yaml": "- {id: pad, url: https://pad.example.org, name: Pad, details: More.}\n",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := BuildModel(cfg, map[string]status.State{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := map[string]string{}
+	for k, p := range m.Pages {
+		out[k] = string(p.HTML)
+	}
+	return out
+}
+
+// The arrow used to be a CSS ::before, which some screen readers read out as
+// "left arrow" before the word, and which a stylesheet that fails to load
+// takes with it. It is an inline svg now, marked as decoration, so the word is
+// the whole message either way.
+func TestTheBackArrowIsDecorationInTheMarkup(t *testing.T) {
+	pages := backPages(t)
+	for _, name := range []string{"en/pad", "en/legal"} {
+		page := pages[name]
+		if !strings.Contains(page, `<a class="back" href="/en/"><svg class="back-glyph"`) {
+			t.Errorf("%s: the back link carries no glyph of its own", name)
+		}
+		if !strings.Contains(page, `aria-hidden="true"`) {
+			t.Errorf("%s: the glyph is not marked as decoration", name)
+		}
+		// The word stays, and it stays translated.
+		if !strings.Contains(page, "Back</a>") {
+			t.Errorf("%s: the back link lost its label", name)
+		}
+	}
+	// Detail and simple pages carry the same control, so a visitor learns it
+	// once. The two templates had drifted before over smaller things.
+	if a, b := backOf(pages["en/pad"]), backOf(pages["en/legal"]); a != b {
+		t.Errorf("the two pages disagree on the back link:\n%s\n%s", a, b)
+	}
+}
+
+// A right-to-left page reads the other way round, so the arrow has to point
+// the other way. It was a different character before; now the same glyph is
+// mirrored, which is the stylesheet's job rather than the template's.
+func TestTheBackArrowTurnsAroundInRTL(t *testing.T) {
+	pages := backPages(t)
+	if !strings.Contains(pages["ar/legal"], `<a class="back" href="/ar/"><svg class="back-glyph"`) {
+		t.Error("the arabic page has no back glyph")
+	}
+	if !strings.Contains(pages["ar/legal"], `dir="rtl"`) {
+		t.Error("the arabic page is not marked right to left, so nothing would mirror")
+	}
+}
+
+func backOf(page string) string {
+	i := strings.Index(page, `<a class="back"`)
+	if i < 0 {
+		return "(no back link)"
+	}
+	j := strings.Index(page[i:], "</a>")
+	return page[i : i+j+4]
+}

--- a/src/internal/render/templates/detail.tmpl
+++ b/src/internal/render/templates/detail.tmpl
@@ -1,6 +1,6 @@
 {{template "top" .}}
 <article class="detail">
-  <p><a class="back" href="{{.Prefix}}/{{.Locale}}/">{{.S.Back}}</a></p>
+  <p><a class="back" href="{{.Prefix}}/{{.Locale}}/"><svg class="back-glyph" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>{{.S.Back}}</a></p>
   <div class="detail-head">
     <span class="tile">{{if .Icon}}<img src="{{.Icon}}" alt="" width="56" height="56">{{else}}{{template "glyph"}}{{end}}</span>
     <div class="detail-title">

--- a/src/internal/render/templates/page.tmpl
+++ b/src/internal/render/templates/page.tmpl
@@ -1,6 +1,6 @@
 {{template "top" .}}
 <article class="detail page">
-  <p><a class="back" href="{{.Prefix}}/{{.Locale}}/">{{.S.Back}}</a></p>
+  <p><a class="back" href="{{.Prefix}}/{{.Locale}}/"><svg class="back-glyph" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>{{.S.Back}}</a></p>
   <header class="page-head">
     <span class="way-mark" aria-hidden="true"></span>
     <h1{{.Title.Attrs}}>{{.Title}}</h1>

--- a/src/internal/render/testdata/golden/en/pdf.html
+++ b/src/internal/render/testdata/golden/en/pdf.html
@@ -53,7 +53,7 @@
 <main id="main"><div class="wrap">
 
 <article class="detail">
-  <p><a class="back" href="/en/">Back</a></p>
+  <p><a class="back" href="/en/"><svg class="back-glyph" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>Back</a></p>
   <div class="detail-head">
     <span class="tile"><svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg></span>
     <div class="detail-title">

--- a/src/internal/render/testdata/golden/fr/pdf.html
+++ b/src/internal/render/testdata/golden/fr/pdf.html
@@ -53,7 +53,7 @@
 <main id="main"><div class="wrap">
 
 <article class="detail">
-  <p><a class="back" href="/fr/">Retour</a></p>
+  <p><a class="back" href="/fr/"><svg class="back-glyph" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>Retour</a></p>
   <div class="detail-head">
     <span class="tile"><svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg></span>
     <div class="detail-title">


### PR DESCRIPTION
The other control that was under the WCAG 2.2 target size, fixed the same way
the card glyph was: the way back out of a detail page.

## What changes

**51 by 23 becomes 72 by 33.** SC 2.5.8 asks 24 by 24 of anything you can
click. The link keeps its translated word and gains the rounded outline the
pills and the host flag already wear, so a visitor meets one shape rather than
three.

**The arrow stops being a CSS `::before`.** That character was read out by some
screen readers before the word, and a stylesheet that fails to load took the
arrow with it. It is an inline svg marked `aria-hidden` now, so the word is the
whole message either way.

**Right to left is one glyph mirrored** rather than a second character to keep
in step: `[dir="rtl"] .back-glyph { transform: scaleX(-1) }` replaces a rule
that swapped `←` for `→`.

Measured on the demo, both themes: 72 by 33, and the words sit at 5.87:1 light
and 6.15:1 dark against the chip, where text asks 4.5:1. `scripts/a11y.mjs`
holds it, and the check is red-proven: the chip flattened back to a bare link
reports 52 by 23 and fails.

## The golden files

Two lines, one per detail page, both the same: the svg appears inside the
anchor. The two home pages and the CSP are untouched, which is what a change to
the detail header should look like.

A Go test pins what the markup owes rather than how it looks: the glyph is
decoration, the word survives, and the two templates that carry a back link,
detail pages and cairn's own pages, render the same control. Those two had
drifted before over smaller things.
