### PR TITLE
Pin the buildkit image, name the demo pages in English, stop curling the chart values

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,16 @@ jobs:
       # through, and the same object behind it, checked rather than assumed.
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
         with:
-          driver-opts: image=mirror.gcr.io/moby/buildkit:buildx-stable-1
+          # Pinned like every action above. This one executes during the
+          # build with the context in reach, and it was the last moving
+          # tag in the chain. The digest is the same on Docker Hub and on
+          # the mirror, so it does not tie us to either.
+          #
+          # Dependabot cannot watch an image named inside a workflow
+          # (dependabot-core#5541), so a pin here would rot in silence.
+          # The buildkit-pin job in security.yml is what stops that: it
+          # runs weekly and says when buildx-stable-1 has moved past it.
+          driver-opts: image=mirror.gcr.io/moby/buildkit@sha256:2f5adac4ecd194d9f8c10b7b5d7bceb5186853db1b26e5abd3a657af0b7e26ec # buildx-stable-1
 
       # A pull request builds the image but never publishes it, so a fork PR
       # needs no registry credentials.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,16 @@ jobs:
       # through, and the same object behind it, checked rather than assumed.
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
         with:
-          driver-opts: image=mirror.gcr.io/moby/buildkit:buildx-stable-1
+          # Pinned like every action above. This one executes during the
+          # build with the context in reach, and it was the last moving
+          # tag in the chain. The digest is the same on Docker Hub and on
+          # the mirror, so it does not tie us to either.
+          #
+          # Dependabot cannot watch an image named inside a workflow
+          # (dependabot-core#5541), so a pin here would rot in silence.
+          # The buildkit-pin job in security.yml is what stops that: it
+          # runs weekly and says when buildx-stable-1 has moved past it.
+          driver-opts: image=mirror.gcr.io/moby/buildkit@sha256:2f5adac4ecd194d9f8c10b7b5d7bceb5186853db1b26e5abd3a657af0b7e26ec # buildx-stable-1
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -42,3 +42,39 @@ jobs:
           severity: HIGH,CRITICAL
           exit-code: "1"
           ignore-unfixed: true
+
+  # The one pinned thing nothing else watches.
+  #
+  # Every action in this repository is pinned to a commit, and the buildkit
+  # image the builder runs is pinned to a digest for the same reason: it
+  # executes during the build, with the context in reach. Dependabot updates
+  # the actions and would update a Dockerfile, but it does not read an image
+  # named inside a workflow (dependabot-core#5541), so that digest is the one
+  # pin with nobody behind it. Left alone it would quietly freeze the builder
+  # on whatever was current the day it was written, which is a worse place to
+  # be than following a tag.
+  #
+  # So this fails, weekly, when buildx-stable-1 has moved past the pin. Never
+  # on a pull request: the jobs above are required checks, and a buildkit
+  # release is no reason to stop everyone merging.
+  buildkit-pin:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: buildx-stable-1 still points at the digest we build with
+        run: |
+          # The two files by name, not a glob: a glob includes this one,
+          # and the pattern below then matches itself.
+          pinned=$(grep -hoE 'buildkit@sha256:[0-9a-f]{64}' \
+            .github/workflows/build.yml .github/workflows/release.yml | sort -u)
+          test "$(echo "$pinned" | wc -l)" -eq 1 || {
+            echo "::error::the workflows pin different buildkit digests: $pinned"; exit 1; }
+          pinned=${pinned#buildkit@}
+          current=$(docker buildx imagetools inspect \
+            mirror.gcr.io/moby/buildkit:buildx-stable-1 --format '{{.Manifest.Digest}}')
+          echo "pinned:  $pinned"
+          echo "current: $current"
+          test "$pinned" = "$current" || {
+            echo "::error::buildx-stable-1 is now $current; bump the pin in build.yml and release.yml"
+            exit 1; }

--- a/demo/config/site.yaml
+++ b/demo/config/site.yaml
@@ -133,7 +133,7 @@ pages:
             your data and your independence; you lose the comfort of having
             nothing to maintain. It is the choice I made for everything
             labelled "Self-hosted".
-  - id: mentions-legales
+  - id: legal
     title: { fr: Mentions légales, en: Legal notice }
     body:
       fr: >
@@ -177,7 +177,7 @@ pages:
             The names and logos of the listed services belong to their
             respective projects. The rest of this site's content is
             published under the publisher's responsibility.
-  - id: confidentialite
+  - id: privacy
     title: { fr: Confidentialité, en: Privacy }
     sections:
       - title: { fr: Données collectées, en: Data we collect }

--- a/docs/deployment/helm.md
+++ b/docs/deployment/helm.md
@@ -34,11 +34,13 @@ there if you ever want to break the pair apart.
 
 The defaults install a cairn that serves its own getting-started page, which is
 right for a first install and tells you nothing about what the page looks like
-with services on it. The chart ships a values file that fills it:
+with services on it. The chart ships a values file that fills it, inside the
+package, so pulling the chart is enough and nothing has to be fetched from
+GitHub:
 
 ```sh
-curl -O https://raw.githubusercontent.com/MorganKryze/cairn/main/charts/cairn/values-example.yaml
-helm install cairn oci://ghcr.io/morgankryze/charts/cairn -f values-example.yaml
+helm pull oci://ghcr.io/morgankryze/charts/cairn --untar
+helm install cairn oci://ghcr.io/morgankryze/charts/cairn -f cairn/values-example.yaml
 kubectl port-forward svc/cairn 8080:80
 ```
 


### PR DESCRIPTION
Three small things off the backlog. No product code changes.

**The buildkit image is pinned by digest.** It runs during the build with the
context in reach, and it was the last moving tag in a chain where every action
is pinned to a commit. The digest is identical on Docker Hub and on the
mirror, so the pin does not tie us to either registry.

This was deferred once before, for a good reason: Dependabot updates the
actions and would update a Dockerfile, but it does not read an image named
inside a workflow file ([dependabot-core#5541](https://github.com/dependabot/dependabot-core/issues/5541),
and the [docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot)
say the same). A pin nothing watches quietly freezes the builder on whatever
was current the day it was written, which is worse than following the tag.

So it arrives with a weekly job that fails when `buildx-stable-1` has moved
past the pin and names the digest to bump to. It never runs on a pull request:
the other jobs in that file are required checks, and a buildkit release is no
reason to stop everyone merging.

Both of its failure modes were exercised before pushing, which is how the
first version got caught: it grepped the workflows with a glob, so the pattern
matched itself inside `security.yml` and the job saw two pins where there is
one. It names the two files now. The pinned digest was also used to build the
image locally, so the pin is known to work rather than assumed to.

**The two older demo pages are `legal` and `privacy`.** Ids become URLs, and
the rule set with `hosting` was English by default. These two predate it and
sat beside it in the same footer, so the demo contradicted itself: `/fr/hosting/`
next to `/fr/mentions-legales/`. Titles untouched and still translated.

**`helm.md` stops curling the values file.** It has been inside the packaged
chart all along, so `helm pull --untar` gives it to you. One fewer thing to
fetch, and one fewer way to end up with a values file from `main` against a
chart that is not `main`.

- [x] `go test ./...` passes (505, unchanged, no Go touched)
- [x] Docs updated in the same PR