### PR TITLE
Mirror with crane, so an old single-manifest tag keeps its digest

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -54,6 +54,22 @@ jobs:
           username: morgankryze
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # crane rather than `buildx imagetools`, which is what release.yml and
+      # build.yml use, and the difference is the whole reason this job needs
+      # its own tool. imagetools only ever writes an index. Given an index it
+      # copies it and the digest survives, which is all a release ever hands
+      # it; given a single manifest it wraps it in a new index, and the digest
+      # cannot survive that. cairn 1.0.0, 1.1.0 and 1.2.0 predate the arm64
+      # build and are single manifests, so the first run of this job failed on
+      # 1.0.0 with exactly that: the assertion below caught it before anything
+      # was believed. crane copies the manifest bytes as they are, whichever
+      # shape they are, measured on both against a throwaway registry.
+      #
+      # Installed with the Go the runner already has rather than through a
+      # third-party action, so there is no extra thing to pin and trust.
+      - name: install crane
+        run: go install github.com/google/go-containerregistry/cmd/crane@v0.21.8
+
       - name: work out which tags to copy
         id: pick
         env:
@@ -103,13 +119,15 @@ jobs:
           TAGS: ${{ steps.pick.outputs.tags }}
         run: |
           set -euo pipefail
+          gopath=$(go env GOPATH)
+          export PATH="$PATH:$gopath/bin"
           src=ghcr.io/morgankryze/cairn
           dst=docker.io/morgankryze/cairn
           copied=0
           for tag in $TAGS; do
-            digest=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "${src}:${tag}")
-            docker buildx imagetools create --tag "${dst}:${tag}" "${src}@${digest}"
-            landed=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' "${dst}:${tag}")
+            digest=$(crane digest "${src}:${tag}")
+            crane copy "${src}:${tag}" "${dst}:${tag}"
+            landed=$(crane digest "${dst}:${tag}")
             [ "$landed" = "$digest" ] || {
               echo "::error::${dst}:${tag} points at ${landed}, not the ${digest} ghcr holds"
               exit 1


### PR DESCRIPTION
The backfill run stopped where it was designed to. `docker.io/morgankryze/cairn:1.0.0` landed as `sha256:3a3f433d…` where ghcr holds `sha256:a4033297…`, and the digest assertion refused it.

**Cause.** `docker buildx imagetools create` only ever writes an index. Handed an index it copies it and the digest survives, which is every image a release has produced since arm64 arrived in 1.3.0. Handed a single manifest it wraps it in a new index, and a wrapper is new bytes, so the digest cannot survive. `1.0.0`, `1.1.0` and `1.2.0` predate the arm64 build and are single manifests. 27 of the 30 releases would have copied cleanly, which is the kind of gap an assertion exists for.

**Fix.** `crane copy`, which copies the manifest as it stands whichever shape it is. Measured against a throwaway registry:

- `1.0.0` and `1.17.1` each arrive under the digest ghcr holds
- the `1.17.1` index keeps both platform manifests and both attestation manifests
- its SLSA provenance reads back from the copy
- the `1.0.0` copy pulls

Installed with the Go the runner already has, so there is no third-party action to pin.

**Only in `mirror.yml`.** `release.yml` and `build.yml` hand imagetools a freshly built multi-arch index every time and never meet a single manifest, so they keep the tool that needs no install on the release path.

`morgankryze/cairn:1.0.0` currently points at the wrapped index on Docker Hub. Re-running the mirror once this lands overwrites it with the right digest.