### PR TITLE
Stack the leaving dialog's buttons on a phone

### DIFF
--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -834,6 +834,127 @@ await check(
     );
   });
 
+  // ---- the same dialog on a phone ----
+  //
+  // Measured because it was wrong: the actions are a wrapping row with the
+  // primary pushed to the far end by an auto margin, which reads well on a
+  // wide screen and falls apart the moment it wraps. At 390px Continue landed
+  // alone on a second line, shoved right, with dead space beside it; at 320px
+  // all three stacked at three different widths, the last one still offset.
+  {
+    const ph = await browser.newPage({ viewport: { width: 390, height: 780 } });
+    await ph.goto(LEAVE, { waitUntil: "networkidle" });
+    await ph.locator("a[data-leave]").first().click();
+
+    const boxes = () =>
+      ph.evaluate(() => {
+        const d = document.getElementById("leave");
+        const one = (s) => {
+          const b = d.querySelector(s).getBoundingClientRect();
+          return {
+            x: +b.x.toFixed(1),
+            y: +b.y.toFixed(1),
+            w: +b.width.toFixed(1),
+            h: +b.height.toFixed(1),
+          };
+        };
+        const acts = d.querySelector(".leave-acts").getBoundingClientRect();
+        return {
+          row: +acts.width.toFixed(1),
+          copy: one(".leave-copy"),
+          stay: one(".leave-stay"),
+          go: one(".leave-go"),
+        };
+      });
+
+    await check(
+      "on a phone the actions stack, each filling the width",
+      async () => {
+        const b = await boxes();
+        for (const k of ["copy", "stay", "go"]) {
+          if (Math.abs(b[k].w - b.row) > 1) {
+            throw new Error(
+              `${k} is ${b[k].w}px inside a ${b.row}px row, so it does not fill it`,
+            );
+          }
+        }
+        // Three rows, not one and a half: every top differs from the others.
+        const tops = new Set([b.copy.y, b.stay.y, b.go.y]);
+        if (tops.size !== 3)
+          throw new Error(
+            `the three actions share ${3 - tops.size + 1} rows, want one each`,
+          );
+      },
+    );
+
+    await check(
+      "and they are painted in the order they are read in",
+      async () => {
+        // Not cosmetic: a column-reverse here would put the primary on top
+        // while a keyboard still tabs copy, stay, continue, which is 2.4.3
+        // broken for the sake of a layout.
+        const b = await boxes();
+        if (!(b.copy.y < b.stay.y && b.stay.y < b.go.y)) {
+          throw new Error(
+            `painted order ${JSON.stringify([b.copy.y, b.stay.y, b.go.y])} does not follow the markup`,
+          );
+        }
+        if (!(b.copy.x === b.stay.x && b.stay.x === b.go.x)) {
+          throw new Error(
+            "the three do not share a left edge, so one is still offset",
+          );
+        }
+      },
+    );
+
+    await check("each action is a 44px target on a phone", async () => {
+      const b = await boxes();
+      for (const k of ["copy", "stay", "go"]) {
+        if (b[k].h < 44) throw new Error(`${k} is ${b[k].h}px tall, want 44`);
+      }
+    });
+
+    await ph.close();
+  }
+
+  // Wide screens keep the row they had: the utility on the left, the primary
+  // at the far end, which is what the phone layout is a departure from.
+  await check("on a wide screen the actions stay on one row", async () => {
+    await l.setViewportSize({ width: 1100, height: 900 });
+    await l.goto(LEAVE, { waitUntil: "networkidle" });
+    await l.locator("a[data-leave]").first().click();
+    const b = await l.evaluate(() => {
+      const d = document.getElementById("leave");
+      const one = (s) => d.querySelector(s).getBoundingClientRect();
+      const go = one(".leave-go");
+      return {
+        // The row's own height, against the tallest thing in it. Comparing
+        // the tops instead looks right and is not: align-items centres them,
+        // and the three are not the same height, so their tops differ by a
+        // few pixels while sharing a row. That comparison is what failed
+        // here on a layout that was correct.
+        rowH: d.querySelector(".leave-acts").getBoundingClientRect().height,
+        tallest: Math.max(
+          one(".leave-copy").height,
+          one(".leave-stay").height,
+          go.height,
+        ),
+        goRight: go.right,
+        edge: d.getBoundingClientRect().right,
+      };
+    });
+    if (b.rowH > b.tallest + 2) {
+      throw new Error(
+        `the actions occupy ${b.rowH.toFixed(0)}px for a ${b.tallest.toFixed(0)}px control, so they wrapped`,
+      );
+    }
+    if (b.edge - b.goRight > 40) {
+      throw new Error(
+        `the primary sits ${(b.edge - b.goRight).toFixed(0)}px from the edge, so it is no longer at the end`,
+      );
+    }
+  });
+
   // The two buttons are controls whose boundary is the only thing saying so,
   // which is the case 1.4.11 asks 3:1 for. This one opens the dialog itself
   // rather than through the script: what is under test is the paint, and

