### PR TITLE
just save: pull a release to dist/, verified before it moves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ node_modules/
 
 # macOS writes one into any folder opened in Finder, docs/assets especially
 .DS_Store
+
+# just save writes release tarballs here; they are downloads, not sources
+dist/

--- a/docs/deployment/airgap.md
+++ b/docs/deployment/airgap.md
@@ -26,6 +26,24 @@ unpack to roughly 10 MB on the node, nearly all of it the one static binary.
 
 ## 1. On the connected side
 
+### A shortcut, if you have the repository
+
+Everything in this section can be done by hand, and the rest of it shows how.
+If you have cairn checked out, two of the steps are a recipe:
+
+```sh
+just save 1.18.2 linux/amd64   # the platform of the cluster, not of your laptop
+```
+
+That pulls cairn's image for that one platform, saves it to `dist/`, pulls the
+packaged chart, and **verifies both signatures before anything moves**, which is
+the step you cannot repeat once the line is cut.
+
+It deliberately stops there. **Gatus, its chart and the icons are still yours to
+fetch**, and the icons in particular are the step nothing downstream will remind
+you about. Read on: the sections below are what the recipe automates and what it
+does not.
+
 ### The chart, verified before it crosses
 
 The order matters. `cosign verify` queries the public transparency log, so it is

--- a/justfile
+++ b/justfile
@@ -48,6 +48,50 @@ demo:
 demo-rebuild:
     docker compose -f demo/compose.yaml up -d --build
 
+# save a release to dist/ for an air-gapped move: just save 1.18.2 [linux/amd64]
+save version platform="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # docker save exports the platform you pulled and nothing else, so this is
+    # an argument rather than an assumption: preparing an amd64 cluster from
+    # an arm64 laptop is the classic way to learn that at CrashLoopBackOff
+    # instead of here. Left out, it is this machine's, spelled the way the
+    # rest of the project spells it: uname says aarch64, images say arm64.
+    plat="{{ platform }}"
+    if [ -z "$plat" ]; then
+      case "$(uname -m)" in
+        arm64|aarch64) plat=linux/arm64 ;;
+        x86_64|amd64) plat=linux/amd64 ;;
+        *) plat="linux/$(uname -m)" ;;
+      esac
+    fi
+    mkdir -p dist
+    docker pull --platform "$plat" morgankryze/cairn:{{ version }}
+    # --platform on the save too, and it is load-bearing rather than belt and
+    # braces. Under the containerd image store a tag keeps its whole index, so
+    # saving by name exports every platform present and `docker load` then
+    # materialises the host's: asking for amd64 on an arm64 laptop produced a
+    # tar that loaded as arm64, silently, which is the CrashLoopBackOff this
+    # recipe exists to prevent. Measured before it was written this way.
+    docker save --platform "$plat" morgankryze/cairn:{{ version }} \
+      -o "dist/cairn-{{ version }}-${plat//\//-}.tar"
+    # The packaged chart rather than charts/ from git: it is the artifact the
+    # release signed, and the only one whose version is not whatever the
+    # working tree happens to say.
+    helm pull oci://ghcr.io/morgankryze/charts/cairn --version {{ version }} --destination dist
+    # Verified here on purpose, and this is the whole reason the recipe exists
+    # rather than two docker commands: cosign queries the public transparency
+    # log, so it is not something you get to do on the other side of the gap.
+    # Both write their summary to stderr, hence 2>&1 and not just >/dev/null.
+    for ref in morgankryze/cairn ghcr.io/morgankryze/charts/cairn; do
+      cosign verify "$ref:{{ version }}" \
+        --certificate-identity-regexp '^https://github.com/MorganKryze/cairn/' \
+        --certificate-oidc-issuer https://token.actions.githubusercontent.com >/dev/null 2>&1 \
+        || { echo "cosign could not verify $ref:{{ version }}; nothing here is trustworthy" >&2; exit 1; }
+    done
+    ls -lh dist/ | tail -n +2 | awk '{print "  " $9 "  " $5}'
+    echo "signatures verified for $plat. Moving it across: docs/deployment/airgap.md"
+
 # stop everything
 down:
     docker compose -f demo/compose.yaml down


### PR DESCRIPTION
```sh
just save 1.18.2              # this machine's platform
just save 1.18.2 linux/amd64  # or the cluster's
```

Pulls the image for one platform, saves it, pulls the packaged chart the release signed rather than `charts/` from the working tree, and verifies both signatures.

**The verification is why this is a recipe and not two docker commands.** cosign queries the public transparency log, so it is the one step you cannot do on the other side of an air gap.

## The measurement found the bug the comment claimed to prevent

Written first, measured after. Under the containerd image store a tag keeps its whole index, so `docker save` by name exports every platform present and `docker load` materialises the host's:

```
cairn-1.18.2-linux-amd64.tar  ->  arch=arm64     # before
cairn-1.18.2-linux-amd64.tar  ->  arch=amd64     # after
```

Asking for `linux/amd64` on an arm64 laptop produced a tar that loaded as arm64, **silently**, which is exactly the `CrashLoopBackOff` that `docs/deployment/airgap.md` opens by warning about. `docker save --platform` fixes it, and each tar now loads as the architecture it is named after, at 4.5 and 4.1 MB, the sizes the README states.

The reloaded image was run rather than trusted: `/healthz` answers 200 and it serves the example config. The chart tarball reads `1.18.2` for both `version` and `appVersion`.

`uname` says `aarch64` where images say `arm64`, so the default platform is translated rather than passed through. `dist/` is gitignored.