### PR TITLE
Credit rbourgeat's second request, and tidy the two Docker badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 [![Release](https://img.shields.io/github/v/release/MorganKryze/cairn?label=release&color=247b7b)](https://github.com/MorganKryze/cairn/releases)
 [![License: GPL-3.0](https://img.shields.io/badge/license-GPL--3.0-blue.svg)](LICENSE)
 
-[![Image](https://img.shields.io/badge/image-4.4%20MB%20pull-2496ED?logo=docker&logoColor=white)](https://hub.docker.com/r/morgankryze/cairn/tags)
-[![Docker Hub](https://img.shields.io/docker/pulls/morgankryze/cairn?label=docker%20hub&color=2496ED&logo=docker&logoColor=white&cacheSeconds=3600)](https://hub.docker.com/r/morgankryze/cairn)
+[![Image](https://img.shields.io/badge/image-4.4%20MB-2496ED?logo=docker&logoColor=white)](https://hub.docker.com/r/morgankryze/cairn/tags)
+[![Docker pulls](https://img.shields.io/docker/pulls/morgankryze/cairn?label=docker%20pulls&color=2496ED&logo=docker&logoColor=white&cacheSeconds=3600)](https://hub.docker.com/r/morgankryze/cairn)
 [![Go](https://img.shields.io/badge/Go-single%20static%20binary-00ADD8?logo=go&logoColor=white)](https://go.dev)
 [![Helm](https://img.shields.io/badge/Helm-chart-0F1689?logo=helm&logoColor=white)](docs/deployment/helm.md)
 [![Docker Compose](https://img.shields.io/badge/Compose-ready-2496ED?logo=docker&logoColor=white)](docs/deployment/docker-compose.md)

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ it, and a translation are all work.
 <td align="center" width="150">
 <a href="https://github.com/rbourgeat"><img src="https://github.com/rbourgeat.png?size=100" width="80" alt=""><br><sub><b>rbourgeat</b></sub></a><br>
 <a href="https://github.com/MorganKryze/cairn/pull/51" title="Code">💻</a>
-<a href="https://github.com/MorganKryze/cairn/issues/50" title="Ideas and planning">🤔</a>
+<a href="https://github.com/MorganKryze/cairn/issues?q=author%3Arbourgeat" title="Ideas and planning">🤔</a>
 </td>
 </tr>
 </table>


### PR DESCRIPTION
Two small README changes.

**The contributors table.** rbourgeat's idea emoji pointed at issue #50. #63 is his too, and it is what `service_links` shipped from. Rather than a second identical emoji or a choice between the two, it points at what he has opened, which is one fewer line to rewrite the next time.

**The two Docker badges.** The size one read `image 4.4 MB pull`, a verb doing nothing next to a badge whose whole subject is pulls; it reads `image 4.4 MB` now. The other said `docker hub 679`, naming the registry rather than what it counts, while the badge beside it already links there; it says `docker pulls` now.

Changing that label also changes the badge URL, which is a fresh entry in shields' cache and in GitHub's image proxy, so it shows the live number straight away instead of waiting out the old one.