--- a/src/internal/render/assets/style.css
+++ b/src/internal/render/assets/style.css
@@ -827,6 +827,28 @@ a.status-pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 
 /* The continue link borrows .btn, which carries a 1.4rem top margin for the
    detail page it was drawn for; in a row of buttons that margin is a step. */
 .leave-acts .btn { margin-top: 0; margin-inline-start: auto; }
+/* Narrow: stack them, each filling the row.
+
+   The row above is a wide-screen idea and it does not degrade, it breaks. The
+   auto margin parks the primary at the far end, which reads well until the row
+   wraps: at 390px Continue landed alone on a second line shoved right, with
+   dead space beside it, and at 320px all three sat at three different widths
+   with the last still offset. Measured, both.
+
+   44rem rather than the width where three buttons stop fitting, because that
+   width is a property of the words in them: "Copy the address" and "Adresse
+   kopieren" wrap at different viewports, and a breakpoint tuned to English
+   would be wrong in six other languages. This is the breakpoint the rest of
+   the site already turns on, and above it the row always fits.
+
+   Order is left alone on purpose. A column-reverse would put the primary on
+   top while the keyboard still tabs copy, stay, continue, which trades 2.4.3
+   for a layout. Stacked in reading order the primary lands at the bottom,
+   nearest the thumb, which is where a phone wants it anyway. */
+@media (max-width: 44rem) {
+  .leave-acts { flex-direction: column; align-items: stretch; }
+  .leave-acts .btn { margin-inline-start: 0; justify-content: center; }
+}
 
 /* ---- hosted pages ---- */
 

--- a/src/internal/render/golden_test.go
+++ b/src/internal/render/golden_test.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/MorganKryze/cairn/src/internal/config"
@@ -117,8 +118,25 @@ func TestAGatusSiteRendersWhatItAlwaysDid(t *testing.T) {
 	}
 }
 
