### PR TITLE
Give Docker Hub a moment to index the signature before reading it back

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,9 +286,28 @@ jobs:
           # same digest, so SECURITY.md's command works unchanged on either
           # name, which is what the verify below is checking.
           cosign sign --yes "${dst}@${DIGEST}"
-          cosign verify "${dst}@${DIGEST}" \
-            --certificate-identity-regexp '^https://github.com/MorganKryze/cairn/' \
-            --certificate-oidc-issuer https://token.actions.githubusercontent.com >/dev/null
+
+          # Given a moment. Docker Hub stores a signature as an OCI referrer
+          # and indexes it asynchronously, so 1.17.2 signed cleanly, failed
+          # this check four seconds later, and verified from a laptop shortly
+          # after with nothing having changed. ghcr answers immediately, which
+          # is why the same two lines never needed this above.
+          #
+          # Waiting rather than dropping the check: a signature that cannot be
+          # read is exactly what this exists to catch, and the last attempt is
+          # loud so a real failure says why instead of timing out in silence.
+          verify() {
+            cosign verify "${dst}@${DIGEST}" \
+              --certificate-identity-regexp '^https://github.com/MorganKryze/cairn/' \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com
+          }
+          for _ in 1 2 3 4 5 6; do
+            verify >/dev/null 2>&1 && exit 0
+            sleep 10
+          done
+          echo "::error::the signature pushed to ${dst} was not readable within a minute"
+          verify
+          exit 1
 
   chart:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `hub` job went red on the 1.17.2 release. Nothing was wrong with the release.

**What happened.** cosign signed the Docker Hub digest cleanly, and `cosign verify` four seconds later answered `no signatures found`. The same command from a laptop shortly afterwards verified, and **re-running the job on the same tag with no code change went green**.

**Cause.** Docker Hub stores a cosign signature as an OCI referrer and indexes it asynchronously. Its referrers API answers 200 with the sigstore bundle now; it did not yet at the moment the job asked. ghcr does not use the referrers API for this at all, which is why the identical two lines on that side have never needed waiting.

**Fix.** The check retries for a minute instead of being removed. A signature that cannot be read is exactly the thing this assertion exists to catch, so weakening it would be the wrong trade; being patient costs nothing on the runs where the registry is quick. The final attempt runs without output suppression so a genuine failure prints its reason.

Verified independently while diagnosing: `1.17.2`, `1.17`, `1`, `stable` and `latest` carry the same digest on both registries, `cosign verify` passes on both names, and the chart and the three binaries are signed and attached.