### PR TITLE
chart: ship an example values file, and a test that keeps it true

### DIFF
--- a/charts/cairn/values-example.yaml
+++ b/charts/cairn/values-example.yaml
@@ -1,0 +1,120 @@
+# A working cairn, in one file, for looking at rather than for running:
+#
+#   helm install cairn oci://ghcr.io/morgankryze/charts/cairn -f values-example.yaml
+#   kubectl port-forward svc/cairn 8080:80
+#
+# The default values install a cairn that serves its own getting-started page,
+# which is the right thing for a first install and shows you nothing about what
+# the page looks like with services on it. This file fills that gap: two
+# locales, three categories, six services, a welcome note and a legal page.
+#
+# Every service here points at a public site, so the page works from any
+# cluster with egress and none of the links are dead. Replace them with yours
+# and you have a real config; nothing in this file is example-only syntax.
+#
+# A test in the repository loads this exact block through cairn's own config
+# loader and runs its checks over it, so it cannot drift out of date quietly.
+
+config:
+  site.yaml: |
+    title: { fr: Nos outils, en: Our tools }
+    tagline:
+      fr: Les services que nous hébergeons, et à quoi ils servent.
+      en: The services we host, and what each one is for.
+    locales: [fr, en]
+    theme:
+      accent: "#247b7b"
+    about:
+      fr: |
+        Bienvenue. Cette page liste les outils disponibles ici. Chacun mène
+        directement au service; le petit glyphe ouvre une page qui explique à
+        quoi il sert.
+      en: |
+        Welcome. This page lists the tools available here. Each one goes
+        straight to the service; the small glyph opens a page explaining what
+        it is for.
+    links:
+      - label: { fr: Documentation, en: Documentation }
+        url: https://github.com/MorganKryze/cairn
+        icon: book
+    pages:
+      - id: legal
+        title: { fr: Mentions légales, en: Legal notice }
+        body:
+          fr: |
+            Éditeur : votre nom, contact@exemple.org
+
+            Hébergement : ce site est auto-hébergé par son éditeur.
+          en: |
+            Publisher: your name, contact@example.org
+
+            Hosting: this site is self-hosted by its publisher.
+
+  categories.yaml: |
+    # order decides the sections; without it, groups fall back to alphabetical
+    - id: write
+      name: { fr: Écrire, en: Write }
+      order: 1
+    - id: files
+      name: { fr: Fichiers, en: Files }
+      order: 2
+    - id: watch
+      name: { fr: Regarder, en: Watch }
+      order: 3
+
+  services.yaml: |
+    - id: pad
+      url: https://demo.hedgedoc.org
+      category: write
+      icon: hedgedoc
+      selfhosted: true
+      name: { fr: Bloc-notes, en: Notepad }
+      desc: { fr: "Écrire à plusieurs, en direct.", en: "Write together, live." }
+      details:
+        fr: |
+          Un bloc-notes partagé. Ouvrez une page, envoyez le lien, et vous
+          écrivez à plusieurs sur le même texte.
+        en: |
+          A shared notepad. Open a page, send the link, and several of you
+          write on the same text.
+    - id: wiki
+      url: https://www.dokuwiki.org
+      category: write
+      icon: dokuwiki
+      selfhosted: true
+      name: { fr: Wiki, en: Wiki }
+      desc: { fr: "La mémoire écrite du groupe.", en: "The group's written memory." }
+    - id: files
+      url: https://nextcloud.com
+      category: files
+      icon: nextcloud
+      selfhosted: true
+      name: { fr: Fichiers, en: Files }
+      desc: { fr: "Vos documents, partagés et synchronisés.", en: "Your documents, shared and synced." }
+      details:
+        fr: |
+          Déposez un fichier, partagez un lien, retrouvez vos documents sur
+          votre téléphone.
+        en: |
+          Drop a file, share a link, find your documents again on your phone.
+    - id: photos
+      url: https://immich.app
+      category: files
+      icon: immich
+      selfhosted: true
+      name: { fr: Photos, en: Photos }
+      desc: { fr: "Vos photos, sauvegardées ici.", en: "Your photos, backed up here." }
+    - id: music
+      url: https://demo.navidrome.org
+      category: watch
+      icon: navidrome
+      selfhosted: true
+      name: { fr: Musique, en: Music }
+      desc: { fr: "Votre bibliothèque, où que vous soyez.", en: "Your library, wherever you are." }
+    - id: maps
+      url: https://www.openstreetmap.org
+      category: watch
+      icon: openstreetmap
+      selfhosted: false
+      name: { fr: Cartes, en: Maps }
+      desc: { fr: "Une carte du monde, faite par ses habitants.", en: "A map of the world, made by the people on it." }

--- a/docs/deployment/helm.md
+++ b/docs/deployment/helm.md
@@ -30,6 +30,24 @@ and cairn version are the same number, always: chart `1.15.0` installs cairn
 `1.15.0`, so there is only ever one version to talk about, and `image.tag` is
 there if you ever want to break the pair apart.
 
+## Seeing it filled first
+
+The defaults install a cairn that serves its own getting-started page, which is
+right for a first install and tells you nothing about what the page looks like
+with services on it. The chart ships a values file that fills it:
+
+```sh
+curl -O https://raw.githubusercontent.com/MorganKryze/cairn/main/charts/cairn/values-example.yaml
+helm install cairn oci://ghcr.io/morgankryze/charts/cairn -f values-example.yaml
+kubectl port-forward svc/cairn 8080:80
+```
+
+Two locales, three groups, six services, a welcome note and a legal page, all
+pointing at public sites so nothing is dead on arrival. Replace the services
+with yours and it is a real config: nothing in that file is example-only
+syntax, and a test in the repository loads it through cairn's own loader and
+runs `-check` over it, so it cannot rot quietly.
+
 ## Feeding it your config
 
 Your YAML goes under `config:`, one entry per file, exactly the files you would