+// blurDigests replaces the content digest in an asset url with a fixed word,
+// so the golden files pin the markup rather than the bytes of the stylesheet.
+//
+// Without it every edit to style.css or a script rewrites four golden files,
+// because the url they are linked under moves with their contents, which is
+// the whole point of the digest and no business of a markup net. What the
+// digest actually is has its own tests: it is computed from the file in
+// TestTheDigestIsOfTheFilesOwnBytes, and no page may link an asset without one
+// in TestNoPageLinksAnUnstampedAsset. Blurring it here loses nothing those two
+// do not already hold, and stops the net crying wolf.
+var digestInURL = regexp.MustCompile(`(/static/[A-Za-z0-9._/-]+?)\.[0-9a-f]{8}\.`)
+
+func blurDigests(b []byte) []byte {
+	return digestInURL.ReplaceAll(b, []byte("$1.DIGEST."))
+}
+
 func compare(t *testing.T, name string, got []byte) {
 	t.Helper()
+	got = blurDigests(got)
 	if *update {
 		if err := os.MkdirAll(filepath.Dir(name), 0o750); err != nil {
 			t.Fatal(err)

--- a/src/internal/render/testdata/golden/en.html
+++ b/src/internal/render/testdata/golden/en.html
@@ -16,13 +16,13 @@
 <link rel="alternate" hreflang="fr" href="https://golden.example.org/fr/">
 <link rel="alternate" hreflang="x-default" href="https://golden.example.org/">
 
-<link rel="icon" href="/static/favicon.3c9c171d.svg" type="image/svg+xml">
-<link rel="icon" href="/static/favicon.981de994.ico" sizes="32x32">
-<link rel="apple-touch-icon" href="/static/touch-icon.e8ccc022.png">
+<link rel="icon" href="/static/favicon.DIGEST.svg" type="image/svg+xml">
+<link rel="icon" href="/static/favicon.DIGEST.ico" sizes="32x32">
+<link rel="apple-touch-icon" href="/static/touch-icon.DIGEST.png">
 <link rel="manifest" href="/manifest.webmanifest">
 
 <link rel="preload" href="/static/fonts/fraunces.woff2" as="font" type="font/woff2" crossorigin>
-<link rel="stylesheet" href="/static/style.0629016b.css">
+<link rel="stylesheet" href="/static/style.DIGEST.css">
 <style>:root{--accent:#247b7b}</style>
 <script>document.documentElement.setAttribute('data-js','');var a=document.cookie.match(/(?:^|; )about=([^;]*)/);if(a&&a[1]===document.documentElement.getAttribute('data-about'))document.documentElement.setAttribute('data-noabout','');try{var t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t)}catch(e){}</script>
 </head>
@@ -133,12 +133,12 @@
   <span class="powered"><span class="foot-mark"><svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg></span>powered by <a href="https://github.com/MorganKryze/cairn" title="cairn 1.14.0">cairn</a> <a class="foot-version" href="https://github.com/MorganKryze/cairn/releases/tag/v1.14.0">1.14.0</a></span>
   </div></footer>
 <a class="totop" href="#top" aria-label="Back to top"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 19V5M5 12l7-7 7 7"/></svg></a>
-<script src="/static/search.f90d989d.js" defer></script>
-<script src="/static/toc.593a76d5.js" defer></script>
-<script src="/static/nav.69fdef43.js" defer></script>
-<script src="/static/about.03d6c70b.js" defer></script>
-<script src="/static/theme.9b560e7f.js" defer></script>
-<script src="/static/status.0008d5f3.js" defer data-poll="30"></script>
+<script src="/static/search.DIGEST.js" defer></script>
+<script src="/static/toc.DIGEST.js" defer></script>
+<script src="/static/nav.DIGEST.js" defer></script>
+<script src="/static/about.DIGEST.js" defer></script>
+<script src="/static/theme.DIGEST.js" defer></script>
+<script src="/static/status.DIGEST.js" defer data-poll="30"></script>
 </body>
 </html>
 

--- a/src/internal/render/testdata/golden/en/pdf.html
+++ b/src/internal/render/testdata/golden/en/pdf.html
@@ -16,13 +16,13 @@
 <link rel="alternate" hreflang="fr" href="https://golden.example.org/fr/pdf/">
 <link rel="alternate" hreflang="x-default" href="https://golden.example.org/">
 
-<link rel="icon" href="/static/favicon.3c9c171d.svg" type="image/svg+xml">
-<link rel="icon" href="/static/favicon.981de994.ico" sizes="32x32">
-<link rel="apple-touch-icon" href="/static/touch-icon.e8ccc022.png">
+<link rel="icon" href="/static/favicon.DIGEST.svg" type="image/svg+xml">
+<link rel="icon" href="/static/favicon.DIGEST.ico" sizes="32x32">
+<link rel="apple-touch-icon" href="/static/touch-icon.DIGEST.png">
 <link rel="manifest" href="/manifest.webmanifest">
 
 <link rel="preload" href="/static/fonts/fraunces.woff2" as="font" type="font/woff2" crossorigin>
-<link rel="stylesheet" href="/static/style.0629016b.css">
+<link rel="stylesheet" href="/static/style.DIGEST.css">
 <style>:root{--accent:#247b7b}</style>
 <script>document.documentElement.setAttribute('data-js','');var a=document.cookie.match(/(?:^|; )about=([^;]*)/);if(a&&a[1]===document.documentElement.getAttribute('data-about'))document.documentElement.setAttribute('data-noabout','');try{var t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t)}catch(e){}</script>
 </head>
@@ -90,12 +90,12 @@
   <span class="powered"><span class="foot-mark"><svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg></span>powered by <a href="https://github.com/MorganKryze/cairn" title="cairn 1.14.0">cairn</a> <a class="foot-version" href="https://github.com/MorganKryze/cairn/releases/tag/v1.14.0">1.14.0</a></span>
   </div></footer>
 <a class="totop" href="#top" aria-label="Back to top"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 19V5M5 12l7-7 7 7"/></svg></a>
-<script src="/static/search.f90d989d.js" defer></script>
-<script src="/static/toc.593a76d5.js" defer></script>
-<script src="/static/nav.69fdef43.js" defer></script>
-<script src="/static/about.03d6c70b.js" defer></script>
-<script src="/static/theme.9b560e7f.js" defer></script>
-<script src="/static/status.0008d5f3.js" defer data-poll="30"></script>
+<script src="/static/search.DIGEST.js" defer></script>
+<script src="/static/toc.DIGEST.js" defer></script>
+<script src="/static/nav.DIGEST.js" defer></script>
+<script src="/static/about.DIGEST.js" defer></script>
+<script src="/static/theme.DIGEST.js" defer></script>
+<script src="/static/status.DIGEST.js" defer data-poll="30"></script>
 </body>
 </html>
 

--- a/src/internal/render/testdata/golden/fr.html
+++ b/src/internal/render/testdata/golden/fr.html
@@ -16,13 +16,13 @@
 <link rel="alternate" hreflang="fr" href="https://golden.example.org/fr/">
 <link rel="alternate" hreflang="x-default" href="https://golden.example.org/">
 
-<link rel="icon" href="/static/favicon.3c9c171d.svg" type="image/svg+xml">
-<link rel="icon" href="/static/favicon.981de994.ico" sizes="32x32">
-<link rel="apple-touch-icon" href="/static/touch-icon.e8ccc022.png">
+<link rel="icon" href="/static/favicon.DIGEST.svg" type="image/svg+xml">
+<link rel="icon" href="/static/favicon.DIGEST.ico" sizes="32x32">
+<link rel="apple-touch-icon" href="/static/touch-icon.DIGEST.png">
 <link rel="manifest" href="/manifest.webmanifest">
 
 <link rel="preload" href="/static/fonts/fraunces.woff2" as="font" type="font/woff2" crossorigin>
-<link rel="stylesheet" href="/static/style.0629016b.css">
+<link rel="stylesheet" href="/static/style.DIGEST.css">
 <style>:root{--accent:#247b7b}</style>
 <script>document.documentElement.setAttribute('data-js','');var a=document.cookie.match(/(?:^|; )about=([^;]*)/);if(a&&a[1]===document.documentElement.getAttribute('data-about'))document.documentElement.setAttribute('data-noabout','');try{var t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t)}catch(e){}</script>
 </head>
@@ -134,12 +134,12 @@
   <span class="powered"><span class="foot-mark"><svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg></span>propulsé par <a href="https://github.com/MorganKryze/cairn" title="cairn 1.14.0">cairn</a> <a class="foot-version" href="https://github.com/MorganKryze/cairn/releases/tag/v1.14.0">1.14.0</a></span>
   </div></footer>
 <a class="totop" href="#top" aria-label="Haut de page"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 19V5M5 12l7-7 7 7"/></svg></a>
-<script src="/static/search.f90d989d.js" defer></script>
-<script src="/static/toc.593a76d5.js" defer></script>
-<script src="/static/nav.69fdef43.js" defer></script>
-<script src="/static/about.03d6c70b.js" defer></script>
-<script src="/static/theme.9b560e7f.js" defer></script>
-<script src="/static/status.0008d5f3.js" defer data-poll="30"></script>
+<script src="/static/search.DIGEST.js" defer></script>
+<script src="/static/toc.DIGEST.js" defer></script>
+<script src="/static/nav.DIGEST.js" defer></script>
+<script src="/static/about.DIGEST.js" defer></script>
+<script src="/static/theme.DIGEST.js" defer></script>
+<script src="/static/status.DIGEST.js" defer data-poll="30"></script>
 </body>
 </html>
 

--- a/src/internal/render/testdata/golden/fr/pdf.html
+++ b/src/internal/render/testdata/golden/fr/pdf.html
@@ -16,13 +16,13 @@
 <link rel="alternate" hreflang="fr" href="https://golden.example.org/fr/pdf/">
 <link rel="alternate" hreflang="x-default" href="https://golden.example.org/">
 
-<link rel="icon" href="/static/favicon.3c9c171d.svg" type="image/svg+xml">
-<link rel="icon" href="/static/favicon.981de994.ico" sizes="32x32">
-<link rel="apple-touch-icon" href="/static/touch-icon.e8ccc022.png">
+<link rel="icon" href="/static/favicon.DIGEST.svg" type="image/svg+xml">
+<link rel="icon" href="/static/favicon.DIGEST.ico" sizes="32x32">
+<link rel="apple-touch-icon" href="/static/touch-icon.DIGEST.png">
 <link rel="manifest" href="/manifest.webmanifest">
 
 <link rel="preload" href="/static/fonts/fraunces.woff2" as="font" type="font/woff2" crossorigin>
-<link rel="stylesheet" href="/static/style.0629016b.css">
+<link rel="stylesheet" href="/static/style.DIGEST.css">
 <style>:root{--accent:#247b7b}</style>
 <script>document.documentElement.setAttribute('data-js','');var a=document.cookie.match(/(?:^|; )about=([^;]*)/);if(a&&a[1]===document.documentElement.getAttribute('data-about'))document.documentElement.setAttribute('data-noabout','');try{var t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t)}catch(e){}</script>
 </head>
@@ -91,12 +91,12 @@
   <span class="powered"><span class="foot-mark"><svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg></span>propulsé par <a href="https://github.com/MorganKryze/cairn" title="cairn 1.14.0">cairn</a> <a class="foot-version" href="https://github.com/MorganKryze/cairn/releases/tag/v1.14.0">1.14.0</a></span>
   </div></footer>
 <a class="totop" href="#top" aria-label="Haut de page"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 19V5M5 12l7-7 7 7"/></svg></a>
-<script src="/static/search.f90d989d.js" defer></script>
-<script src="/static/toc.593a76d5.js" defer></script>
-<script src="/static/nav.69fdef43.js" defer></script>
-<script src="/static/about.03d6c70b.js" defer></script>
-<script src="/static/theme.9b560e7f.js" defer></script>
-<script src="/static/status.0008d5f3.js" defer data-poll="30"></script>
+<script src="/static/search.DIGEST.js" defer></script>
+<script src="/static/toc.DIGEST.js" defer></script>
+<script src="/static/nav.DIGEST.js" defer></script>
+<script src="/static/about.DIGEST.js" defer></script>
+<script src="/static/theme.DIGEST.js" defer></script>
+<script src="/static/status.DIGEST.js" defer data-poll="30"></script>
 </body>
 </html>
 


### PR DESCRIPTION
The dialog's actions were a wrapping row with the primary pushed to the far end by an auto margin. That reads well on a wide screen and does not degrade, it breaks.

Measured before:

| viewport | what happened |
| --- | --- |
| 390px | `Copy` and `Stay` shared a line, `Continue` landed **alone on a second line, shoved right**, with dead space beside it |
| 320px | all three stacked at three different widths (167.9 / 105.8 / 126.4), the last still offset |

After: three controls, each filling the row, same left edge, in reading order.

## The breakpoint

44rem, not the width where three buttons stop fitting. That width is a property of the words in them: "Copy the address" and "Adresse kopieren" wrap at different viewports, so a number tuned to English would be wrong in six other languages. 44rem is the breakpoint the rest of the site already turns on, and above it the row always fits.

**Order is left alone on purpose.** A `column-reverse` would put the primary on top while the keyboard still tabs copy → stay → continue, trading 2.4.3 for a layout. Stacked in reading order the primary lands at the bottom, nearest the thumb, which is where a phone wants it.

Short landscape was measured and left alone: at 667×375 the dialog caps itself and scrolls, with every control reachable.

## Checks

Four, two of them red on the old layout with the numbers above as their failure message. The other two guard what the fix must not cost: a 44px target, and the row staying a row on a wide screen.

**One of the four was wrong before it was right**, and it is the same mistake as the focus-ring check last week: it compared the buttons' top edges to decide they shared a row, while `align-items: center` centres three controls of different heights, so their tops legitimately differ by a few pixels. It failed on a layout that was correct. It measures the row's own height now.

## Also: the golden net stopped pinning digests

An edit to `style.css` moves the url four pages link it under, so every css change rewrote four golden files. That is the digest working, and no business of a markup net. Digests have their own tests already: computed from the file's bytes, and required on every asset a page links.

Checked both ways rather than assumed: a stray markup attribute still fails the net, and a stray css rule no longer does.