### PR TITLE
Fold the welcome note's dismiss button like the host flag

### DIFF
--- a/example/site.yaml
+++ b/example/site.yaml
@@ -4,6 +4,11 @@ tagline:
   fr: Des outils libres, simples, pour tout le monde.
   en: Free, simple tools for everyone.
 locales: [fr, en]
+about:
+  fr: |
+    Bienvenue ! Voici les services que j'héberge pour vous.
+  en: |
+    Welcome! These are the services I host for you.
 theme:
   accent: "#247b7b"
   # Typography: a CSS font stack for body text, or the first name of a font

--- a/justfile
+++ b/justfile
@@ -148,6 +148,7 @@ test-browser:
     /tmp/cairn-browser -config scripts/fixtures/status -addr 127.0.0.1:8092 &
     pids="$pids $!"
     /tmp/cairn-browser -config scripts/fixtures/themed -addr 127.0.0.1:8093 &
+    pids="$pids $!"
     /tmp/cairn-browser -config scripts/fixtures/leave -addr 127.0.0.1:8094 &
     pids="$pids $!"
     trap 'kill $pids 2>/dev/null || true' EXIT INT TERM

--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -94,6 +94,79 @@ await check("and it flips with the theme, in both directions", async () => {
     );
 });
 
+// ---- A2: the welcome note's dismiss button folds like the host flag ----
+
+// Two controls on this page wear the same fold: a glyph at rest, the word
+// unfurled beside it on hover. Nothing of that survives a look at the markup,
+// and it has to run here rather than on `home` below, which asks for reduced
+// motion and so measures every transition already finished.
+//
+// A display swap satisfies neither half. It cannot be animated, since display
+// does not interpolate, and it takes the glyph away at the instant the pointer
+// lands on it, which is the one moment the visitor is looking at it. So both
+// states are held: faded and clipped at rest, both parts painted once open.
+await check("the welcome note's dismiss button unfurls its label", async () => {
+  const x = page.locator("#about-x");
+  await x.waitFor({ state: "visible" });
+  const read = () =>
+    x.evaluate((el) => {
+      const box = el.getBoundingClientRect();
+      const g = el.querySelector("svg").getBoundingClientRect();
+      return {
+        w: box.width,
+        h: box.height,
+        // the glyph's own rect ignores the clip, so a negative side is a
+        // cross with a leg cut off rather than one merely sitting off centre
+        sides: [g.left - box.left, box.right - g.right],
+        glyph: el.querySelector("svg").getClientRects().length > 0,
+        // a span that is display:none still reports opacity 1, so this reads as
+        // "faded" only when it really is faded
+        label: parseFloat(getComputedStyle(el.querySelector("span")).opacity),
+      };
+    });
+
+  const rest = await read();
+  if (rest.label !== 0)
+    throw new Error(
+      `the label sits at opacity ${rest.label} before anyone hovers, so there is nothing to fade in`,
+    );
+  if (!rest.glyph)
+    throw new Error("no glyph at rest: the button reads as empty");
+  // Folded, it is a disc rather than a pill. The border radius is already past
+  // half of either side, so any difference between the two reads as a circle
+  // squashed flat top and bottom, and the eye catches it at a glance.
+  if (Math.abs(rest.w - rest.h) > 1)
+    throw new Error(
+      `${Math.round(rest.w)} by ${Math.round(rest.h)} folded, so the pill is not round`,
+    );
+  // and the cross sits in the middle of it, whole: a clip tight enough to
+  // square the box must not be tight enough to take a leg off the glyph
+  const [near, far] = rest.sides;
+  if (Math.min(near, far) < 0 || Math.abs(near - far) > 1)
+    throw new Error(
+      `the glyph leaves ${near.toFixed(1)}px on one side and ${far.toFixed(1)}px on the other`,
+    );
+  if (rest.w < 24)
+    throw new Error(
+      `${Math.round(rest.w)}px wide folded, and WCAG 2.2 asks 24 by 24 of a target`,
+    );
+
+  await x.hover();
+  await page.waitForTimeout(450);
+  const open = await read();
+  if (open.label !== 1)
+    throw new Error(`hovered, the label is still at opacity ${open.label}`);
+  if (!open.glyph)
+    throw new Error(
+      "the glyph left as the pointer arrived: the button empties itself to show the word",
+    );
+  if (open.w <= rest.w + 8)
+    throw new Error(
+      `${Math.round(rest.w)}px folded and ${Math.round(open.w)}px hovered: the label is not unfurling`,
+    );
+  await page.mouse.move(2, 2);
+});
+
 // ---- A3: 3:1 for the boundary of a control someone can operate (1.4.11) ----
 
 // The border and both of its neighbours, straight out of the browser: the

--- a/src/internal/render/assets/style.css
+++ b/src/internal/render/assets/style.css
@@ -276,14 +276,29 @@ header { padding-block: 1.4rem; }
 }
 .about p { line-height: 1.7; margin: 0 0 .85rem; }
 .about p:last-of-type { margin-bottom: 0; }
