### PR TITLE
Keep Tab inside the leaving dialog

### DIFF
--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -876,6 +876,45 @@ await check(
     eq(await go.getAttribute("rel"), "noopener noreferrer", "the rel");
   });
 
+  // Chromium lets Tab walk off the end of a modal dialog: the press after the
+  // last control leaves the page for the browser's own toolbar, and nothing on
+  // screen moves. A bare <dialog> with three controls does the same, so this is
+  // the platform rather than anything in this markup, and it is worth holding
+  // because one press in four then reads as a dead key. WAI-ARIA's dialog
+  // pattern asks for the wrap.
+  await check(
+    "Tab wraps inside the dialog rather than leaving it",
+    async () => {
+      eq(
+        await dialog.evaluate((d) => d.open),
+        true,
+        "dialog.open before tabbing",
+      );
+      const focused = () =>
+        l.evaluate(() => {
+          const a = document.activeElement;
+          if (!a) return "(none)";
+          return a.closest("#leave") ? a.className : `outside: ${a.tagName}`;
+        });
+
+      await l.locator(".leave-go").focus();
+      await l.keyboard.press("Tab");
+      eq(
+        await focused(),
+        "leave-copy",
+        "where Tab off the last control landed",
+      );
+
+      await l.locator(".leave-copy").focus();
+      await l.keyboard.press("Shift+Tab");
+      eq(
+        await focused(),
+        "btn leave-go",
+        "where Shift+Tab off the first control landed",
+      );
+    },
+  );
+
   await check("Escape closes it and the focus comes back", async () => {
     // Asserted open first, and not for tidiness: with no script at all this
     // check passed on its own, because a dialog that never opened is already

--- a/src/internal/render/assets/leave.js
+++ b/src/internal/render/assets/leave.js
@@ -63,6 +63,28 @@
 
   if (stay) stay.addEventListener("click", function () { dialog.close(); });
 
+  // The one thing showModal() does not give us. Chromium lets Tab walk off the
+  // end of a modal dialog: the press after the last control leaves the page for
+  // the browser's own toolbar, so nothing on screen moves and one press in four
+  // reads as a dead key. A bare <dialog> with three buttons does the same, so
+  // this is the platform and not the markup. WAI-ARIA's dialog pattern asks for
+  // the wrap, and three controls are few enough that the visitor notices the
+  // gap. Painted, not merely present: a control the layout dropped is not a
+  // place to send the focus.
+  dialog.addEventListener("keydown", function (e) {
+    if (e.key !== "Tab") return;
+    var stops = [];
+    var all = dialog.querySelectorAll("a[href], button:not([disabled])");
+    for (var i = 0; i < all.length; i++) {
+      if (all[i].getClientRects().length) stops.push(all[i]);
+    }
+    if (!stops.length) return;
+    var edge = e.shiftKey ? stops[0] : stops[stops.length - 1];
+    if (document.activeElement !== edge) return;
+    e.preventDefault();
+    (e.shiftKey ? stops[stops.length - 1] : stops[0]).focus();
+  });
+
   // A click on the backdrop lands on the dialog element itself, since its
   // children cover the rest of it.
   dialog.addEventListener("click", function (e) {


### PR DESCRIPTION
Reported as "Tab does nothing once the dialog is open". The focus was moving
the whole time; one press in every cycle was landing on `<body>`, outside the
dialog, where nothing paints a ring. In a real browser that press leaves the
page for the toolbar, so the screen sits still and the key reads as dead.

Measured before anything was changed, on the fixture and on the demo:

```
on open  -> BUTTON.leave-copy
tab 1    -> BUTTON.leave-stay
tab 2    -> A.btn.leave-go
tab 3    -> BODY            <- outside the dialog, no ring
tab 4    -> BUTTON.leave-copy
```

A bare `<dialog>` with three controls and no stylesheet does the same, so this
is the platform and not this markup. `showModal()` gives the modality, Escape,
the inert page behind and the focus returning to the link that opened it; the
wrap is the one part it leaves to us, and WAI-ARIA's dialog pattern asks for it.

`leave.js` now sends Tab off the last control back to the first, and
`Shift+Tab` off the first back to the last. The stops are read on each press
and filtered to what the layout actually painted, since a control the CSS
dropped is not a place to send focus. Nothing else moves: Escape still closes,
so does the backdrop, and continue is still a real anchor with a real href.

## Proved red

The check went in first and failed the way the measurement said it would:

```
FAIL  Tab wraps inside the dialog rather than leaving it
      where Tab off the last control landed: got "outside: BODY", want "leave-copy"
```

It holds both directions, which matters: a wrap written for Tab alone still
lets `Shift+Tab` off the other end, and the failure would look identical to the
visitor.

57 browser checks, `go test` 529, `go vet` clean.