--- a/src/internal/check/chartexample_test.go
+++ b/src/internal/check/chartexample_test.go
@@ -1,6 +1,8 @@
 package check
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,7 +22,15 @@ import (
 // So it is loaded here through cairn's own loader, from the same YAML the
 // ConfigMap will carry, and put through the same checks a running site gets.
 func TestTheChartExampleIsAConfigCairnAccepts(t *testing.T) {
+	// The image build runs this suite with only src/ and schema/ copied in, so
+	// the chart is genuinely not there and skipping is the honest answer. It
+	// still runs on every checkout, which is where CI lints and measures
+	// coverage, and on every local run. Only a missing file skips: anything
+	// else is a real failure.
 	raw, err := os.ReadFile(filepath.Join("..", "..", "..", "charts", "cairn", "values-example.yaml"))
+	if errors.Is(err, fs.ErrNotExist) {
+		t.Skip("no charts/ in this build context, which is what the image build looks like")
+	}
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/internal/check/chartexample_test.go
+++ b/src/internal/check/chartexample_test.go
@@ -1,0 +1,73 @@
+package check
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/MorganKryze/cairn/src/internal/config"
+)
+
+// The chart ships an example values file so somebody can install cairn and see
+// a real page rather than the getting-started one. That file is config nobody
+// runs on the way past, which is exactly how an example rots: a key gets
+// renamed, the sample keeps the old spelling, and the first person to try it
+// meets an error the docs promised they would not.
+//
+// So it is loaded here through cairn's own loader, from the same YAML the
+// ConfigMap will carry, and put through the same checks a running site gets.
+func TestTheChartExampleIsAConfigCairnAccepts(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "..", "..", "charts", "cairn", "values-example.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var values struct {
+		Config map[string]string `yaml:"config"`
+	}
+	if err := yaml.Unmarshal(raw, &values); err != nil {
+		t.Fatalf("the example is not YAML the chart could render: %v", err)
+	}
+	if len(values.Config) == 0 {
+		t.Fatal("the example carries no config block, so installing with it shows the getting-started page")
+	}
+
+	dir := t.TempDir()
+	for name, body := range values.Config {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatalf("the example does not load: %v", err)
+	}
+
+	// It is meant to show what a filled page looks like, so it has to be one.
+	if n := config.CountServices(cfg); n < 4 {
+		t.Errorf("the example lists %d services: too few to show what a page looks like", n)
+	}
+	if len(cfg.Categories) < 2 {
+		t.Errorf("the example has %d categories, and grouping is half of what a directory does", len(cfg.Categories))
+	}
+	if len(cfg.Site.Locales) < 2 {
+		t.Error("the example is single-language, so it shows nothing about the switcher")
+	}
+
+	// And it has to be exemplary: a warning here is one every person who
+	// copies this file inherits.
+	//
+	// Two warnings are the right answer here rather than something to silence.
+	// The icons are CDN slugs because -emit-icons needs a writable assets dir,
+	// which an example install does not have; and there is no site url,
+	// because the person running this has no domain yet and a canonical link
+	// pointing at one they do not own is worse than none.
+	for _, w := range checkWarnings(cfg, dir) {
+		if strings.Contains(w, "load from a CDN") || strings.Contains(w, "has no url") {
+			continue
+		}
+		t.Errorf("the example config earns a warning: %s", w)
+	}
+}


### PR DESCRIPTION
`helm install` with the defaults gives you a cairn serving its own
getting-started page. That is right for a first install and shows you nothing
about what the page looks like with services on it. This is the file that fills
it:

```sh
helm install cairn oci://ghcr.io/morgankryze/charts/cairn -f values-example.yaml
kubectl port-forward svc/cairn 8080:80
```

Two locales, three ordered groups, six services, a welcome note and a legal
page. Every service points at a public site, so nothing is dead on arrival from
a cluster with egress, and nothing in the file is example-only syntax: replace
the services and it is a real config.

## The test is the point

An example nobody runs is an example that rots. A key gets renamed, the sample
keeps the old spelling, and the first person to try it meets an error the docs
promised would not happen.

`TestTheChartExampleIsAConfigCairnAccepts` reads the same `config:` block the
ConfigMap will carry, writes it to a temp dir, and puts it through cairn's own
loader and its own `-check`. It also asserts the example stays exemplary: at
least four services, at least two categories, at least two locales, because an
example with one of each demonstrates nothing.

Two warnings are tolerated, with the reason written down rather than silenced:
the icons are CDN slugs, since `-emit-icons` wants a writable assets dir that an
example install does not have, and there is no site `url`, since whoever runs
this has no domain yet and a canonical link pointing at one they do not own is
worse than none.

It earned its keep immediately: the first draft carried
`desc: { fr: Écrire à plusieurs, en direct., en: … }`, and the unquoted comma
split the flow mapping in two. The test failed with cairn's own message before
the file was ever committed.

Red-proven twice more: an id in capitals fails the load, and a misspelled
`strings` key fails the warning half.

Also verified by hand: `helm lint` with the file, `helm template` putting all
three YAML files into the ConfigMap, and a real cairn serving the rendered
config, which is where the missing `order:` on the categories showed up as
groups sorted alphabetically instead of the way they were written.
