### PR TITLE
The dismiss button is a disc on a phone too

### DIFF
--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -581,6 +581,46 @@ const phone = await browser.newContext({ viewport: PHONE });
 const m = await phone.newPage();
 await m.goto(MANY);
 
+// A phone raises the dismiss button to 44px for the thumb, and that rule is
+// older than the fold. The fold caps the width from the desktop block, so
+// raising only the height leaves an oval with the cross pressed against the
+// clip: 30 by 44 with 3px of air on one side, measured on a shipped release.
+// Held at 320 as well, where a rem is no smaller but the note is tightest.
+for (const width of [390, 320]) {
+  await check(`the dismiss button is a disc at ${width}px`, async () => {
+    const p = await browser.newPage({ viewport: { width, height: 780 } });
+    await p.goto(SITE);
+    const x = p.locator("#about-x");
+    await x.waitFor({ state: "visible" });
+    const g = await x.evaluate((el) => {
+      const r = el.getBoundingClientRect();
+      const svg = el.querySelector("svg").getBoundingClientRect();
+      return {
+        w: r.width,
+        h: r.height,
+        near: svg.left - r.left,
+        far: r.right - svg.right,
+      };
+    });
+    await p.close();
+    if (Math.abs(g.w - g.h) > 1) {
+      throw new Error(
+        `${Math.round(g.w)} by ${Math.round(g.h)}, so the pill is not round`,
+      );
+    }
+    if (g.h < 44) {
+      throw new Error(
+        `${Math.round(g.h)}px tall, and the rule that raises it exists to give a thumb 44`,
+      );
+    }
+    if (Math.min(g.near, g.far) < 0 || Math.abs(g.near - g.far) > 1) {
+      throw new Error(
+        `the cross leaves ${g.near.toFixed(1)}px on one side and ${g.far.toFixed(1)}px on the other`,
+      );
+    }
+  });
+}
+
 // Measured still as well, and at phone width, which is the only place this
 // control is painted at all.
 const stillPhone = await browser.newContext({

--- a/src/internal/render/assets/style.css
+++ b/src/internal/render/assets/style.css
@@ -1382,7 +1382,14 @@ footer {
   .theme-toggle { width: 2.75rem; height: 2.75rem; }
   .langs a { display: inline-flex; align-items: center; min-height: 2.75rem; }
   .search-box input { padding-block: .55rem; }
-  .about-x { height: 2.75rem; padding-inline: .85rem; }
+  /* 44px for the thumb, and still a disc: the width is capped by the fold, so
+     raising the height alone left a 30 by 44 oval with the cross 3px from the
+     clip. Same arithmetic as the desktop rule, at this height. */
+  .about-x {
+    height: 2.75rem;
+    max-width: 2.75rem;
+    padding-inline: calc(.975rem - 1px);
+  }
 
   /* the category trail becomes a wrapping chip row under the intro */
   .toc { display: block; margin: 1.5rem 0 .3rem; }


### PR DESCRIPTION
Reported from a real site: the welcome note's dismiss button renders as a tall oval on a phone, with the cross pressed against its edge.

Measured on `example/` before touching anything:

| Width | Box | | Glyph, each side |
| --- | --- | --- | --- |
| 1200px | 30 x 30 | round | 8.8 / 8.8 |
| 390px | **30 x 44** | oval | **14.6 / 3.0** |
| 320px | **30 x 44** | oval | **14.6 / 3.0** |

## Mine, and how

A rule older than the fold raises the button to 44px on a phone, for the thumb:

```css
.about-x { height: 2.75rem; padding-inline: .85rem; }
```

1.18.2 gave the button a fold, which caps its width with `max-width` in the desktop block. That cap still applies at phone width, so raising only the height left a 30 by 44 oval, and the wider padding pushed the cross to 3px from the clip. Two defects from one line I did not read.

The mobile rule now carries the same arithmetic as the desktop one at its own height: the folded width equals the height, and the padding is what the border and the glyph leave. 44 x 44, round, cross centred at 15.6 / 15.6.

## Proved red

Two checks, at 390 and at 320, both saying `30 by 44, so the pill is not round` before the fix.

They exist at those widths for the reason the bug does: the roundness check written with the fold ran at desktop width only, and the rule that broke it lives in a media query. A check that measures one viewport says nothing about the others.

64 browser checks, 547 Go tests, `just lint` clean.