### PR TITLE
Match a monitor's name whatever its case, and say what it offered

### DIFF
--- a/docs/recipes/status.md
+++ b/docs/recipes/status.md
@@ -180,9 +180,11 @@ exist.
 
 Three things have to be true, and only the first is work:
 
-1. **Each monitor is named after the cairn service id.** Kuma has no config
-   file and no setup API, so there is no `cairn -emit-kuma` and there cannot
-   be one: everything in Kuma is created by clicking, which is exactly how the
+1. **Each monitor is named after the cairn service id.** Capitals do not
+   matter, a monitor called `Immich` finds the service `immich`, but a space
+   or a dot does: neither can appear in an id. Kuma has no config file and no
+   setup API, so there is no `cairn -emit-kuma` and there cannot be one:
+   everything in Kuma is created by clicking, which is exactly how the
    instance this was tested against was set up, with a script driving a
    browser.
 2. **The monitors are attached to the status page**, inside a group. A page
@@ -284,10 +286,11 @@ pending, maintenance, validating`, in lower case: `validating` is the amber
   field. So a test you switched off draws a **green** pill on your directory.
   Delete the tests you stop using rather than pausing them. StatusCake also
   pages at 25, hence `?limit=100`.
-- **A monitor's name has to be a valid cairn service id**: lowercase letters,
-  digits and dashes. A monitor named after a domain, `pdf.example.org`,
-  never matches, because a service id carries no dot. Rename the monitor, or
-  the pill never appears.
+- **A monitor's name has to be a cairn service id**: letters, digits and
+  dashes. Capitals are fine, cairn folds them, so `Immich` finds `immich`. A
+  dot or a space is not: a monitor named after a domain, `pdf.example.org`,
+  never matches, because an id carries neither. Rename the monitor, or the
+  pill never appears.
 
 ### The token, if the API needs one
 

--- a/docs/recipes/status.md
+++ b/docs/recipes/status.md
@@ -13,7 +13,14 @@ and never asks a visitor's browser to.
 | anything else with a status API                        | `status.url`, `status.provider: json`, `status.map`  | the same, from any document shaped like a list of name, state |
 
 Whichever you pick, the agreement is the same: **the monitor's name for a
-service is the cairn service id**. Nothing else has to match.
+service is the cairn service id**. Nothing else has to match, and the case
+does not either: a service id is always lowercase, so a monitor called
+`Immich` finds the service `immich`. A name with a space or a dot in it will
+not, since neither can appear in an id.
+
+When something goes unmatched, the log says so at every poll, and it names
+both sides: the services with no pill, and the names the monitor offered that
+no id claims. Those two lists beside each other are usually the whole answer.
 
 Gatus first below, because it is the one cairn can write the config for.
 [Which monitors cairn reads](#which-monitors-cairn-reads) at the end of this

--- a/src/internal/status/gatus.go
+++ b/src/internal/status/gatus.go
@@ -112,9 +112,12 @@ func Key(group, name string) string {
 // mismatch is one log line instead of a silent missing pill.
 func Unmonitored(cfg *config.Config, statuses map[string]State) string {
 	var ids []string
+	claimed := make(map[string]bool, len(statuses))
 	for _, c := range cfg.Categories {
 		for _, s := range c.Services {
-			if _, ok := statuses[s.ID]; !ok {
+			if _, ok := statuses[s.ID]; ok {
+				claimed[s.ID] = true
+			} else {
 				ids = append(ids, s.ID)
 			}
 		}
@@ -122,8 +125,37 @@ func Unmonitored(cfg *config.Config, statuses map[string]State) string {
 	if len(ids) == 0 {
 		return ""
 	}
-	return fmt.Sprintf("%d services the %s at %s says nothing about, their cards show no pill: %s",
-		len(ids), cfg.Site.StatusProvider(), cfg.Site.StatusAddress(), strings.Join(ids, ", "))
+	subject, cards := "services", "their cards show"
+	if len(ids) == 1 {
+		subject, cards = "service", "its card shows"
+	}
+	line := fmt.Sprintf("%d %s the %s at %s says nothing about, %s no pill: %s",
+		len(ids), subject, cfg.Site.StatusProvider(), cfg.Site.StatusAddress(), cards, strings.Join(ids, ", "))
+	// The other half of the answer. Listing what is missing tells an operator
+	// nothing they did not already see on the page; listing the names the
+	// monitor actually offered puts the two side by side, and a mismatch that
+	// case-folding cannot reach, a domain name or a name with a space in it,
+	// is obvious at a glance. It is only the leftovers: names no service
+	// claimed, which is exactly the set worth renaming.
+	//
+	// Nothing is printed when every name was claimed, since a second list that
+	// is always there is a second list nobody reads.
+	var spare []string
+	for k := range statuses {
+		if !claimed[k] {
+			spare = append(spare, k)
+		}
+	}
+	if len(spare) == 0 {
+		return line
+	}
+	slices.Sort(spare)
+	names := "names"
+	if len(spare) == 1 {
+		names = "name"
+	}
+	return fmt.Sprintf("%s. It reports %d %s no service id matches: %s",
+		line, len(spare), names, strings.Join(spare, ", "))
 }
 
 // verifying and skipping are built once and reused. A client per poll would
@@ -273,7 +305,35 @@ func Fetch(src Source) (map[string]State, error) {
 	if err != nil {
 		return nil, err
 	}
-	return f(client, src)
+	got, err := f(client, src)
+	if err != nil {
+		return nil, err
+	}
+	return folded(got), nil
+}
+
+// folded lowercases what a monitor reported, because that is the difference
+// between a pill and no pill for the most ordinary mistake there is.
+//
+// A cairn service id can only be lowercase, idRe sees to that. A monitor name
+// is typed into a form by a person, who writes "Immich". Reported on issue
+// #33 by somebody whose setup was otherwise entirely correct: published page,
+// right slug, monitor green, and no pill on the card.
+//
+// Folding can add a match and cannot invent a wrong one, since the thing on
+// the other side is lowercase by construction. It is done here rather than in
+// each provider so a provider added later cannot forget it; Gatus is
+// unaffected either way, since it reports a key it has already normalised.
+//
+// Two monitors whose names differ only in case would collapse into one. That
+// is a directory nobody could read anyway, and the alternative is the silence
+// this exists to end.
+func folded(in map[string]State) map[string]State {
+	out := make(map[string]State, len(in))
+	for k, v := range in {
+		out[strings.ToLower(k)] = v
+	}
+	return out
 }
 
 // fetchGatus reads the endpoint statuses of a Gatus instance, keyed by

--- a/src/internal/status/jsonmap_test.go
+++ b/src/internal/status/jsonmap_test.go
@@ -49,8 +49,12 @@ func TestOneMappingShapeReadsEveryFlatAPI(t *testing.T) {
 				Up:          []string{"operational"},
 				Degraded:    []string{"degraded_performance", "partial_outage"},
 				Maintenance: []string{"under_maintenance"}},
-			map[string]string{"Packages": "up", "Actions": "maintenance",
-				"Pages": "degraded", "API": "degraded", "Git": "down"}},
+			// Lowercase on this side, because Fetch folds what a monitor
+			// reports: a service id cannot carry a capital, so "API" as a key
+			// could never have matched anything an operator is allowed to
+			// write. See TestAMonitorNameMatchesWhateverItsCase.
+			map[string]string{"packages": "up", "actions": "maintenance",
+				"pages": "degraded", "api": "degraded", "git": "down"}},
 		{"upptime, a bare array with its three states",
 			`[{"slug":"google","status":"up"},{"slug":"slow","status":"degraded"},
 			  {"slug":"gone","status":"down"}]`,

--- a/src/internal/status/naming_test.go
+++ b/src/internal/status/naming_test.go
@@ -1,0 +1,126 @@
+package status_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MorganKryze/cairn/src/internal/config"
+	"github.com/MorganKryze/cairn/src/internal/status"
+	"github.com/MorganKryze/cairn/src/internal/testutil"
+)
+
+// Reported on issue #33, from a working Uptime Kuma: the monitor was named
+// "Immich", the way a person names a thing in a form, and the service id was
+// immich, because cairn forces an id to lowercase. Nothing matched and the
+// card simply had no pill.
+//
+// A service id can only be lowercase, so folding what a monitor reports can
+// add a match and can never invent a wrong one. It is done for every provider
+// rather than for Kuma alone: Statuspage, Cachet and Upptime name their
+// components by hand too, and Gatus is unaffected because it reports a key it
+// has already normalised itself.
+func TestAMonitorNameMatchesWhateverItsCase(t *testing.T) {
+	page := `{"publicGroupList":[{"id":1,"name":"Services","monitorList":[
+		{"id":1,"name":"Immich","type":"http"},
+		{"id":2,"name":"PDF","type":"http"}]}]}`
+	beats := `{"heartbeatList":{"1":[{"status":1}],"2":[{"status":0}]}}`
+	srv := kuma(t, page, beats)
+
+	got, err := status.Fetch(status.Source{URL: srv.URL, Provider: "kuma", Slug: "probe"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for id, want := range map[string]string{"immich": status.LevelUp, "pdf": status.LevelDown} {
+		st, ok := got[id]
+		if !ok {
+			t.Errorf("the service id %q finds nothing, so its card shows no pill; keys came back as %v", id, got)
+			continue
+		}
+		if st.Level != want {
+			t.Errorf("%s is %q, want %q", id, st.Level, want)
+		}
+	}
+}
+
+// The same for the json mapper, whose key is whatever field an operator
+// pointed at, and which is written by a person just as often.
+func TestAMappedKeyMatchesWhateverItsCase(t *testing.T) {
+	body := `{"components":[{"name":"Photo-Backup","status":"operational"}]}`
+	got, err := status.Fetch(status.Source{
+		URL: serving(t, body), Provider: "json",
+		Map: status.Mapping{List: "components", Key: "name", State: "status", Up: []string{"operational"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := got["photo-backup"]; !ok {
+		t.Errorf("a mapped key keeps its case: %v", got)
+	}
+}
+
+// Folding the case closes the commonest mismatch, not every one: a monitor
+// named after a domain, or with a space in it, still matches nothing. The log
+// line is then the only thing standing between an operator and a silent
+// missing pill, and listing the ids it did not find is half an answer. What
+// they need is the other half, the names the monitor did offer, because the
+// mismatch is obvious the moment the two lists sit side by side.
+func TestTheUnmonitoredLineSaysWhatTheMonitorOffered(t *testing.T) {
+	cfg := twoServiceConfig(t)
+	line := status.Unmonitored(cfg, map[string]status.State{
+		"photo backup":    {Level: status.LevelUp},
+		"pad.example.org": {Level: status.LevelUp},
+	})
+	for _, want := range []string{"pad", "immich", "photo backup", "pad.example.org"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("the line does not carry %q:\n%s", want, line)
+		}
+	}
+}
+
+// And it stays quiet about the other side when every name was claimed: a
+// second list that is always there is a second list nobody reads.
+func TestTheUnmonitoredLineOffersNothingWhenEveryNameWasUsed(t *testing.T) {
+	cfg := twoServiceConfig(t)
+	line := status.Unmonitored(cfg, map[string]status.State{"pad": {Level: status.LevelUp}})
+	if strings.Contains(line, "reports") {
+		t.Errorf("nothing was left over, so nothing should be offered:\n%s", line)
+	}
+	if !strings.Contains(line, "immich") {
+		t.Errorf("the service with no status went unnamed:\n%s", line)
+	}
+}
+
+// twoServiceConfig is a config with the two ids the tests above look for.
+func twoServiceConfig(t *testing.T) *config.Config {
+	t.Helper()
+	cfg, err := config.Load(testutil.WriteFiles(t, map[string]string{
+		"site.yaml": "locales: [en]\nstatus:\n  provider: kuma\n  url: https://kuma.example.org\n  slug: tools\n",
+		"services.yaml": "- {id: pad, url: https://pad.example.org, name: Pad}\n" +
+			"- {id: immich, url: https://immich.example.org, name: Immich}\n",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cfg
+}
+
+// One is one. The line is read by an operator at the moment something is
+// wrong, and "1 services ... their cards" is a line that reads as though
+// nobody looked at it.
+func TestTheUnmonitoredLineCountsInWords(t *testing.T) {
+	cfg := twoServiceConfig(t)
+	one := status.Unmonitored(cfg, map[string]status.State{
+		"pad": {Level: status.LevelUp}, "photo backup": {Level: status.LevelUp},
+	})
+	for _, want := range []string{"1 service the", "its card shows no pill", "1 name no service id matches"} {
+		if !strings.Contains(one, want) {
+			t.Errorf("singular line missing %q:\n%s", want, one)
+		}
+	}
+	many := status.Unmonitored(cfg, map[string]status.State{"a": {}, "b": {}})
+	for _, want := range []string{"2 services the", "their cards show no pill", "2 names no service id matches"} {
+		if !strings.Contains(many, want) {
+			t.Errorf("plural line missing %q:\n%s", want, many)
+		}
+	}
+}


### PR DESCRIPTION
Reported on #33.

**What does this change, seen from the page or the config?**

A card that should carry a pill carries one.

The reporter's setup was entirely correct: published Uptime Kuma status page,
right slug, monitor green at 100%. His monitor was named `Immich`, the way a
person names a thing in a form, and his service id was `immich`, because
`idRe` forces an id to lowercase. Nothing matched, so the card had no pill and
the page gave no hint why. Reproduced from his own screenshot before anything
was changed:

```
keys cairn came back with: map[Immich:{up }]
```

`Fetch` now folds what a provider reports. A service id can only be lowercase,
so folding can add a match and can never invent a wrong one. It is done once
for every provider rather than inside each: Statuspage, Cachet and Upptime
have their component names typed in by hand too, and Gatus is unaffected
because it reports a key it has already normalised itself. Two monitors
differing only in case would collapse into one, which is a directory nobody
could read anyway, and the alternative is the silence this exists to end.

**The second half.** Folding closes the commonest mismatch, not every one: a
monitor named after a domain still matches nothing, and that trap has already
caught one person on this same issue. The log line listed only what was
missing, which an operator can already see on the page. It now names both
sides:

```
1 service the kuma at http://kuma.example.org says nothing about, its card
shows no pill: pad. It reports 1 name no service id matches: photo backup
```

Only the leftovers, since those are the set worth renaming, and nothing at all
when every name was claimed: a second list that is always there is a second
list nobody reads.

While in that sentence, the count and its noun disagreed: "1 services ... their
cards". It is a line an operator only ever reads when something is already
wrong.

Verified end to end against the reporter's exact config, with a stand-in Kuma
answering his shapes: the pill appears, and the log line reads as above.

- [x] `go test ./...` passes (505, 5 new)
- [x] Docs updated in the same PR