### PR TITLE
Make Docker Hub the documented default, and give it the same tags

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -28,7 +28,7 @@ One or two sentences: what this release is about, in plain words.
 ## 📦 Image
 
 ```sh
-docker pull ghcr.io/morgankryze/cairn:X.Y.Z   # or: docker pull morgankryze/cairn:X.Y.Z
+docker pull morgankryze/cairn:X.Y.Z   # or: ghcr.io/morgankryze/cairn:X.Y.Z
 ```
 
 This release also moves `X.Y`, `X` (majors ≥ 1), `stable` and `latest`, on

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,6 +142,9 @@ jobs:
     permissions:
       contents: read
       packages: write # pushes ghcr.io/…:unstable, on main only
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -182,7 +185,8 @@ jobs:
             type=sha,prefix=
 
       # vet + tests run inside the Dockerfile, so they gate the push.
-      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+      - id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: docker/Dockerfile
@@ -197,6 +201,54 @@ jobs:
           provenance: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # `unstable` and the by-sha tag, on Docker Hub too, so the two registries
+  # carry the same names rather than Hub holding releases alone.
+  #
+  # Same shape as the release's own hub job and for the same reason: it copies
+  # the digest the build already pushed instead of building again, and it sits
+  # outside the `image` job so it cannot fail one. That matters more here than
+  # there, because `image` is a required check and a Docker Hub hiccup has no
+  # business blocking a merge. This job is deliberately not a required check.
+  #
+  # Nothing signs `unstable` on either registry: it is whatever main is this
+  # minute, not something anyone is asked to trust. Releases are signed, in
+  # release.yml, on both.
+  hub:
+    needs: image
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4
+        with:
+          username: morgankryze
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: copy the pushed digest to Docker Hub
+        env:
+          DIGEST: ${{ needs.image.outputs.digest }}
+          TAGS: ${{ needs.image.outputs.tags }}
+        run: |
+          set -euo pipefail
+          refs=$(printf '%s' "$TAGS" | tr ' ' '\n' | grep . \
+            | sed 's|^ghcr\.io/|docker.io/|')
+          src=$(printf '%s\n' "$TAGS" | head -n1); src="${src%%:*}"
+          for ref in $refs; do
+            docker buildx imagetools create --tag "$ref" "${src}@${DIGEST}"
+            landed=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "$ref")
+            [ "$landed" = "$DIGEST" ] || {
+              echo "::error::${ref} points at ${landed}, not ${DIGEST}"
+              exit 1
+            }
+          done
 
   demo:
     runs-on: ubuntu-latest

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,120 @@
+name: mirror
+
+# Copies tags from ghcr to Docker Hub, on demand and never on its own.
+#
+# It exists for two jobs. The first was one-off: Docker Hub joined at 1.17.2,
+# and everything published before that lived on ghcr alone, so the two
+# registries told different stories about the same project. The second is
+# repair. Releases copy themselves, but if that job ever fails after ghcr is
+# already published, re-running the whole release is a heavier thing than
+# copying one tag across, and this is the smaller tool.
+#
+# It never builds. Every tag it writes is the index ghcr already holds, copied
+# digest for digest, which is asserted per tag rather than assumed.
+#
+# It signs nothing, deliberately. cosign signs a digest, and the signature made
+# at release time lives in the registry it was pushed to. Signing a 1.9.0 here
+# in 2026 would produce a valid signature saying something true but useless,
+# that this workflow pushed those bytes today, in a place where a reader will
+# reasonably take it for the release's own. Better that `cosign verify` says
+# nothing on a mirrored old tag and the reader goes to ghcr, which SECURITY.md
+# tells them to do. Releases from 1.17.2 onward are signed on both registries
+# by release.yml, at the moment they are cut.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: "Tags to copy, space separated. Empty means every release, every floating version, stable, latest and unstable."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mirror
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read # reads the source index from ghcr
+    steps:
+      - uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4
+        with:
+          username: morgankryze
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: work out which tags to copy
+        id: pick
+        env:
+          WANTED: ${{ inputs.tags }}
+        run: |
+          set -euo pipefail
+          if [ -n "$WANTED" ]; then
+            # Held to what a tag can contain before it reaches $GITHUB_OUTPUT,
+            # where a newline would be a second key rather than a bad tag.
+            # Dispatching this already needs write access, so this is a guard
+            # against a slip, not against a stranger.
+            case "$WANTED" in
+              *[!A-Za-z0-9._\ -]*|"")
+                echo "::error::tags may only contain letters, digits, dot, underscore, dash and spaces"
+                exit 1 ;;
+            esac
+            echo "tags=$WANTED" >> "$GITHUB_OUTPUT"
+            echo "asked for: $WANTED"
+            exit 0
+          fi
+
+          token=$(curl -fsS "https://ghcr.io/token?scope=repository:morgankryze/cairn:pull" \
+            | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])')
+          curl -fsS -H "Authorization: Bearer $token" \
+            "https://ghcr.io/v2/morgankryze/cairn/tags/list?n=1000" > tags.json
+
+          # The version tags are derived from the releases rather than matched
+          # by shape, because a commit hash can look exactly like a major: the
+          # repository has tags `3403640` and `5299497`, and any pattern loose
+          # enough to accept `1` accepts those too. Starting from X.Y.Z and
+          # keeping only the X.Y and X that actually exist cannot make that
+          # mistake.
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json, re
+          tags = set(json.load(open("tags.json"))["tags"])
+          rel = sorted(t for t in tags if re.fullmatch(r"\d+\.\d+\.\d+", t))
+          want = list(rel)
+          want += sorted({t.rsplit(".", 1)[0] for t in rel} & tags)
+          want += sorted({t.split(".", 1)[0] for t in rel} & tags)
+          want += [t for t in ("stable", "latest", "unstable") if t in tags]
+          print("tags=" + " ".join(want))
+          PY
+          echo "found: $(grep '^tags=' "$GITHUB_OUTPUT" | tail -n1)"
+
+      - name: copy each one, and prove it landed unchanged
+        env:
+          TAGS: ${{ steps.pick.outputs.tags }}
+        run: |
+          set -euo pipefail
+          src=ghcr.io/morgankryze/cairn
+          dst=docker.io/morgankryze/cairn
+          copied=0
+          for tag in $TAGS; do
+            digest=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "${src}:${tag}")
+            docker buildx imagetools create --tag "${dst}:${tag}" "${src}@${digest}"
+            landed=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "${dst}:${tag}")
+            [ "$landed" = "$digest" ] || {
+              echo "::error::${dst}:${tag} points at ${landed}, not the ${digest} ghcr holds"
+              exit 1
+            }
+            echo "  ${tag}  ${digest}"
+            copied=$((copied + 1))
+          done
+          echo "::notice::mirrored ${copied} tags to Docker Hub"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Release](https://img.shields.io/github/v/release/MorganKryze/cairn?label=release&color=247b7b)](https://github.com/MorganKryze/cairn/releases)
 [![License: GPL-3.0](https://img.shields.io/badge/license-GPL--3.0-blue.svg)](LICENSE)
 
-[![Image](https://img.shields.io/badge/image-4.4%20MB%20pull-2496ED?logo=docker&logoColor=white)](https://github.com/MorganKryze/cairn/pkgs/container/cairn)
+[![Image](https://img.shields.io/badge/image-4.4%20MB%20pull-2496ED?logo=docker&logoColor=white)](https://hub.docker.com/r/morgankryze/cairn/tags)
 [![Docker Hub](https://img.shields.io/docker/pulls/morgankryze/cairn?label=docker%20hub&color=2496ED&logo=docker&logoColor=white)](https://hub.docker.com/r/morgankryze/cairn)
 [![Go](https://img.shields.io/badge/Go-single%20static%20binary-00ADD8?logo=go&logoColor=white)](https://go.dev)
 [![Helm](https://img.shields.io/badge/Helm-chart-0F1689?logo=helm&logoColor=white)](docs/deployment/helm.md)
@@ -182,7 +182,7 @@ deliberately tight, from the image down to the wire.
 Nothing to write, nothing to mount, just look at it:
 
 ```sh
-docker run --rm -p 8080:8080 ghcr.io/morgankryze/cairn:stable
+docker run --rm -p 8080:8080 morgankryze/cairn:stable
 ```
 
 That is a running cairn on <http://localhost:8080>, telling you what to feed
@@ -204,7 +204,7 @@ every text key works both ways. See [Languages](docs/configuration/i18n.md).)
 # compose.yaml
 services:
   cairn:
-    image: ghcr.io/morgankryze/cairn:latest
+    image: morgankryze/cairn:latest
     ports:
       - 8080:8080
     volumes:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,17 +26,22 @@ there is no maintainer key to steal, the signature is bound to the workflow
 identity.
 
 ```sh
-cosign verify ghcr.io/morgankryze/cairn:stable \
+cosign verify morgankryze/cairn:stable \
   --certificate-identity-regexp '^https://github.com/MorganKryze/cairn/' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
 
-The same image is published to Docker Hub as `morgankryze/cairn`, and the
-command works there unchanged: the release copies the digest ghcr has already
-signed rather than building a second time, so both names resolve to the same
-object and the signature covers the same bytes. Substituting one name for the
-other in any command on this page is safe, including the provenance inspection
-below.
+The same image is published to GitHub Container Registry as
+`ghcr.io/morgankryze/cairn`, and the command works there unchanged: the release
+publishes and signs on ghcr first, then copies that exact digest to Docker Hub
+rather than building a second time, so both names resolve to the same object
+and the signature covers the same bytes.
+
+Two limits worth knowing. Signatures exist on both registries **from 1.17.2
+onward**, which is when Docker Hub joined; earlier versions were mirrored to it
+afterwards and carry their signature on ghcr alone, so verify those against
+`ghcr.io/morgankryze/cairn`. The build provenance and the bill of materials
+travel with the image itself and are readable from either name at any version.
 
 The [Helm chart](docs/deployment/helm.md) is published the same way, as an OCI
 artifact next to the image, and signed by the same workflow:
@@ -50,7 +55,7 @@ cosign verify ghcr.io/morgankryze/charts/cairn:1.12.0 \
 It also ships SLSA build provenance and a software bill of materials:
 
 ```sh
-docker buildx imagetools inspect ghcr.io/morgankryze/cairn:stable \
+docker buildx imagetools inspect morgankryze/cairn:stable \
   --format '{{ json .Provenance }}'
 ```
 

--- a/charts/cairn/values.yaml
+++ b/charts/cairn/values.yaml
@@ -4,7 +4,7 @@
 # serves its own getting-started page and tells you what to feed it.
 
 image:
-  repository: ghcr.io/morgankryze/cairn
+  repository: morgankryze/cairn
   # Empty means the chart's appVersion, which is the cairn this chart was
   # released with. Set a tag to pin a version or to follow `stable`.
   tag: ""

--- a/docker/README.md
+++ b/docker/README.md
@@ -48,6 +48,8 @@ has the two config files to put in `./config`, and it is a five minute read.
 | ------------------------------------------------------- | ---------------------------------- |
 | `stable`, `latest`                                      | the newest release                 |
 | `<major>`, `<major>.<minor>`, `<major>.<minor>.<patch>` | that major, minor or exact version |
+| `unstable`                                              | every commit on the main branch    |
+| a commit hash                                           | that exact build                   |
 
 Pin the exact version if something else depends on the page looking the way it
 looks today. `1` and `stable` move on every release; the
@@ -66,10 +68,11 @@ writable filesystem, which is what makes the Compose block above possible.
 
 ## Verify what you pulled
 
-This image is the same object published to GitHub Container Registry, copied
-here digest for digest. It is signed keylessly, so there is no maintainer key
-to steal, and it carries SLSA build provenance and a software bill of
-materials.
+This image is the same object published to
+[GitHub Container Registry](https://github.com/MorganKryze/cairn/pkgs/container/cairn),
+copied here digest for digest rather than built twice. It is signed keylessly,
+so there is no maintainer key to steal, and it carries SLSA build provenance
+and a software bill of materials.
 
 ```sh
 cosign verify morgankryze/cairn:stable \

--- a/docs/deployment/airgap.md
+++ b/docs/deployment/airgap.md
@@ -39,7 +39,7 @@ cosign verify ghcr.io/morgankryze/charts/cairn:1.17.1 \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
 
-The same two lines for `ghcr.io/morgankryze/cairn:1.17.1`, the image. Keep the
+The same two lines for `morgankryze/cairn:1.17.1`, the image. Keep the
 output: this is the only moment where you can prove where these bytes came from.
 
 Gatus publishes its own chart, from a classic repository rather than a registry,
@@ -64,7 +64,7 @@ amd64 cluster from an arm64 laptop is the classic way to learn this at
 ```sh
 PLATFORM=linux/amd64
 
-docker pull --platform $PLATFORM ghcr.io/morgankryze/cairn:1.17.1
+docker pull --platform $PLATFORM morgankryze/cairn:1.17.1
 docker pull --platform $PLATFORM ghcr.io/twin/gatus:v5.36.0
 ```
 
@@ -75,7 +75,7 @@ names nothing you can reason about six months later. To be exact, v5.36.0 is
 Then give both the name they will carry inside, and save them together:
 
 ```sh
-docker tag ghcr.io/morgankryze/cairn:1.17.1 harbor.internal/cairn:1.17.1
+docker tag morgankryze/cairn:1.17.1 harbor.internal/cairn:1.17.1
 docker tag ghcr.io/twin/gatus:v5.36.0 harbor.internal/gatus:5.36.0
 docker save harbor.internal/cairn:1.17.1 harbor.internal/gatus:5.36.0 -o images.tar
 ```
@@ -89,7 +89,7 @@ to have a route after all: the mistake becomes loud instead of invisible.
 This is the step nothing downstream will remind you about.
 
 ```sh
-docker run --rm -v ./config:/config ghcr.io/morgankryze/cairn:1.17.1 -emit-icons > get-icons.sh
+docker run --rm -v ./config:/config morgankryze/cairn:1.17.1 -emit-icons > get-icons.sh
 mkdir -p assets && (cd assets && sh ../get-icons.sh)
 ```
 
@@ -101,7 +101,7 @@ bring the files. See [Icons](../recipes/icons.md).
 ### The Gatus endpoints
 
 ```sh
-docker run --rm -v ./config:/config ghcr.io/morgankryze/cairn:1.17.1 -emit-gatus > gatus-endpoints.yaml
+docker run --rm -v ./config:/config morgankryze/cairn:1.17.1 -emit-gatus > gatus-endpoints.yaml
 ```
 
 One endpoint per service, named after its id, which is how each pill finds its
@@ -111,7 +111,7 @@ service. More in [Status page](../recipes/status.md).
 
 ```sh
 docker run --rm -v ./config:/config:ro -v ./assets:/assets:ro \
-  ghcr.io/morgankryze/cairn:1.17.1 -check
+  morgankryze/cairn:1.17.1 -check
 ```
 
 **Mount both directories.** Given only `/config`, `-check` cannot see the icons

--- a/docs/deployment/docker-compose.md
+++ b/docs/deployment/docker-compose.md
@@ -6,7 +6,7 @@ use them, they cost nothing here.
 ```yaml
 services:
   cairn:
-    image: ghcr.io/morgankryze/cairn:latest
+    image: morgankryze/cairn:latest
     # user: "1000:1000"    # optional; the image defaults to 65534 (nobody)
     ports:
       - 8080:8080
@@ -58,8 +58,9 @@ Why each line holds:
 docker compose pull && docker compose up -d
 ```
 
-Images are published to `ghcr.io/morgankryze/cairn`, always gated by the
-test suite inside the build:
+Images are published to `morgankryze/cairn` on Docker Hub and to
+`ghcr.io/morgankryze/cairn`, the same tags on both, always gated by the test
+suite inside the build:
 
 | Tag                 | Follows                                                 |
 | ------------------- | ------------------------------------------------------- |
@@ -67,6 +68,10 @@ test suite inside the build:
 | `1`, `1.0`, `1.0.0` | semver, from the release tags; pin as tight as you like |
 | `unstable`          | every commit on `main`                                  |
 | a commit hash       | that exact build                                        |
+
+Prefix any of them with `ghcr.io/` to pull from GitHub instead. One build
+produces one digest, published to ghcr and copied to Docker Hub, so the two
+registries hold the same bytes under the same names.
 
 Following `latest` or `stable` means a new version arrives on its own. A
 release occasionally tightens what the config accepts, and this is the
@@ -76,7 +81,7 @@ your site. One command tells you beforehand, and
 [Upgrading](../upgrading.md) is the page that answers whatever it prints:
 
 ```sh
-docker run --rm -v ./config:/config ghcr.io/morgankryze/cairn:stable -check
+docker run --rm -v ./config:/config morgankryze/cairn:stable -check
 ```
 
 To build from source instead, replace `image:` with:

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -61,7 +61,7 @@ spec:
         seccompProfile: { type: RuntimeDefault }
       containers:
         - name: cairn
-          image: ghcr.io/morgankryze/cairn:stable
+          image: morgankryze/cairn:stable
           ports:
             - containerPort: 8080
           securityContext:
@@ -161,7 +161,7 @@ More in [Reverse proxies](reverse-proxies.md#under-a-sub-path).
 natural gate in whatever pipeline renders your manifests:
 
 ```sh
-docker run --rm -v ./config:/config ghcr.io/morgankryze/cairn:stable -check
+docker run --rm -v ./config:/config morgankryze/cairn:stable -check
 ```
 
 Next: [Helm](helm.md)

--- a/docs/deployment/podman.md
+++ b/docs/deployment/podman.md
@@ -20,7 +20,7 @@ Save as `~/.config/containers/systemd/cairn.container` (rootless) or
 Description=cairn directory page
 
 [Container]
-Image=ghcr.io/morgankryze/cairn:stable
+Image=morgankryze/cairn:stable
 PublishPort=8080:8080
 Volume=%h/cairn/config:/config:ro,Z
 ReadOnly=true

--- a/docs/deployment/reverse-proxies.md
+++ b/docs/deployment/reverse-proxies.md
@@ -69,7 +69,7 @@ lives and every URL it writes carries the prefix:
 # compose.yaml
 services:
   cairn:
-    image: ghcr.io/morgankryze/cairn:latest
+    image: morgankryze/cairn:latest
     command: ["-base-path", "/cairn"]
     ports:
       - 8080:8080

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,7 +33,7 @@ Save this as `compose.yaml`, next to the `config` folder:
 ```yaml
 services:
   cairn:
-    image: ghcr.io/morgankryze/cairn:latest
+    image: morgankryze/cairn:latest
     ports:
       - 8080:8080
     volumes:
@@ -55,10 +55,12 @@ docker compose up -d
 Open <http://localhost:8080>. You get a finished page: one category, one
 card, working search, light and dark.
 
-The image is also on Docker Hub as `morgankryze/cairn`, if that is where the
-rest of your stack comes from. It is the same object, copied from the same
-signed digest, so the two are interchangeable. This documentation uses `ghcr.io`
-throughout because it is where the release publishes first.
+The same image is on GitHub Container Registry as `ghcr.io/morgankryze/cairn`,
+if that is where the rest of your stack comes from. Every tag lives on both,
+copied from one signed digest rather than built twice, so the two names are
+interchangeable everywhere in this documentation. Docker Hub is what the
+examples use; ghcr is worth knowing about if you pull a lot from one address,
+since it sets no anonymous rate limit.
 
 ## 3. Make it yours
 
@@ -105,7 +107,7 @@ a key that was accepted and then does nothing, icons that load from a CDN. It
 exits 0 or 1, so it slots into CI if you version your config:
 
 ```sh
-docker run --rm -v ./config:/config ghcr.io/morgankryze/cairn:stable -check
+docker run --rm -v ./config:/config morgankryze/cairn:stable -check
 ```
 
 The two warnings that open a file, the `/assets` path and the icon size, need
@@ -123,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - run: docker run --rm -v ./config:/config ghcr.io/morgankryze/cairn:stable -check
+      - run: docker run --rm -v ./config:/config morgankryze/cairn:stable -check
 ```
 
 ## Next

--- a/docs/recipes/icons.md
+++ b/docs/recipes/icons.md
@@ -91,7 +91,7 @@ network with no internet it means broken images. cairn removes it in two
 steps and zero YAML edits:
 
 ```sh
-docker run --rm -v ./config:/config ghcr.io/morgankryze/cairn:stable -emit-icons > get-icons.sh
+docker run --rm -v ./config:/config morgankryze/cairn:stable -emit-icons > get-icons.sh
 cd assets && sh ../get-icons.sh
 ```
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -10,7 +10,7 @@ The new image validates your existing config without touching anything you are
 running. Do this first, every time:
 
 ```sh
-docker run --rm -v ./config:/config ghcr.io/morgankryze/cairn:1.17.1 -check
+docker run --rm -v ./config:/config morgankryze/cairn:1.17.1 -check
 ```
 
 Exit code 0 means the upgrade will load. Exit 1 prints the exact message and


### PR DESCRIPTION
Follows #61. Docker Hub becomes the address the documentation gives, ghcr stays documented beside it, and the two registries stop telling different stories.

## The flip

Every image reference a reader copies now names `morgankryze/cairn`. `ghcr.io/morgankryze/cairn` is written down next to it as the same object at another address.

**Three references deliberately stay on ghcr**, because moving them would break them:

- the workflows and the demo, which pull through ghcr and Google's mirror on purpose. That was #34: an anonymous Docker Hub pull shares one rate limit with every GitHub-hosted runner and fails by timing out rather than by saying so.
- `launch/casaos`, pinned to `1.11.0` by digest. Nothing before 1.17.2 exists on Hub until the mirror below runs.
- the Helm chart artifact, which is published to ghcr alone.

**One behaviour change, not just wording**: the chart's default `image.repository` moves too. A cluster that never set it switches registry on upgrade, and Docker Hub rate limits anonymous pulls per IP where ghcr does not. Worth knowing before merging; it is one line to keep on ghcr if you would rather.

## `unstable` on Docker Hub

A `hub` job in `build.yml`, shaped like the release's own: it copies the digest the build just pushed. Outside the `image` job on purpose, since that one is a required check and a Docker Hub hiccup has no business blocking a merge. Nothing signs `unstable` on either registry, because it is whatever `main` is this minute.

## The backfill

`mirror.yml`, dispatch only. Copies tags from ghcr to Hub, for the history published before Hub existed, and afterwards as a repair tool when a single tag needs re-copying without re-running a whole release.

It derives the version tags from the `X.Y.Z` tags that exist rather than matching a shape, because this repository has tags `3403640` and `5299497` and any pattern loose enough to accept `1` accepts those too. **Run against the live tag list it selects 52 tags and no commit hash.** The dispatch input is held to a tag's own character set before it reaches `$GITHUB_OUTPUT`, where a newline would become a second key: the newline, `;` and `$(…)` shapes are all refused, ordinary tag lists pass.

**It signs nothing, deliberately.** A signature made today on 1.9.0 would be valid and say something true but useless, that this workflow pushed those bytes in 2026, sitting where a reader would take it for the release's own proof.

`SECURITY.md` says where that leaves verification: signatures on both registries from 1.17.2 onward, and for anything mirrored afterwards, verify against ghcr. Provenance and the SBOM travel with the image and read from either name at any version.

## Order this wants to land in

1. merge this
2. run `mirror.yml` once, which fills Hub with the history and makes the `1.17.1` the docs mention true there
3. bump and tag 1.17.2

The merge itself is the first live test of the token: the `hub` job in `build.yml` will push `unstable` to Docker Hub before any release depends on it working.