### PR TITLE
Say that a first pull request's checks wait for a click

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,12 @@ docs: quickstart readme and example config
 
 No trailers, no bodies unless the _why_ genuinely needs a sentence.
 
+**On your first pull request the checks will sit there doing nothing**, and
+that is normal rather than something you did wrong: this repository asks a
+maintainer to approve workflow runs coming from a fork the first time, so
+nobody can spend its CI by opening a pull request. One click here starts them,
+and after that yours run on their own.
+
 ## The browser tests
 
 A handful of behaviours are what `go test` cannot reach: the Go tests assert


### PR DESCRIPTION
Two outside contributions in a row have stalled on mechanics rather than on their content. rbourgeat's hit CodeQL's default setup, which does not analyse fork pull requests; AntonPalmqvist's sat with **no checks at all**, because this repository asks a maintainer to approve workflow runs from a fork the first time.

The setting is the right one: without it anyone could spend this repository's CI by opening a pull request. What was missing is the sentence telling a contributor that an empty check list on their first pull request is the repository being careful, not their branch being wrong.