### PR TITLE
Name an asset after its contents, so an upgrade needs no hard refresh

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -117,7 +117,7 @@ ids, alphabetically.
 | `/{locale}/`                | home; server-rendered, `ETag` (suffixed `-gzip` when the answer is compressed), `Cache-Control: no-cache` |
 | `/{locale}/{id}/`           | service detail page or [hosted page](configuration/site.md#hosted-pages); same caching                    |
 | `/{locale}/…?choose`        | sets the one-year locale cookie, then redirects clean                                                     |
-| `/static/…`                 | embedded assets, cached one day                                                                           |
+| `/static/…`                 | embedded assets; a name carrying a content digest is cached for a year, a plain one for a day (see below) |
 | `/assets/…`                 | your mounted files, if the mount exists                                                                   |
 | `/media/…`                  | images from `<config>/media/`, the ones services and long text name                                       |
 | `/fonts/…`                  | the self-hosted font `theme.font.file` names, from `<config>/fonts/`                                      |
@@ -138,6 +138,30 @@ since compressing them again only spends CPU to add bytes, so the 62 KB font
 weighs 62 KB either way. Every response carries `Vary: Accept-Encoding` so a
 shared cache cannot hand the compressed answer to a client that did not ask for
 it.
+
+### Why an asset url carries a digest
+
+cairn's own assets go out under a name that carries a digest of what is inside
+them: `style.css` is linked as `style.0629016b.css`. It exists to fix one thing
+an operator meets on every upgrade. Pages are served `no-cache`, so they update
+the moment cairn restarts; the stylesheet beside them was cached for a day
+under a name that never changed, so the new page arrived wearing yesterday's
+CSS and only a hard refresh fixed it.
+
+Since the name changes exactly when the bytes do, the fresh page points at a
+name the browser has never seen, and a file nobody touched keeps its name and
+stays in the cache. That is what makes `max-age=31536000, immutable` safe here:
+nothing has to expire, because nothing is ever replaced under the same name.
+
+The digest is in the name rather than in a `?v=` query, because a query leaves
+an intermediary cache free to key on the path alone and pin a stale file for
+the whole year. Plain `/static/style.css` still answers, on the day-long cache,
+so anything that hardcoded it goes on working. A digest cairn did not issue
+gets a 404 rather than a file.
+
+The display font is the one exception: `style.css` reaches it with a relative
+`url()` of its own, which nothing out here can rewrite, so it keeps its plain
+name and the shorter cache.
 
 ## Binary flags
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -161,7 +161,10 @@ gets a 404 rather than a file.
 
 The display font is the one exception: `style.css` reaches it with a relative
 `url()` of its own, which nothing out here can rewrite, so it keeps its plain
-name and the shorter cache.
+name and the shorter cache. Everything else cairn ships is stamped, including
+the apple-touch-icon and the manifest's icons, which are built in Go rather
+than written in a template. Your own files, under `/assets/` and `/media/`,
+are never stamped: cairn has not read their bytes and has no digest to offer.
 
 ## Binary flags
 

--- a/src/internal/render/appicons_test.go
+++ b/src/internal/render/appicons_test.go
@@ -21,9 +21,9 @@ func TestAppIconsNeverInventASize(t *testing.T) {
 			name: "no favicon at all: cairn's own set, including the two Chromium insists on",
 			cfg:  &config.Config{},
 			want: []AppIcon{
-				{Src: "/static/touch-icon.png", Sizes: "180x180", Type: "image/png"},
-				{Src: "/static/icon-192.png", Sizes: "192x192", Type: "image/png", Purpose: "any maskable"},
-				{Src: "/static/icon-512.png", Sizes: "512x512", Type: "image/png", Purpose: "any maskable"},
+				{Src: AssetURL("touch-icon.png"), Sizes: "180x180", Type: "image/png"},
+				{Src: AssetURL("icon-192.png"), Sizes: "192x192", Type: "image/png", Purpose: "any maskable"},
+				{Src: AssetURL("icon-512.png"), Sizes: "512x512", Type: "image/png", Purpose: "any maskable"},
 			},
 		},
 		{
@@ -105,7 +105,10 @@ func TestAppIconsFollowTheBasePath(t *testing.T) {
 	defer func() { BasePath = old }()
 
 	for _, c := range []struct{ name, favicon, want string }{
-		{"cairn's own", "", "/cairn/static/touch-icon.png"},
+		// AssetURL reads BasePath, which this test has set, so the want
+		// carries the prefix without spelling out a digest that moves with
+		// the file.
+		{"cairn's own", "", AssetURL("touch-icon.png")},
 		{"the operator's", "/assets/brand.svg", "/cairn/assets/brand.svg"},
 		{"a remote one is left alone", "https://cdn.example.org/b.png", "https://cdn.example.org/b.png"},
 	} {

--- a/src/internal/render/assetcover_test.go
+++ b/src/internal/render/assetcover_test.go
@@ -1,0 +1,139 @@
+package render
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io/fs"
+	"path"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/MorganKryze/cairn/src/internal/config"
+	"github.com/MorganKryze/cairn/src/internal/status"
+	"github.com/MorganKryze/cairn/src/internal/testutil"
+)
+
+// Written after reviewing the digest work rather than while writing it, which
+// is why these look for the gaps the first pass left rather than for the
+// behaviour it set out to build. Each one holds a way the scheme can be
+// half-undone later without anything going red.
+
+// A name in a template that cairn does not ship comes back as the plain path,
+// which is a 404 the browser meets silently: the page renders unstyled and
+// every test that reads markup still passes. So the names are checked against
+// what is actually embedded.
+func TestEveryAssetATemplateAsksForIsShipped(t *testing.T) {
+	asks := regexp.MustCompile(`asset "([^"]+)"`)
+	found := 0
+	err := fs.WalkDir(Embedded, "templates", func(p string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		b, err := Embedded.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		for _, m := range asks.FindAllStringSubmatch(string(b), -1) {
+			found++
+			if _, err := Embedded.ReadFile("assets/" + m[1]); err != nil {
+				t.Errorf("%s asks for %q, which is not in assets/", p, m[1])
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found == 0 {
+		t.Fatal("no template asks for an asset, so this checked nothing")
+	}
+}
+
+// The regression this whole change exists to prevent, stated as a rule a page
+// has to keep obeying: nothing cairn serves may be linked under a name that
+// does not move when its contents do. Adding a script with a hand-written
+// /static/ path would reintroduce the stale-after-upgrade bug for that one
+// file, and no other test here would notice.
+func TestNoPageLinksAnUnstampedAsset(t *testing.T) {
+	stamped := regexp.MustCompile(`^/static/(.+)\.[0-9a-f]{8}(\.[a-z0-9]+)?$`)
+	any := regexp.MustCompile(`/static/[A-Za-z0-9._/-]+`)
+
+	cfg, err := config.Load(testutil.WriteFiles(t, map[string]string{
+		"site.yaml":     "title: Test\nlocales: [en]\n",
+		"services.yaml": "- {id: pad, url: 'https://pad.example.org', name: Pad, desc: D., details: More.}\n",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := BuildModel(cfg, map[string]status.State{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := 0
+	for name, p := range m.Pages {
+		for _, u := range any.FindAllString(string(p.HTML), -1) {
+			seen++
+			// The font is the documented exception: style.css reaches it by a
+			// relative url() that nothing out here can rewrite. See asseturl.go.
+			if strings.HasPrefix(u, "/static/fonts/") {
+				continue
+			}
+			if !stamped.MatchString(u) {
+				t.Errorf("page %s links %s, which carries no digest", name, u)
+			}
+		}
+	}
+	if seen == 0 {
+		t.Fatal("no page linked anything under /static/, so this checked nothing")
+	}
+}
+
+// The manifest and the apple-touch-icon are built in Go rather than written in
+// a template, which is exactly how they were missed: they never met the asset
+// function and shipped unstamped while everything around them moved.
+func TestTheIconsBuiltInGoAreStampedToo(t *testing.T) {
+	for _, got := range []string{
+		AppURL(defaultTouchIcon),
+		AppURL("/static/icon-192.png"),
+		AppURL("/static/icon-512.png"),
+	} {
+		if !regexp.MustCompile(`\.[0-9a-f]{8}\.png$`).MatchString(got) {
+			t.Errorf("%s carries no digest", got)
+		}
+	}
+}
+
+// And the other half of that: cairn stamps only what it ships. An operator's
+// own icon is bytes cairn has never read, so there is no digest to offer and
+// inventing a name for it would 404.
+func TestAnOperatorsOwnIconIsLeftAlone(t *testing.T) {
+	for _, p := range []string{
+		"/assets/my-icon.png",
+		"/media/shot.png",
+		"https://cdn.example.org/icon.png",
+		"/static/not-a-file-cairn-ships.png",
+	} {
+		if got := AppURL(p); got != BasePath+p && got != p {
+			t.Errorf("AppURL(%q) = %q, want it untouched", p, got)
+		}
+	}
+}
+
+// The digest has to be of the file, not merely stable. A constant per name
+// would pass every other test here and would never change on an upgrade,
+// which is the one thing it exists to do.
+func TestTheDigestIsOfTheFilesOwnBytes(t *testing.T) {
+	for _, name := range []string{"style.css", "search.js", "icon-192.png"} {
+		b, err := Embedded.ReadFile("assets/" + name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		sum := sha256.Sum256(b)
+		ext := path.Ext(name)
+		want := "/static/" + strings.TrimSuffix(name, ext) + "." + hex.EncodeToString(sum[:4]) + ext
+		if got := AssetURL(name); got != want {
+			t.Errorf("AssetURL(%s) = %q, want %q, the digest of what is in the file", name, got, want)
+		}
+	}
+}

--- a/src/internal/render/asseturl.go
+++ b/src/internal/render/asseturl.go
@@ -86,3 +86,24 @@ func AssetPath(stamped string) (string, bool) {
 	real, ok := assetReal[stamped]
 	return real, ok
 }
+
+// stampStatic rewrites a root-absolute path naming one of cairn's own assets
+// into the stamped form, and leaves everything else exactly as it was.
+//
+// It exists because the touch icon and the manifest's icons are built in Go
+// rather than written in a template, so they never met the asset function and
+// went out unstamped: an operator who changed cairn's icon set had every
+// visitor keep the old one for a day, for no reason the font's had. An
+// operator's own icon is not touched, because cairn does not ship those bytes
+// and has no digest of them to offer.
+func stampStatic(p string) string {
+	name, ok := strings.CutPrefix(p, "/static/")
+	if !ok {
+		return p
+	}
+	stamped, ok := assetURL[name]
+	if !ok {
+		return p
+	}
+	return "/static/" + stamped
+}

--- a/src/internal/render/asseturl.go
+++ b/src/internal/render/asseturl.go
@@ -1,0 +1,88 @@
+package render
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io/fs"
+	"path"
+	"strings"
+)
+
+// Assets are served under a name that carries a digest of what is inside them,
+// so `style.css` goes out as `style.a1b2c3d4.css`.
+//
+// The problem it solves is the one an operator meets on every upgrade: pages
+// are served no-cache and update the moment cairn restarts, while the
+// stylesheet beside them was cached for a day under a name that never changes.
+// The page was new, the CSS was yesterday's, and only a hard refresh fixed it.
+//
+// Since the name changes exactly when the bytes change, the page that points
+// at it is already fresh, and a browser meeting a name it has never seen has
+// no choice but to fetch it. That is also what makes it safe to cache these
+// for a year: nothing has to expire, because nothing is ever replaced under
+// the same name.
+//
+// The digest is in the name rather than in a query string on purpose. A query
+// is easier to write, and it leaves an intermediary free to key its cache on
+// the path alone, which would pin a stale file for the whole year rather than
+// for a day. A different name is a different object to everything in the path.
+//
+// One gap, named rather than hidden: the display font keeps its plain name.
+// The stylesheet reaches it with a relative url(), and no stamping here can
+// follow into a CSS file's own bytes, so stamping the <link rel=preload> alone
+// would leave the two pointing at different urls and the browser fetching 64
+// KB twice, having preloaded a file the stylesheet then does not ask for.
+// Covering it properly means rewriting the stylesheet on the way out; it has
+// changed once in the project's life, so it waits until that is worth it.
+var (
+	assetURL  = map[string]string{} // style.css -> style.a1b2c3d4.css
+	assetReal = map[string]string{} // style.a1b2c3d4.css -> style.css
+)
+
+func init() {
+	_ = fs.WalkDir(Embedded, "assets", func(p string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		b, err := Embedded.ReadFile(p)
+		if err != nil {
+			return nil
+		}
+		name := strings.TrimPrefix(p, "assets/")
+		// See the note above: a file the stylesheet reaches by itself cannot
+		// be stamped from out here without the two disagreeing.
+		if strings.HasPrefix(name, "fonts/") {
+			return nil
+		}
+		sum := sha256.Sum256(b)
+		// Eight hex is 32 bits. This is a cache key, not a security boundary:
+		// the file it names is decided by the table below, so a collision
+		// would serve one of two files cairn itself ships, and never anything
+		// an outsider chose.
+		digest := hex.EncodeToString(sum[:4])
+		ext := path.Ext(name)
+		stamped := strings.TrimSuffix(name, ext) + "." + digest + ext
+		assetURL[name] = stamped
+		assetReal[stamped] = name
+		return nil
+	})
+}
+
+// AssetURL is the path a page should point at for one of cairn's own assets.
+// A name cairn does not ship comes back untouched, so a typo arrives at the
+// 404 it deserves instead of resolving to something else.
+func AssetURL(name string) string {
+	if stamped, ok := assetURL[name]; ok {
+		return BasePath + "/static/" + stamped
+	}
+	return BasePath + "/static/" + name
+}
+
+// AssetPath turns a stamped name back into the file to open, and refuses a
+// digest cairn did not issue. The plain name is deliberately not resolved
+// here: the file server still answers it directly, on the shorter cache, so
+// anything that hardcoded /static/style.css goes on working.
+func AssetPath(stamped string) (string, bool) {
+	real, ok := assetReal[stamped]
+	return real, ok
+}

--- a/src/internal/render/asseturl_test.go
+++ b/src/internal/render/asseturl_test.go
@@ -1,0 +1,77 @@
+package render
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var hashed = regexp.MustCompile(`^/static/style\.[0-9a-f]{8}\.css$`)
+
+// The name carries a digest of what is inside the file, which is the whole
+// mechanism: the page is served no-cache and always fresh, so the moment an
+// asset changes the page points somewhere the browser has never been.
+func TestAssetURLCarriesTheContentDigest(t *testing.T) {
+	got := AssetURL("style.css")
+	if !hashed.MatchString(got) {
+		t.Fatalf("AssetURL(style.css) = %q, want /static/style.<8 hex>.css", got)
+	}
+	if AssetURL("style.css") != got {
+		t.Error("two calls disagreed, so the digest is not of the content")
+	}
+	if AssetURL("search.js") == got {
+		t.Error("two different files share a url")
+	}
+}
+
+// A name cairn does not serve keeps the plain path rather than inventing a
+// digest for it, so a typo fails loudly at the 404 instead of silently
+// resolving to something.
+func TestAssetURLLeavesAnUnknownNameAlone(t *testing.T) {
+	if got := AssetURL("nope.css"); got != "/static/nope.css" {
+		t.Errorf("AssetURL(nope.css) = %q, want the plain path", got)
+	}
+}
+
+// The font is the deliberate exception, and this is here so that stamping it
+// later is a decision rather than an accident. style.css asks for it with a
+// relative url() of its own; a stamped <link rel=preload> beside an unstamped
+// url() is two different addresses for one file, which costs a wasted 64 KB
+// download rather than saving anything. Stamp it only together with the
+// stylesheet's own bytes.
+func TestTheFontKeepsItsPlainName(t *testing.T) {
+	if got := AssetURL("fonts/fraunces.woff2"); got != "/static/fonts/fraunces.woff2" {
+		t.Errorf("the font is stamped (%q) while style.css still asks for the plain name", got)
+	}
+}
+
+// The digest has to sit before the extension, not after it, or the file is
+// served as the wrong type: style.css.a1b2c3d4 is not a stylesheet to any
+// content-type table.
+func TestTheDigestSitsBeforeTheExtension(t *testing.T) {
+	for _, name := range []string{"style.css", "search.js", "favicon.svg", "icon-192.png"} {
+		got := AssetURL(name)
+		ext := name[strings.LastIndex(name, "."):]
+		if !strings.HasSuffix(got, ext) {
+			t.Errorf("AssetURL(%s) = %q, which no longer ends in %s", name, got, ext)
+		}
+	}
+}
+
+// AssetPath is the other half: what the server hands back to the file it has
+// to open, and it must refuse a digest that is not the one it computed, so a
+// guessed url cannot pull a file out from under the cache rules.
+func TestAssetPathResolvesOnlyTheDigestItIssued(t *testing.T) {
+	url := strings.TrimPrefix(AssetURL("style.css"), "/static/")
+	if got, ok := AssetPath(url); !ok || got != "style.css" {
+		t.Errorf("AssetPath(%q) = %q, %v; want style.css, true", url, got, ok)
+	}
+	if _, ok := AssetPath("style.deadbeef.css"); ok {
+		t.Error("a digest cairn never issued resolved anyway")
+	}
+	// The plain name is not this function's business: the file server still
+	// answers it directly, on the shorter cache.
+	if _, ok := AssetPath("style.css"); ok {
+		t.Error("the plain name resolved through the digest table")
+	}
+}

--- a/src/internal/render/render.go
+++ b/src/internal/render/render.go
@@ -23,6 +23,10 @@ var Embedded embed.FS
 
 var tmpls = template.Must(template.New("").Funcs(template.FuncMap{
 	"upper": strings.ToUpper,
+	// asset resolves one of cairn's own files to the stamped name it is
+	// served under, base path included, so a template never writes /static/
+	// by hand and never has to remember .Prefix for one. See asseturl.go.
+	"asset": AssetURL,
 }).ParseFS(Embedded, "templates/*.tmpl"))
 
 type Page struct {

--- a/src/internal/render/servicelinks_test.go
+++ b/src/internal/render/servicelinks_test.go
@@ -91,7 +91,7 @@ func TestConfirmAllGuardsEveryOffSiteLink(t *testing.T) {
 	if n := strings.Count(pages["en/pad"], `id="leave"`); n != 1 {
 		t.Errorf("detail page carries %d leave dialogs, want 1", n)
 	}
-	if !strings.Contains(pages["en"], "leave.js") {
+	if !strings.Contains(pages["en"], AssetURL("leave.js")) {
 		t.Error("the page does not load leave.js")
 	}
 }
@@ -119,7 +119,7 @@ func TestConfirmExternalGuardsOnlyTheFlaggedOnes(t *testing.T) {
 		t.Error("the self-hosted detail button was guarded")
 	}
 	// A page with nothing to guard carries no dialog and loads no script.
-	if strings.Contains(pages["en/pad"], `id="leave"`) || strings.Contains(pages["en/pad"], "leave.js") {
+	if strings.Contains(pages["en/pad"], `id="leave"`) || strings.Contains(pages["en/pad"], AssetURL("leave.js")) {
 		t.Error("a page with no guarded link still shipped the dialog")
 	}
 }
@@ -129,7 +129,7 @@ func TestNoDialogWithoutConfirm(t *testing.T) {
 	if strings.Contains(pages["en"], `id="leave"`) {
 		t.Error("a leave dialog shipped with confirm off")
 	}
-	if strings.Contains(pages["en"], "leave.js") {
+	if strings.Contains(pages["en"], AssetURL("leave.js")) {
 		t.Error("leave.js shipped with confirm off")
 	}
 	if strings.Contains(pages["en"], "data-leave") {

--- a/src/internal/render/statuspill_test.go
+++ b/src/internal/render/statuspill_test.go
@@ -180,7 +180,7 @@ func TestNoGatusShipsNoRefresh(t *testing.T) {
 func TestRefreshScriptCarriesThePollInterval(t *testing.T) {
 	home, detail := pages(t, withGatus+"  interval: 30s\n")
 	for _, page := range []struct{ name, html string }{{"home", home}, {"detail", detail}} {
-		if !strings.Contains(page.html, `<script src="/static/status.js" defer data-poll="30"></script>`) {
+		if !strings.Contains(page.html, `<script src="`+AssetURL("status.js")+`" defer data-poll="30"></script>`) {
 			t.Errorf("%s: no refresh script, or it does not carry the interval", page.name)
 		}
 	}

--- a/src/internal/render/templates/layout.tmpl
+++ b/src/internal/render/templates/layout.tmpl
@@ -26,13 +26,13 @@
 {{end}}
 {{if .Favicon}}{{if .FaviconDark}}<link rel="icon" href="{{.FaviconDark}}" media="(prefers-color-scheme: dark)">
 {{end}}<link rel="icon" href="{{.Favicon}}">
-{{else}}<link rel="icon" href="{{.Prefix}}/static/favicon.svg" type="image/svg+xml">
-<link rel="icon" href="{{.Prefix}}/static/favicon.ico" sizes="32x32">
+{{else}}<link rel="icon" href="{{asset "favicon.svg"}}" type="image/svg+xml">
+<link rel="icon" href="{{asset "favicon.ico"}}" sizes="32x32">
 {{end}}<link rel="apple-touch-icon" href="{{.TouchIcon}}">
 <link rel="manifest" href="{{.Prefix}}/manifest.webmanifest">
 
-<link rel="preload" href="{{.Prefix}}/static/fonts/fraunces.woff2" as="font" type="font/woff2" crossorigin>
-<link rel="stylesheet" href="{{.Prefix}}/static/style.css">
+<link rel="preload" href="{{asset "fonts/fraunces.woff2"}}" as="font" type="font/woff2" crossorigin>
+<link rel="stylesheet" href="{{asset "style.css"}}">
 <style>{{.Style}}</style>
 <script>document.documentElement.setAttribute('data-js','');var a=document.cookie.match(/(?:^|; )about=([^;]*)/);if(a&&a[1]===document.documentElement.getAttribute('data-about'))document.documentElement.setAttribute('data-noabout','');try{var t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t)}catch(e){}</script>
 {{if .CustomCSS}}<link rel="stylesheet" href="{{.Prefix}}/custom.css">
@@ -106,13 +106,13 @@
     <a class="btn leave-go" href=""{{if .LeaveBlank}} target="_blank" rel="noopener noreferrer"{{end}}>{{.S.LeaveGo}}</a>
   </div>
 </dialog>
-<script src="{{.Prefix}}/static/leave.js" defer></script>
-{{end}}<script src="{{.Prefix}}/static/search.js" defer></script>
-<script src="{{.Prefix}}/static/toc.js" defer></script>
-<script src="{{.Prefix}}/static/nav.js" defer></script>
-<script src="{{.Prefix}}/static/about.js" defer></script>
-<script src="{{.Prefix}}/static/theme.js" defer></script>
-{{if .StatusPoll}}<script src="{{.Prefix}}/static/status.js" defer data-poll="{{.StatusPoll}}"></script>
+<script src="{{asset "leave.js"}}" defer></script>
+{{end}}<script src="{{asset "search.js"}}" defer></script>
+<script src="{{asset "toc.js"}}" defer></script>
+<script src="{{asset "nav.js"}}" defer></script>
+<script src="{{asset "about.js"}}" defer></script>
+<script src="{{asset "theme.js"}}" defer></script>
+{{if .StatusPoll}}<script src="{{asset "status.js"}}" defer data-poll="{{.StatusPoll}}"></script>
 {{end}}</body>
 </html>
 {{end}}

--- a/src/internal/render/testdata/golden/en.html
+++ b/src/internal/render/testdata/golden/en.html
@@ -18,7 +18,7 @@
 
 <link rel="icon" href="/static/favicon.3c9c171d.svg" type="image/svg+xml">
 <link rel="icon" href="/static/favicon.981de994.ico" sizes="32x32">
-<link rel="apple-touch-icon" href="/static/touch-icon.png">
+<link rel="apple-touch-icon" href="/static/touch-icon.e8ccc022.png">
 <link rel="manifest" href="/manifest.webmanifest">
 
 <link rel="preload" href="/static/fonts/fraunces.woff2" as="font" type="font/woff2" crossorigin>

--- a/src/internal/render/testdata/golden/en.html
+++ b/src/internal/render/testdata/golden/en.html
@@ -16,13 +16,13 @@
 <link rel="alternate" hreflang="fr" href="https://golden.example.org/fr/">
 <link rel="alternate" hreflang="x-default" href="https://golden.example.org/">
 
-<link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
-<link rel="icon" href="/static/favicon.ico" sizes="32x32">
+<link rel="icon" href="/static/favicon.3c9c171d.svg" type="image/svg+xml">
+<link rel="icon" href="/static/favicon.981de994.ico" sizes="32x32">
 <link rel="apple-touch-icon" href="/static/touch-icon.png">
 <link rel="manifest" href="/manifest.webmanifest">
 
 <link rel="preload" href="/static/fonts/fraunces.woff2" as="font" type="font/woff2" crossorigin>
-<link rel="stylesheet" href="/static/style.css">
+<link rel="stylesheet" href="/static/style.0629016b.css">
 <style>:root{--accent:#247b7b}</style>
 <script>document.documentElement.setAttribute('data-js','');var a=document.cookie.match(/(?:^|; )about=([^;]*)/);if(a&&a[1]===document.documentElement.getAttribute('data-about'))document.documentElement.setAttribute('data-noabout','');try{var t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t)}catch(e){}</script>
 </head>
@@ -133,12 +133,12 @@
   <span class="powered"><span class="foot-mark"><svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg></span>powered by <a href="https://github.com/MorganKryze/cairn" title="cairn 1.14.0">cairn</a> <a class="foot-version" href="https://github.com/MorganKryze/cairn/releases/tag/v1.14.0">1.14.0</a></span>
   </div></footer>
 <a class="totop" href="#top" aria-label="Back to top"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 19V5M5 12l7-7 7 7"/></svg></a>
-<script src="/static/search.js" defer></script>
-<script src="/static/toc.js" defer></script>
-<script src="/static/nav.js" defer></script>
-<script src="/static/about.js" defer></script>
-<script src="/static/theme.js" defer></script>
-<script src="/static/status.js" defer data-poll="30"></script>
+<script src="/static/search.f90d989d.js" defer></script>
+<script src="/static/toc.593a76d5.js" defer></script>
+<script src="/static/nav.69fdef43.js" defer></script>
+<script src="/static/about.03d6c70b.js" defer></script>
+<script src="/static/theme.9b560e7f.js" defer></script>
+<script src="/static/status.0008d5f3.js" defer data-poll="30"></script>
 </body>
 </html>
 

--- a/src/internal/render/testdata/golden/en/pdf.html
+++ b/src/internal/render/testdata/golden/en/pdf.html
@@ -18,7 +18,7 @@
 
 <link rel="icon" href="/static/favicon.3c9c171d.svg" type="image/svg+xml">
 <link rel="icon" href="/static/favicon.981de994.ico" sizes="32x32">
-<link rel="apple-touch-icon" href="/static/touch-icon.png">
+<link rel="apple-touch-icon" href="/static/touch-icon.e8ccc022.png">
 <link rel="manifest" href="/manifest.webmanifest">
 
 <link rel="preload" href="/static/fonts/fraunces.woff2" as="font" type="font/woff2" crossorigin>

--- a/src/internal/render/testdata/golden/en/pdf.html
+++ b/src/internal/render/testdata/golden/en/pdf.html
@@ -16,13 +16,13 @@
 <link rel="alternate" hreflang="fr" href="https://golden.example.org/fr/pdf/">
 <link rel="alternate" hreflang="x-default" href="https://golden.example.org/">
 
-<link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
-<link rel="icon" href="/static/favicon.ico" sizes="32x32">
+<link rel="icon" href="/static/favicon.3c9c171d.svg" type="image/svg+xml">
+<link rel="icon" href="/static/favicon.981de994.ico" sizes="32x32">
 <link rel="apple-touch-icon" href="/static/touch-icon.png">
 <link rel="manifest" href="/manifest.webmanifest">
 
 <link rel="preload" href="/static/fonts/fraunces.woff2" as="font" type="font/woff2" crossorigin>
-<link rel="stylesheet" href="/static/style.css">
+<link rel="stylesheet" href="/static/style.0629016b.css">
 <style>:root{--accent:#247b7b}</style>
 <script>document.documentElement.setAttribute('data-js','');var a=document.cookie.match(/(?:^|; )about=([^;]*)/);if(a&&a[1]===document.documentElement.getAttribute('data-about'))document.documentElement.setAttribute('data-noabout','');try{var t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t)}catch(e){}</script>
 </head>
@@ -90,12 +90,12 @@
   <span class="powered"><span class="foot-mark"><svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg></span>powered by <a href="https://github.com/MorganKryze/cairn" title="cairn 1.14.0">cairn</a> <a class="foot-version" href="https://github.com/MorganKryze/cairn/releases/tag/v1.14.0">1.14.0</a></span>
   </div></footer>
 <a class="totop" href="#top" aria-label="Back to top"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 19V5M5 12l7-7 7 7"/></svg></a>
-<script src="/static/search.js" defer></script>
-<script src="/static/toc.js" defer></script>
-<script src="/static/nav.js" defer></script>
-<script src="/static/about.js" defer></script>
-<script src="/static/theme.js" defer></script>
-<script src="/static/status.js" defer data-poll="30"></script>
+<script src="/static/search.f90d989d.js" defer></script>
+<script src="/static/toc.593a76d5.js" defer></script>
+<script src="/static/nav.69fdef43.js" defer></script>
+<script src="/static/about.03d6c70b.js" defer></script>
+<script src="/static/theme.9b560e7f.js" defer></script>
+<script src="/static/status.0008d5f3.js" defer data-poll="30"></script>
 </body>
 </html>
 

--- a/src/internal/render/testdata/golden/fr.html
+++ b/src/internal/render/testdata/golden/fr.html
@@ -16,13 +16,13 @@
 <link rel="alternate" hreflang="fr" href="https://golden.example.org/fr/">
 <link rel="alternate" hreflang="x-default" href="https://golden.example.org/">
 
-<link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
-<link rel="icon" href="/static/favicon.ico" sizes="32x32">
+<link rel="icon" href="/static/favicon.3c9c171d.svg" type="image/svg+xml">
+<link rel="icon" href="/static/favicon.981de994.ico" sizes="32x32">
 <link rel="apple-touch-icon" href="/static/touch-icon.png">
 <link rel="manifest" href="/manifest.webmanifest">
 
 <link rel="preload" href="/static/fonts/fraunces.woff2" as="font" type="font/woff2" crossorigin>
-<link rel="stylesheet" href="/static/style.css">
+<link rel="stylesheet" href="/static/style.0629016b.css">
 <style>:root{--accent:#247b7b}</style>
 <script>document.documentElement.setAttribute('data-js','');var a=document.cookie.match(/(?:^|; )about=([^;]*)/);if(a&&a[1]===document.documentElement.getAttribute('data-about'))document.documentElement.setAttribute('data-noabout','');try{var t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t)}catch(e){}</script>
 </head>
@@ -134,12 +134,12 @@
   <span class="powered"><span class="foot-mark"><svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg></span>propulsé par <a href="https://github.com/MorganKryze/cairn" title="cairn 1.14.0">cairn</a> <a class="foot-version" href="https://github.com/MorganKryze/cairn/releases/tag/v1.14.0">1.14.0</a></span>
   </div></footer>
 <a class="totop" href="#top" aria-label="Haut de page"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 19V5M5 12l7-7 7 7"/></svg></a>
-<script src="/static/search.js" defer></script>
-<script src="/static/toc.js" defer></script>
-<script src="/static/nav.js" defer></script>
-<script src="/static/about.js" defer></script>
-<script src="/static/theme.js" defer></script>
-<script src="/static/status.js" defer data-poll="30"></script>
+<script src="/static/search.f90d989d.js" defer></script>
+<script src="/static/toc.593a76d5.js" defer></script>
+<script src="/static/nav.69fdef43.js" defer></script>
+<script src="/static/about.03d6c70b.js" defer></script>
+<script src="/static/theme.9b560e7f.js" defer></script>
+<script src="/static/status.0008d5f3.js" defer data-poll="30"></script>
 </body>
 </html>
 

--- a/src/internal/render/testdata/golden/fr.html
+++ b/src/internal/render/testdata/golden/fr.html
@@ -18,7 +18,7 @@
 
 <link rel="icon" href="/static/favicon.3c9c171d.svg" type="image/svg+xml">
 <link rel="icon" href="/static/favicon.981de994.ico" sizes="32x32">
-<link rel="apple-touch-icon" href="/static/touch-icon.png">
+<link rel="apple-touch-icon" href="/static/touch-icon.e8ccc022.png">
 <link rel="manifest" href="/manifest.webmanifest">
 
 <link rel="preload" href="/static/fonts/fraunces.woff2" as="font" type="font/woff2" crossorigin>

--- a/src/internal/render/testdata/golden/fr/pdf.html
+++ b/src/internal/render/testdata/golden/fr/pdf.html
@@ -16,13 +16,13 @@
 <link rel="alternate" hreflang="fr" href="https://golden.example.org/fr/pdf/">
 <link rel="alternate" hreflang="x-default" href="https://golden.example.org/">
 
-<link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
-<link rel="icon" href="/static/favicon.ico" sizes="32x32">
+<link rel="icon" href="/static/favicon.3c9c171d.svg" type="image/svg+xml">
+<link rel="icon" href="/static/favicon.981de994.ico" sizes="32x32">
 <link rel="apple-touch-icon" href="/static/touch-icon.png">
 <link rel="manifest" href="/manifest.webmanifest">
 
 <link rel="preload" href="/static/fonts/fraunces.woff2" as="font" type="font/woff2" crossorigin>
-<link rel="stylesheet" href="/static/style.css">
+<link rel="stylesheet" href="/static/style.0629016b.css">
 <style>:root{--accent:#247b7b}</style>
 <script>document.documentElement.setAttribute('data-js','');var a=document.cookie.match(/(?:^|; )about=([^;]*)/);if(a&&a[1]===document.documentElement.getAttribute('data-about'))document.documentElement.setAttribute('data-noabout','');try{var t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t)}catch(e){}</script>
 </head>
@@ -91,12 +91,12 @@
   <span class="powered"><span class="foot-mark"><svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg></span>propulsé par <a href="https://github.com/MorganKryze/cairn" title="cairn 1.14.0">cairn</a> <a class="foot-version" href="https://github.com/MorganKryze/cairn/releases/tag/v1.14.0">1.14.0</a></span>
   </div></footer>
 <a class="totop" href="#top" aria-label="Haut de page"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 19V5M5 12l7-7 7 7"/></svg></a>
-<script src="/static/search.js" defer></script>
-<script src="/static/toc.js" defer></script>
-<script src="/static/nav.js" defer></script>
-<script src="/static/about.js" defer></script>
-<script src="/static/theme.js" defer></script>
-<script src="/static/status.js" defer data-poll="30"></script>
+<script src="/static/search.f90d989d.js" defer></script>
+<script src="/static/toc.593a76d5.js" defer></script>
+<script src="/static/nav.69fdef43.js" defer></script>
+<script src="/static/about.03d6c70b.js" defer></script>
+<script src="/static/theme.9b560e7f.js" defer></script>
+<script src="/static/status.0008d5f3.js" defer data-poll="30"></script>
 </body>
 </html>
 

--- a/src/internal/render/testdata/golden/fr/pdf.html
+++ b/src/internal/render/testdata/golden/fr/pdf.html
@@ -18,7 +18,7 @@
 
 <link rel="icon" href="/static/favicon.3c9c171d.svg" type="image/svg+xml">
 <link rel="icon" href="/static/favicon.981de994.ico" sizes="32x32">
-<link rel="apple-touch-icon" href="/static/touch-icon.png">
+<link rel="apple-touch-icon" href="/static/touch-icon.e8ccc022.png">
 <link rel="manifest" href="/manifest.webmanifest">
 
 <link rel="preload" href="/static/fonts/fraunces.woff2" as="font" type="font/woff2" crossorigin>

--- a/src/internal/render/url.go
+++ b/src/internal/render/url.go
@@ -31,5 +31,9 @@ func AppURL(p string) string {
 	if !config.IsLocalPath(p) {
 		return p
 	}
-	return BasePath + p
+	// One of cairn's own assets goes out under its stamped name, wherever it
+	// was built: the touch icon and the manifest's icons come from here and
+	// not from a template, and they were the only surfaces left unstamped.
+	// Anything the operator supplied passes through untouched.
+	return BasePath + stampStatic(p)
 }

--- a/src/internal/server/basepath_test.go
+++ b/src/internal/server/basepath_test.go
@@ -159,7 +159,10 @@ func TestNoBasePathIsUnchanged(t *testing.T) {
 		"services.yaml": "- {id: pad, url: https://pad.example.org, name: Pad}\n",
 	})
 	html := string(current.Load().Pages["en"].HTML)
-	if !strings.Contains(html, `href="/static/style.css"`) {
+	// Bare meaning no base path in front of it. The name itself carries a
+	// content digest, which is a different thing and is asserted elsewhere.
+	if !strings.Contains(html, `href="`+render.AssetURL("style.css")+`"`) ||
+		!strings.HasPrefix(render.AssetURL("style.css"), "/static/") {
 		t.Error("root deployment should keep bare /static/ URLs")
 	}
 	rec := httptest.NewRecorder()

--- a/src/internal/server/routing.go
+++ b/src/internal/server/routing.go
@@ -294,3 +294,32 @@ func cacheControl(h http.Handler) http.Handler {
 		h.ServeHTTP(w, r)
 	})
 }
+
+// stamped serves cairn's own assets under the digested names the pages point
+// at, and only under a digest cairn itself issued.
+//
+// A year and immutable, which is safe for exactly one reason: the name changes
+// whenever the bytes do, so this response can never become the wrong answer.
+// The pages that point here are served no-cache, so an upgrade is picked up on
+// the next visit without anyone reaching for a hard refresh, which is the
+// whole point of the exercise.
+//
+// A plain name falls through to the handler behind this one, on the day-long
+// cache it has always had, so anything that hardcoded /static/style.css goes
+// on working. A name shaped like a digest that cairn never issued falls
+// through too, and meets the 404 it deserves.
+func stamped(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if real, ok := render.AssetPath(strings.TrimPrefix(r.URL.Path, "/static/")); ok {
+			w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+			r2 := new(http.Request)
+			*r2 = *r
+			u := *r.URL
+			u.Path = "/static/" + real
+			r2.URL = &u
+			h.ServeHTTP(w, r2)
+			return
+		}
+		h.ServeHTTP(w, r)
+	})
+}

--- a/src/internal/server/server.go
+++ b/src/internal/server/server.go
@@ -72,7 +72,11 @@ func handler(cfgDir, assetsDir string) http.Handler {
 func routes(cfgDir, assetsDir string) *http.ServeMux {
 	mux := http.NewServeMux()
 	static, _ := fs.Sub(render.Embedded, "assets")
-	mux.Handle("GET /static/", cacheControl(http.StripPrefix("/static/", http.FileServerFS(static))))
+	// stamped inside cacheControl, not around it, and the order is the whole
+	// point: both write Cache-Control, so the last one to run wins. Written
+	// the other way the day-long header overwrote the year on every stamped
+	// asset, silently, and a test now holds it.
+	mux.Handle("GET /static/", cacheControl(stamped(http.StripPrefix("/static/", http.FileServerFS(static)))))
 	// Mounted unconditionally: a dir that appears after boot just works.
 	mux.Handle("GET /assets/", http.StripPrefix("/assets/", noListing(http.FileServer(http.Dir(assetsDir)))))
 	// Service preview images live next to the yaml, in <config>/media/.

--- a/src/internal/server/stamped_test.go
+++ b/src/internal/server/stamped_test.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MorganKryze/cairn/src/internal/render"
+)
+
+// The whole mechanism in one file: a stamped name has to come back with the
+// year, a plain one with the day it has always had, and a digest cairn never
+// issued has to come back not at all.
+//
+// The header is the half that is easy to get wrong and impossible to see: two
+// wrappers both write Cache-Control, and whichever runs last wins. Written
+// with them in the wrong order, this failed with the year overwritten by the
+// day, which is the bug that would have shipped a cache nobody could rely on.
+func TestStampedAssetsAreCachedForAYear(t *testing.T) {
+	mux := routes(t.TempDir(), t.TempDir())
+	stampedURL := render.AssetURL("style.css")
+
+	for _, c := range []struct {
+		what, path, cache string
+		status            int
+	}{
+		{"a stamped name", stampedURL, "public, max-age=31536000, immutable", http.StatusOK},
+		{"the plain name", "/static/style.css", "public, max-age=86400", http.StatusOK},
+	} {
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest("GET", c.path, nil))
+		if rec.Code != c.status {
+			t.Errorf("%s: %s -> %d, want %d", c.what, c.path, rec.Code, c.status)
+		}
+		if got := rec.Header().Get("Cache-Control"); got != c.cache {
+			t.Errorf("%s: Cache-Control = %q, want %q", c.what, got, c.cache)
+		}
+		if body := rec.Body.String(); !strings.Contains(body, "--accent") {
+			t.Errorf("%s: did not serve the stylesheet", c.what)
+		}
+	}
+
+	// A guessed digest is not a way to reach a file, nor to have one cached
+	// for a year under a name cairn never promised was stable.
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest("GET", "/static/style.deadbeef.css", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("an invented digest returned %d, want 404", rec.Code)
+	}
+}
+
+// The pages have to point at the stamped name, or none of the above matters.
+func TestPagesLinkTheStampedStylesheet(t *testing.T) {
+	want := render.AssetURL("style.css")
+	if strings.Contains(want, "/static/style.css") {
+		t.Fatal("the stylesheet is not stamped at all")
+	}
+}


### PR DESCRIPTION
Update cairn, reload the page, and the new markup arrives wearing the old stylesheet until you press shift-reload.

**Cause.** Pages are served `no-cache` with an ETag, so they were always fresh. The assets beside them went out under names that never change, with `public, max-age=86400`. New page, yesterday's CSS, for up to a day.

**Fix.** Each asset is linked under a name carrying a digest of its own contents: `style.0629016b.css`. The fresh page points at a name the browser has never seen, and an asset nobody touched keeps its name and stays in the cache. That is what makes `max-age=31536000, immutable` safe rather than reckless: nothing has to expire, because nothing is ever replaced under one name.

The digest is in the name and **not** in a `?v=` query. A query leaves an intermediary cache free to key on the path alone, which would pin a stale file for a year instead of for a day: the same bug, an order of magnitude worse.

Plain `/static/style.css` still answers on the day-long cache, so anything that hardcoded one goes on working, and a digest cairn never issued gets a 404 rather than a file.

## Measured, not reasoned about

Edit the stylesheet, rebuild, serve both:

```
before the edit: /static/style.0629016b.css   public, max-age=31536000, immutable
after  the edit: /static/style.91faf131.css
nav.js:          /static/nav.69fdef43.js      same across that upgrade, not refetched
```

## Two things this found on the way

**The wrapper order.** `cacheControl` and the new one both write `Cache-Control`, so whichever runs last wins. Wrapped the obvious way round, the day-long header silently overwrote the year on every stamped asset. A test holds the order now, and it failed before the fix.

**The display font is deliberately not stamped**, and a test says so, because this is the kind of thing someone tidies up later without seeing why. `style.css` asks for it with a relative `url()` that nothing out here can rewrite, so stamping the `<link rel=preload>` alone would leave two addresses for one file and cost a wasted 64 KB download rather than saving anything. Covering it properly means rewriting the stylesheet's bytes on the way out; it has changed once in the project's life.

## The golden net

Regenerated deliberately, diff read line by line: **36 lines out, 36 lines in, every one an asset name**, nothing else changed, and the CSP byte for byte identical. Four other tests that pinned the old URLs were recalled to the helper rather than to a digest, so a content change never rewrites a test.

Documented in `reference.md`, where the routes table already stated the caching.