+/* The same fold as the host flag, and deliberately the same: a glyph at rest,
+   the word unfurled beside it on hover or focus. It used to swap display
+   between the two, which is the one way of writing this that cannot be
+   animated, since display does not interpolate; and it took the cross away at
+   the instant the pointer landed on it, so the button emptied itself to show
+   its own label. Clipping a nowrap row keeps both parts on screen and gives
+   the width something to travel. */
 .about-x {
   position: absolute;
   top: .8rem;
   inset-inline-end: .8rem;
   display: inline-flex;
   align-items: center;
+  gap: .32rem;
   height: 1.9rem;
-  padding: 0 .55rem;
+  /* Folded it is a disc, not a pill: the same 1.9rem across as it is tall.
+     Which forces the padding, since the border, the glyph and two paddings
+     have to add up to exactly that: .8rem of glyph and 2px of border leave
+     .55rem a side minus the pixel the border took. Round it up and the box
+     goes oval; leave the pixel in and the cross sits 1px shy of centre. */
+  max-width: 1.9rem;
+  overflow: hidden;
+  padding: 0 calc(.55rem - 1px);
   border: 1px solid var(--border);
   border-radius: 999px;
   background: var(--faint);
@@ -291,15 +306,26 @@ header { padding-block: 1.4rem; }
   font: inherit;
   font-size: .78rem;
   font-weight: 500;
+  white-space: nowrap;
   cursor: pointer;
-  transition: color .16s, border-color .16s;
+  transition: max-width .3s cubic-bezier(.2, .7, .3, 1), color .16s, border-color .16s;
 }
-.about-x svg { width: .8rem; height: .8rem; }
-.about-x span { display: none; }
-.about-x:hover, .about-x:focus-visible { color: var(--fg); border-color: color-mix(in oklab, var(--accent) 45%, var(--border)); }
-.about-x:hover svg, .about-x:focus-visible svg { display: none; }
-.about-x:hover span, .about-x:focus-visible span { display: inline; }
+/* flex: none, or the glyph is what gives way when the box is clipped */
+.about-x svg { width: .8rem; height: .8rem; flex: none; }
+.about-x span { opacity: 0; transition: opacity .18s; }
+.about-x:hover, .about-x:focus-visible {
+  max-width: 14rem;
+  color: var(--fg);
+  border-color: color-mix(in oklab, var(--accent) 45%, var(--border));
+}
+.about-x:hover span, .about-x:focus-visible span { opacity: 1; }
 .about-x:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+/* No (hover: none) rule here, and that is the one place this parts company
+   with the flag. The flag sits in the card foot, in flow, so a permanently
+   unfurled label costs nothing. This button is absolute over the note, which
+   reserves 3.4rem of end padding for it folded: unfurled on every phone it
+   would lay its own label across the first line of the welcome text. A touch
+   visitor gets the cross, which is what the button means anyway. */
 /* width lives on the wrapper: as a flex item it would otherwise size to the
    box's max-content and leave the box shy of the right edge */
 .search {
@@ -590,6 +616,9 @@ a.flag { min-height: 1.5rem; }
 @media (prefers-reduced-motion: reduce) {
   .flag { transition: none; max-width: 14rem; }
   .flag-label { transition: none; opacity: 1; }
+  /* the dismiss button loses the travel but keeps the fold, unlike the flag
+     just above: see the note on why it does not unfurl on touch either */
+  .about-x, .about-x span { transition: none; }
   header, .nav-links { transition: none; }
 }
 .card-name {


### PR DESCRIPTION
The welcome note's dismiss button swapped `display` between its cross and its
label. That is the one way of writing this that cannot be animated, since
`display` does not interpolate, and it took the cross away at the instant the
pointer landed on it, so the button emptied itself to show its own name.

It now folds the way the host flag beside it already does: a clipped `nowrap`
row, the glyph pinned with `flex: none`, the label at `opacity: 0`. Same curve
and same durations as the flag, so the two controls on a card page move
alike.

Folded it is a disc rather than a pill, which forces the padding: the border,
a `.8rem` glyph and two paddings have to add up to exactly the `1.9rem` height,
leaving `calc(.55rem - 1px)` a side. Round that pixel up and the box goes oval;
leave it in and the cross sits a pixel shy of centre.

One deliberate difference from the flag: no `(hover: none)` rule. The flag sits
in the card foot, in flow, so an unfurled label costs nothing there. This button
is absolute over the note, which reserves `3.4rem` of end padding for it folded;
unfurled on every phone it would lay its own label across the first line of the
welcome text. A touch visitor gets the cross, which is what the button means
anyway. Under reduced motion it keeps the fold and loses the travel.

## Proved red

`scripts/a11y.mjs` gains one check, and each rule it guards was deleted in turn
to watch it fail:

- `opacity: 0` removed: _the label sits at opacity 1 before anyone hovers, so
  there is nothing to fade in_
- the folded `max-width` removed: _84px folded and 84px hovered: the label is
  not unfurling_
- the first attempt's `2.1rem`: _34 by 30 folded, so the pill is not round_

The check also asks that the glyph keep the same gap on both sides, because
squaring the box by tightening the padding without redoing the arithmetic takes
a leg off the cross, and a roundness assertion alone would still pass.

It needed a page carrying a note, so `example/site.yaml` gains the `about` block
that `docs/configuration/site.md` already prints word for word in its full
example.

## Also here

`just test-browser` never captured the pid of the server it starts on 8093: the
`pids="$pids $!"` after the `leave` line collected that one, and the previous
`$!` was gone. Every run since 8093 was added left a cairn behind, and the guard
at the top of the recipe then refused to start the next one. One line, and the
five ports are free on the way out.

56 browser checks, `go test` 529, `go vet` clean.
