### PR TITLE
Publish the image to Docker Hub, and three smaller corrections

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -28,7 +28,9 @@ One or two sentences: what this release is about, in plain words.
 ## 📦 Image
 
 ```sh
-docker pull ghcr.io/morgankryze/cairn:X.Y.Z
+docker pull ghcr.io/morgankryze/cairn:X.Y.Z   # or: docker pull morgankryze/cairn:X.Y.Z
 ```
 
-This release also moves `X.Y`, `X` (majors ≥ 1), `stable` and `latest`.
+This release also moves `X.Y`, `X` (majors ≥ 1), `stable` and `latest`, on
+both registries. Docker Hub gets the digest ghcr signed, copied rather than
+rebuilt, so the two are the same object and `cosign verify` works on either.

--- a/.github/badges.sh
+++ b/.github/badges.sh
@@ -20,9 +20,11 @@ color=$(awk -v p="$pct" 'BEGIN {
 
 # badge LABEL VALUE LABEL_WIDTH VALUE_WIDTH COLOUR NAME
 #
-# The widths are given rather than measured: this writes the SVG by hand
-# instead of pulling in a renderer, and a shell script has no font metrics.
-# They only have to hold what these two ever say, a percentage and a count.
+# The widths are passed in rather than worked out here: this writes the SVG by
+# hand instead of pulling in a renderer, and a shell script has no font
+# metrics. They were measured elsewhere, in Verdana at 11px, the first family
+# the SVG asks for, and they are what makes the two badges look like a pair:
+# roughly 6px of air on each side of a label, 4.5px on each side of a value.
 badge() {
   local w=$(($3 + $4))
   cat >"/tmp/$6.svg" <<SVG
@@ -40,7 +42,16 @@ SVG
 }
 
 badge coverage "${pct}%" 62 46 "$color" coverage
-badge tests "$tests" 44 46 "#4c1" tests
+
+# A count is the one value here that can gain a character, so its box is the
+# one that has to follow: a digit is exactly 7px wide in Verdana at 11px, and
+# 9px is the air the coverage value already carries. A box wide enough for a
+# percentage is what left `505` floating in the middle of its own.
+#
+# Even widths on purpose where the choice exists: the text is centred on
+# width/2 in shell arithmetic, which truncates, so an odd box sits its text
+# half a pixel off centre.
+badge tests "$tests" 38 "$((9 + 7 * ${#tests}))" "#4c1" tests
 
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,12 @@ jobs:
       contents: read
       packages: write # pushes the versioned tags to ghcr.io
       id-token: write # cosign signs keylessly against this workflow identity
+    # What the `hub` job copies. The tag rules live here and only here: a
+    # second registry that recomputed them would be a list to keep in step.
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+      tags: ${{ steps.meta.outputs.tags }}
+      floating: ${{ steps.promote.outputs.tags }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -185,6 +191,7 @@ jobs:
       # rebuilds the index instead of copying it, the tag would point at an
       # unsigned digest, and this is what would catch it.
       - name: move stable and latest onto the verified digest
+        id: promote
         if: ${{ !contains(github.ref_name, '-') }}
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
@@ -198,7 +205,90 @@ jobs:
               exit 1
             }
           done
+          # Written from inside the loop's own step rather than restated below,
+          # so a prerelease, which skips this step, hands the `hub` job an
+          # empty string and floats nothing there either.
+          echo "tags=${IMAGE}:stable ${IMAGE}:latest" >> "$GITHUB_OUTPUT"
 
+
+  # Docker Hub, from the digest ghcr has already published, signed and proved.
+  #
+  # A copy, not a second push target. Naming docker.io in the build's own tag
+  # list is one line shorter and it puts Hub on the critical path of every
+  # release: this is the registry cairn stopped pulling from after 1.13.2,
+  # because it does not fail by saying so, it times out. As a separate job a
+  # Hub outage is one red square on a release that is already complete and
+  # signed on ghcr, and it can be re-run by itself.
+  #
+  # Copying the index means the same digest lands in both registries, so the
+  # SLSA provenance and the SBOM come with it and one signature covers the
+  # same bytes either side. Asserted below rather than assumed, the way the
+  # promotion above is.
+  hub:
+    needs: image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # cosign signs keylessly, same workflow identity as ghcr
+    # No setup-buildx-action here, deliberately. `imagetools` talks to the two
+    # registries directly and needs no builder, so starting one would pull the
+    # buildkit image to do nothing. The runner ships the plugin itself, listed
+    # as Docker-Buildx in the ubuntu image manifest.
+    steps:
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      # ghcr serves this package publicly, so the read would work without a
+      # token. Logging in anyway keeps the copy off the anonymous rate limit.
+      - uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # No registry key: docker/login-action defaults to Docker Hub. The
+      # account name is public, so only the token is a secret. It carries
+      # Read & Write and not Delete, which is why nothing here removes a tag.
+      - uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4
+        with:
+          username: morgankryze
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: copy the verified digest to Docker Hub, then sign it there
+        env:
+          DIGEST: ${{ needs.image.outputs.digest }}
+          TAGS: ${{ needs.image.outputs.tags }}
+          FLOATING: ${{ needs.image.outputs.floating }}
+        run: |
+          set -euo pipefail
+          # The tags the release actually published, from the job that
+          # published them, with the registry swapped. Nothing here decides
+          # which tags a version gets, so a prerelease floats nothing here
+          # for the same reason it floats nothing on ghcr: FLOATING is empty.
+          refs=$(printf '%s %s' "$TAGS" "$FLOATING" | tr ' ' '\n' | grep . \
+            | sed 's|^ghcr\.io/|docker.io/|')
+
+          # Both names come out of the tag lists rather than out of
+          # github.repository, which carries a capital the registries refuse.
+          src=$(printf '%s\n' "$TAGS" | head -n1); src="${src%%:*}"
+          dst=$(printf '%s\n' "$refs" | head -n1); dst="${dst%%:*}"
+
+          for ref in $refs; do
+            docker buildx imagetools create --tag "$ref" "${src}@${DIGEST}"
+            landed=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$ref")
+            [ "$landed" = "$DIGEST" ] || {
+              echo "::error::${ref} points at ${landed}, not the signed ${DIGEST}"
+              exit 1
+            }
+          done
+
+          # A signature is an object in the registry it is pushed to, so the
+          # one made against ghcr does not exist here. Same keyless identity,
+          # same digest, so SECURITY.md's command works unchanged on either
+          # name, which is what the verify below is checking.
+          cosign sign --yes "${dst}@${DIGEST}"
+          cosign verify "${dst}@${DIGEST}" \
+            --certificate-identity-regexp '^https://github.com/MorganKryze/cairn/' \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com >/dev/null
 
   chart:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 
 # just shots installs playwright here on demand; nothing to commit
 node_modules/
+
+# macOS writes one into any folder opened in Finder, docs/assets especially
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![License: GPL-3.0](https://img.shields.io/badge/license-GPL--3.0-blue.svg)](LICENSE)
 
 [![Image](https://img.shields.io/badge/image-4.4%20MB%20pull-2496ED?logo=docker&logoColor=white)](https://github.com/MorganKryze/cairn/pkgs/container/cairn)
+[![Docker Hub](https://img.shields.io/docker/pulls/morgankryze/cairn?label=docker%20hub&color=2496ED&logo=docker&logoColor=white)](https://hub.docker.com/r/morgankryze/cairn)
 [![Go](https://img.shields.io/badge/Go-single%20static%20binary-00ADD8?logo=go&logoColor=white)](https://go.dev)
 [![Helm](https://img.shields.io/badge/Helm-chart-0F1689?logo=helm&logoColor=white)](docs/deployment/helm.md)
 [![Docker Compose](https://img.shields.io/badge/Compose-ready-2496ED?logo=docker&logoColor=white)](docs/deployment/docker-compose.md)

--- a/README.md
+++ b/README.md
@@ -312,10 +312,14 @@ it, and a translation are all work.
 <span title="Maintenance">🚧</span>
 </td>
 <td align="center" width="150">
+<a href="https://github.com/AntonPalmqvist"><img src="https://github.com/AntonPalmqvist.png?size=100" width="80" alt=""><br><sub><b>AntonPalmqvist</b></sub></a><br>
+<a href="https://github.com/MorganKryze/cairn/issues/33" title="Bug reports">🐛</a>
+<a href="https://github.com/MorganKryze/cairn/issues/33" title="Ideas and planning">🤔</a>
+</td>
+<td align="center" width="150">
 <a href="https://github.com/rbourgeat"><img src="https://github.com/rbourgeat.png?size=100" width="80" alt=""><br><sub><b>rbourgeat</b></sub></a><br>
 <a href="https://github.com/MorganKryze/cairn/pull/51" title="Code">💻</a>
-<a href="https://github.com/MorganKryze/cairn/issues/33" title="Bug reports">🐛</a>
-<span title="Ideas and planning">🤔</span>
+<a href="https://github.com/MorganKryze/cairn/issues/50" title="Ideas and planning">🤔</a>
 </td>
 </tr>
 </table>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,6 +31,13 @@ cosign verify ghcr.io/morgankryze/cairn:stable \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
 
+The same image is published to Docker Hub as `morgankryze/cairn`, and the
+command works there unchanged: the release copies the digest ghcr has already
+signed rather than building a second time, so both names resolve to the same
+object and the signature covers the same bytes. Substituting one name for the
+other in any command on this page is safe, including the provenance inspection
+below.
+
 The [Helm chart](docs/deployment/helm.md) is published the same way, as an OCI
 artifact next to the image, and signed by the same workflow:
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,86 @@
+# cairn
+
+The directory page for the people you host services for: no account,
+multilingual, live status, one tiny container.
+
+![The cairn home page: a welcome note, service cards grouped by category with live status pills, and a category trail in the margin](https://raw.githubusercontent.com/MorganKryze/cairn/main/docs/assets/home-light.png)
+
+You run things for other people. Family, a club, a team, a floor of an office.
+They have no idea what any of it is called or where it lives, and they should
+not have to. cairn is the one page you send them: what you host, what it is
+for, whether it is up, in their own language.
+
+You write two YAML files. cairn serves them. There is no database, no account
+system, no admin panel, and nothing to log into.
+
+**[Live demo](https://cairn.libresoftware.cloud)** ·
+**[Source and documentation](https://github.com/MorganKryze/cairn)**
+
+## Run it
+
+```sh
+docker run --rm -p 8080:8080 -v ./config:/config:ro morgankryze/cairn:stable
+```
+
+Or with Compose, which is how most people run it:
+
+```yaml
+services:
+  cairn:
+    image: morgankryze/cairn:stable
+    ports:
+      - 8080:8080
+    volumes:
+      - ./config:/config:ro
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+```
+
+The [getting started guide](https://github.com/MorganKryze/cairn/blob/main/docs/getting-started.md)
+has the two config files to put in `./config`, and it is a five minute read.
+
+## Tags
+
+| Tag                                                     | Points at                          |
+| ------------------------------------------------------- | ---------------------------------- |
+| `stable`, `latest`                                      | the newest release                 |
+| `<major>`, `<major>.<minor>`, `<major>.<minor>.<patch>` | that major, minor or exact version |
+
+Pin the exact version if something else depends on the page looking the way it
+looks today. `1` and `stable` move on every release; the
+[upgrading notes](https://github.com/MorganKryze/cairn/blob/main/docs/upgrading.md)
+say what a version can refuse to load.
+
+Built for `linux/amd64` and `linux/arm64`, so a Raspberry Pi is a first-class
+target rather than an afterthought.
+
+## What is in it
+
+A single static Go binary on `scratch`, with a CA bundle and nothing else. No
+shell, no package manager, no interpreter: there is nothing in the image to
+run but cairn. It drops every capability, runs as a non-root user and needs no
+writable filesystem, which is what makes the Compose block above possible.
+
+## Verify what you pulled
+
+This image is the same object published to GitHub Container Registry, copied
+here digest for digest. It is signed keylessly, so there is no maintainer key
+to steal, and it carries SLSA build provenance and a software bill of
+materials.
+
+```sh
+cosign verify morgankryze/cairn:stable \
+  --certificate-identity-regexp '^https://github.com/MorganKryze/cairn/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+The [security policy](https://github.com/MorganKryze/cairn/blob/main/SECURITY.md)
+explains what that proves and how to report a problem.
+
+## Licence
+
+GPL-3.0. Issues, translations and pull requests are welcome on
+[GitHub](https://github.com/MorganKryze/cairn).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,6 +55,11 @@ docker compose up -d
 Open <http://localhost:8080>. You get a finished page: one category, one
 card, working search, light and dark.
 
+The image is also on Docker Hub as `morgankryze/cairn`, if that is where the
+rest of your stack comes from. It is the same object, copied from the same
+signed digest, so the two are interchangeable. This documentation uses `ghcr.io`
+throughout because it is where the release publishes first.
+
 ## 3. Make it yours
 
 Add `config/site.yaml`, every key optional:

--- a/scripts/screenshots.mjs
+++ b/scripts/screenshots.mjs
@@ -19,8 +19,11 @@ import { readFileSync } from 'node:fs';
 
 const OUT = join(dirname(fileURLToPath(import.meta.url)), '..', 'docs', 'assets');
 const URL = process.env.CAIRN_URL ?? 'http://127.0.0.1:8080/en/';
-// The same site, for the shots that open a page of their own.
-const DEMO = URL.replace(/\/en\/$/, '/en/');
+// The same site, for the shots that open a page of their own. The two below
+// append a path to it, so what it has to guarantee is the trailing slash, not
+// the locale: this replaced `/en/` with `/en/`, which is nothing, and left
+// `CAIRN_URL=http://host/en` producing `http://host/enwhoami/`.
+const DEMO = URL.endsWith('/') ? URL : URL + '/';
 const SIZE = { width: 1440, height: 1000 };
 
 const browser = await chromium.launch();


### PR DESCRIPTION
Docker Hub as a second registry, plus the badge and credit fixes and one CodeQL alert that came up while this was being written.

## Docker Hub

A new `hub` job in `release.yml`, after `image`. It **copies the index ghcr has already published, signed and verified**, rather than adding `docker.io` to the build's own tag list.

The one line version would put Hub on the critical path of every release, and Hub is the registry cairn stopped pulling from after 1.13.2 precisely because it does not fail by saying so, it times out. As a separate job, a Hub outage is one red square on a release that is already complete and signed on ghcr, and it can be re-run alone.

**Tested against the live 1.17.1 index**, copied into a throwaway local registry:

- the digest survives the copy, for all five tags
- both platform manifests and both attestation manifests come with it
- the SLSA provenance reads back from the copy

So the two registries hold the same object, and `cosign verify` works on either name. The image is signed again on Hub because a signature is an object in the registry it is pushed to, and the job runs the verify command `SECURITY.md` hands the reader before it finishes.

The tag list is an output of the `image` job rather than a second list to keep in step, so a prerelease floats nothing here for the same reason it floats nothing there.

`docker/README.md` is the Hub overview page, carried in the repo so it has a reviewable source. It is **not** synced by a workflow: the action for that wants a token with delete scope, which is a worse credential to leave sitting in a secret than the overview is worth. It names no version, so it does not go stale.

Docs follow: `SECURITY.md` says the two names are interchangeable and why, `getting-started.md` mentions the alternative while keeping `ghcr.io` as the documented default, and the release template carries both pull commands.

## The tests badge

It carried a value box wide enough for a percentage, so `505` sat with 12.5px of air on each side against coverage's 4.6, measured in Verdana at 11px in a browser. It now follows the digit count, 7px each plus the 9px coverage already carries. 90px wide down to 68, and a four figure count will not cramp.

## Contributors

Issue #33 is AntonPalmqvist's, not rbourgeat's. He opened it, then found and photographed the case-sensitivity bug that 1.17.0 fixed, and he is credited for both. rbourgeat's own request is #50, which his entry points at now.

## CodeQL alert 10

`js/identity-replacement`: the screenshot script derived its base URL by replacing `/en/` with `/en/`. What the two shots that append a path need is the trailing slash, and without it `CAIRN_URL=http://host/en` produced `http://host/enwhoami/`.