### PR TITLE
Clean up the comments: say the constraint, drop the story

### DIFF
--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -1,8 +1,7 @@
-// Drives five accessibility behaviours in a real browser against a running
-// cairn, because not one of them survives a look at the markup: the theme
-// toggle's state is only known once theme.js has run, the mobile category
-// swap turns on whether JavaScript exists at all, a contrast ratio needs the
-// colours the browser actually resolved, and a scroll is a scroll.
+// Drives the accessibility behaviours no look at the markup can settle: the
+// theme toggle's state is only known once theme.js has run, the mobile
+// category swap turns on whether JavaScript exists at all, a contrast ratio
+// needs the colours the browser resolved, and a scroll is a scroll.
 //
 // Run it with `just test-browser`, which builds cairn and serves the example
 // config, scripts/fixtures/many-categories, scripts/fixtures/status,
@@ -45,9 +44,9 @@ const eq = (got, want, label) => {
   const [g, w] = [JSON.stringify(got), JSON.stringify(want)];
   if (g !== w) throw new Error(`${label}: got ${g}, want ${w}`);
 };
-// Painted, not merely marked. Everything below turns on a display rule, and a
-// display rule is invisible to any test that asks the DOM what it contains:
-// the element is there either way. getClientRects asks what the layout did.
+// Painted, not merely marked. A display rule is invisible to any test that
+// asks the DOM what it contains, since the element is there either way.
+// getClientRects asks what the layout did.
 const painted = (page, sel) =>
   page.$$eval(sel, (els) =>
     els
@@ -100,15 +99,13 @@ await check("and it flips with the theme, in both directions", async () => {
 
 // ---- A2: the welcome note's dismiss button folds like the host flag ----
 
-// Two controls on this page wear the same fold: a glyph at rest, the word
-// unfurled beside it on hover. Nothing of that survives a look at the markup,
-// and it has to run here rather than on `home` below, which asks for reduced
-// motion and so measures every transition already finished.
+// The fold: a glyph at rest, the word unfurled beside it on hover. It runs on
+// `page` rather than on `home` below, which asks for reduced motion and so
+// measures every transition already finished.
 //
-// A display swap satisfies neither half. It cannot be animated, since display
-// does not interpolate, and it takes the glyph away at the instant the pointer
-// lands on it, which is the one moment the visitor is looking at it. So both
-// states are held: faded and clipped at rest, both parts painted once open.
+// A display swap satisfies neither half: display does not interpolate, and it
+// takes the glyph away at the instant the pointer lands on it. Both states are
+// held instead, faded and clipped at rest, both parts painted once open.
 await check("the welcome note's dismiss button unfurls its label", async () => {
   const x = page.locator("#about-x");
   await x.waitFor({ state: "visible" });
@@ -119,32 +116,32 @@ await check("the welcome note's dismiss button unfurls its label", async () => {
       return {
         w: box.width,
         h: box.height,
-        // the glyph's own rect ignores the clip, so a negative side is a
-        // cross with a leg cut off rather than one merely sitting off centre
+        // the glyph's own rect ignores the clip, so a negative side is a leg
+        // cut off rather than a cross merely sitting off centre
         sides: [g.left - box.left, box.right - g.right],
-        glyph: el.querySelector("svg").getClientRects().length > 0,
-        // a span that is display:none still reports opacity 1, so this reads as
-        // "faded" only when it really is faded
-        label: parseFloat(getComputedStyle(el.querySelector("span")).opacity),
+        glyphPainted: el.querySelector("svg").getClientRects().length > 0,
+        // a display:none span still reports opacity 1
+        labelOpacity: parseFloat(
+          getComputedStyle(el.querySelector("span")).opacity,
+        ),
       };
     });
 
   const rest = await read();
-  if (rest.label !== 0)
+  if (rest.labelOpacity !== 0)
     throw new Error(
-      `the label sits at opacity ${rest.label} before anyone hovers, so there is nothing to fade in`,
+      `the label sits at opacity ${rest.labelOpacity} before anyone hovers, so there is nothing to fade in`,
     );
-  if (!rest.glyph)
+  if (!rest.glyphPainted)
     throw new Error("no glyph at rest: the button reads as empty");
-  // Folded, it is a disc rather than a pill. The border radius is already past
-  // half of either side, so any difference between the two reads as a circle
-  // squashed flat top and bottom, and the eye catches it at a glance.
+  // Folded it is a disc, not a pill: the radius is already past half of either
+  // side, so any difference between width and height reads as a circle
+  // squashed flat top and bottom.
   if (Math.abs(rest.w - rest.h) > 1)
     throw new Error(
       `${Math.round(rest.w)} by ${Math.round(rest.h)} folded, so the pill is not round`,
     );
-  // and the cross sits in the middle of it, whole: a clip tight enough to
-  // square the box must not be tight enough to take a leg off the glyph
+  // a clip tight enough to square the box must not take a leg off the cross
   const [near, far] = rest.sides;
   if (Math.min(near, far) < 0 || Math.abs(near - far) > 1)
     throw new Error(
@@ -158,9 +155,11 @@ await check("the welcome note's dismiss button unfurls its label", async () => {
   await x.hover();
   await page.waitForTimeout(450);
   const open = await read();
-  if (open.label !== 1)
-    throw new Error(`hovered, the label is still at opacity ${open.label}`);
-  if (!open.glyph)
+  if (open.labelOpacity !== 1)
+    throw new Error(
+      `hovered, the label is still at opacity ${open.labelOpacity}`,
+    );
+  if (!open.glyphPainted)
     throw new Error(
       "the glyph left as the pointer arrived: the button empties itself to show the word",
     );
@@ -173,16 +172,15 @@ await check("the welcome note's dismiss button unfurls its label", async () => {
 
 // ---- A3: 3:1 for the boundary of a control someone can operate (1.4.11) ----
 
-// The border and both of its neighbours, straight out of the browser: the
-// inside is the control's own fill, the outside is the nearest ancestor that
-// actually paints one, since the header paints nothing on a wide viewport and
-// the colour behind the box is really the body's.
+// The border and both of its neighbours, straight out of the browser. The
+// outside is the nearest ancestor that actually paints one: the header paints
+// nothing on a wide viewport, so the colour behind the box is the body's.
 const boundary = (p, sel) =>
   p.$eval(sel, async (el) => {
     const chan = (s) => {
       // Plain colours serialize as rgb()/rgba(). A color-mix() comes back as
-      // oklab(), whose three numbers are not sRGB channels at all, and reading
-      // them as channels reports near-black for every mix without complaining.
+      // oklab(), whose three numbers are not sRGB channels, and reading them
+      // as channels reports near-black for every mix without complaining.
       if (!s.startsWith("rgb"))
         throw new Error(`cannot read ${s} as sRGB channels`);
       return s
@@ -213,10 +211,10 @@ const boundary = (p, sel) =>
     }
     // Read once, wait a frame, read again. A colour still on its way from one
     // palette value to the other differs between the two, and that is the only
-    // way this measurement has ever been wrong: it reported a point between
-    // --border and --ui-border and called it the answer. Reduced motion should
-    // make that impossible; this is here for the day it stops working, and it
-    // fails on any machine rather than only on a slow one.
+    // way this measurement has ever been wrong: a point between --border and
+    // --ui-border, reported as the answer. Reduced motion should make it
+    // impossible; this catches the day that stops holding, on any machine
+    // rather than only on a slow one.
     const before = getComputedStyle(el).borderTopColor;
     await new Promise((r) =>
       requestAnimationFrame(() => requestAnimationFrame(r)),
@@ -248,15 +246,14 @@ const atLeast3 = (m, what) => {
   }
 };
 
-// Every contrast measurement runs with reduced motion asked for, because the
-// box transitions its border-color over .15s and search.js starts that fade by
-// enabling the input on load. Sampling mid-fade reads a colour that is on
-// neither palette: a CI runner reported rgb(149, 152, 146) at 2.55:1, which is
-// neither --border nor --ui-border but a point between them. A page of its own
-// is not enough, since the fade starts on every one of them, and a fast machine
-// hides the race entirely. The stylesheet turns every transition off under
-// prefers-reduced-motion, so asking for it measures the resting value by
-// construction rather than by winning a race, and that is also the colour a
+// Every contrast measurement runs with reduced motion asked for. The box
+// transitions its border-color over .15s and search.js starts that fade by
+// enabling the input on load, so sampling mid-fade reads a colour on neither
+// palette: a CI runner reported rgb(149, 152, 146) at 2.55:1, a point between
+// --border and --ui-border. A page of its own does not help, since the fade
+// starts on every one, and a fast machine hides the race. Under
+// prefers-reduced-motion the stylesheet turns every transition off, so this
+// measures the resting value by construction, which is also the colour a
 // visitor with that preference sees for the whole life of the page.
 const still = await browser.newContext({ reducedMotion: "reduce" });
 const home = await still.newPage();
@@ -269,10 +266,9 @@ await check(
   },
 );
 
-// The rule is scoped rather than global on purpose: 1.4.11 exempts an inactive
-// component, and the bar renders disabled and decorative on every page but the
-// home page, purely for layout parity. So there is no ratio to assert for the
-// sleeping one, only that it was left alone.
+// 1.4.11 exempts an inactive component, and the bar renders disabled and
+// decorative on every page but the home page, for layout parity. There is no
+// ratio to assert for the sleeping one, only that it was left alone.
 const detail = await still.newPage();
 await detail.goto(new URL("pdf/", SITE).href);
 await check(
@@ -289,9 +285,7 @@ await check(
 );
 
 // The colour math in node, for the checks below. boundary keeps its own copy
-// inside the page because it walks the ancestors there; here the two colours
-// come out and the ratio is computed on this side, which is the half that is
-// easier to read when a value moves.
+// inside the page because it walks the ancestors there.
 const luminance = (s) => {
   if (!s.startsWith("rgb"))
     throw new Error(`cannot read ${s} as sRGB channels`);
@@ -311,10 +305,9 @@ const ratio = (a, b) => {
 
 // ---- A5: the card's detail glyph, which is both a target and a graphic ----
 
-// It replaced words at the end of the description, so it has two duties the
-// words did not: it has to be big enough to hit (2.5.8 asks 24 by 24) and its
-// glyph has to be visible, since the glyph is now the whole message (1.4.11
-// asks 3:1 of a graphic that carries meaning).
+// It replaced words at the end of the description, so it carries two duties
+// those words did not: 24 by 24 to hit (2.5.8), and 3:1 for the glyph, which
+// is now the whole message (1.4.11, a graphic that carries meaning).
 const glyph = (p, theme) =>
   p.$eval(
     ".card-more",
@@ -352,15 +345,14 @@ for (const theme of ["light", "dark"]) {
   );
 }
 
-// The button that opens the service, keyboard-first. Added after a rewrite of
-// the stylesheet silently dropped .btn:focus-visible, which no check here
-// noticed because every other one is about size or colour at rest.
+// The button that opens the service, keyboard-first. Added after a stylesheet
+// rewrite silently dropped .btn:focus-visible, which no check here noticed
+// because every other one is about size or colour at rest.
 //
-// It asserts the designed ring rather than merely that focus is visible, and
-// the difference is the whole point: with the rule gone the button still gets
-// a ring, Chromium's own, which reports outline-style "auto" at 1px in its
-// blue. The rule paints solid 2px in --fg. A check that only asked "is there
-// an outline" passed with the rule deleted, measured.
+// It asserts the designed ring rather than merely that focus is visible: with
+// the rule gone the button still gets a ring, Chromium's own, outline-style
+// "auto" at 1px in its blue, and a check that only asked for an outline passed
+// with the rule deleted. The rule paints solid 2px in --fg.
 await check(
   "the detail page's open button wears cairn's focus ring",
   async () => {
@@ -377,8 +369,7 @@ await check(
   },
 );
 
-// The way back out of a detail page: the same two duties as the card glyph,
-// since it was the other control under 24 by 24.
+// The way back out of a detail page: the same two duties as the card glyph.
 await check("the back link is a real target on a detail page", async () => {
   const m = await detail.$eval(".back", (el) => {
     const r = el.getBoundingClientRect();
@@ -403,9 +394,8 @@ await check("the back link is a real target on a detail page", async () => {
   }
 });
 
-// A hosting flag that leads somewhere is a control, and the demo sets one, so
-// the resting size is worth holding: folded, before anyone hovers, is what a
-// thumb arrives on.
+// A hosting flag that leads somewhere is a control, and folded, before anyone
+// hovers, is what a thumb arrives on.
 await check(
   "a linked hosting flag is a real target while still folded",
   async () => {
@@ -423,11 +413,11 @@ await check(
 
 // A card is one big link, so the pointer is a hand everywhere on it and says
 // nothing extra when it reaches a control. The fill is what tells a visitor
-// they are on a button, so it is worth holding: 3:1 against the card for the
-// boundary, 4.5:1 for the words the pill and the flag carry on top of it.
+// they are on a button: 3:1 against the card for the boundary, 4.5:1 for the
+// words the pill and the flag carry on top of it.
 //
 // color-mix() serializes as oklab(), which the sRGB reader above refuses, so
-// the colours go through a canvas: it hands back what would be painted.
+// these colours go through a canvas, which hands back what would be painted.
 const hoverColours = (p, sel, theme) =>
   p.$eval(
     sel,
@@ -456,9 +446,9 @@ for (const theme of ["light", "dark"]) {
   await check(
     `hovering a card control fills it, visibly, in ${theme}`,
     async () => {
-      // The example config has no monitor, so it has no pill: the controls
-      // checked are the ones this page actually carries, and none at all is a
-      // failure rather than a quiet pass.
+      // The example config has no monitor, so it has no pill. The controls
+      // checked are the ones this page carries, and none at all is a failure
+      // rather than a quiet pass.
       const present = [];
       for (const sel of [
         ".card-more",
@@ -493,11 +483,9 @@ for (const theme of ["light", "dark"]) {
 }
 
 // A card grid lands on fractional track widths, so every card sits at its own
-// subpixel phase. A ring painted on the box edges and a glyph centred inside it
-// then round to different sides, and the glyph reads off centre, differently on
-// each card. Whole numbers on both sides is what stops it, so that is what is
-// held here: the gap has to be an integer, or the drawing goes back to
-// disagreeing with its own outline.
+// subpixel phase. A ring painted on the box edges and a glyph centred inside
+// it then round to different sides, and the glyph reads off centre,
+// differently on each card. An integer gap on both sides is what stops it.
 await check("the detail glyph and its ring round the same way", async () => {
   const gap = await home.$eval(".card-more", (el) => {
     const s = getComputedStyle(el);
@@ -517,11 +505,10 @@ await check("the detail glyph and its ring round the same way", async () => {
 
 // ---- A6: 3:1 for a dot that carries meaning, on both themes (1.4.11) ----
 
-// The fixture's monitor is a port nothing listens on, so every pill on that
-// page renders unknown and neither of these two states can be reached by
-// waiting. Both come from monitors that report more than a bool, which a
-// fixture cannot stand up. What the stylesheet keys on is the class, so the
-// class is what is set: this measures the colours, which is all it claims to.
+// The fixture's monitor is a port nothing listens on, so every pill renders
+// unknown and neither of these two states can be reached by waiting: both come
+// from monitors that report more than a bool. The stylesheet keys on the
+// class, so the class is what is set, and this measures colours only.
 const dot = (p, cls, theme) =>
   p.$eval(
     ".status-pill",
@@ -560,8 +547,8 @@ for (const cls of ["status-degraded", "status-maintenance"]) {
 }
 
 // Blue against green is the pairing most often indistinguishable, and this dot
-// is nine pixels across. The label carries the meaning without colour, which is
-// what 1.4.1 asks for; the shape is the redundancy for the glance.
+// is nine pixels across. The label carries the meaning without colour (1.4.1);
+// the shape is the redundancy for the glance.
 await check(
   "the maintenance dot is square, so colour is not the only cue",
   async () => {
@@ -584,8 +571,8 @@ await m.goto(MANY);
 // A phone raises the dismiss button to 44px for the thumb, and that rule is
 // older than the fold. The fold caps the width from the desktop block, so
 // raising only the height leaves an oval with the cross pressed against the
-// clip: 30 by 44 with 3px of air on one side, measured on a shipped release.
-// Held at 320 as well, where a rem is no smaller but the note is tightest.
+// clip: 30 by 44 with 3px of air on one side, on a shipped release. Held at
+// 320 as well, where a rem is no smaller but the note is tightest.
 for (const width of [390, 320]) {
   await check(`the dismiss button is a disc at ${width}px`, async () => {
     const p = await browser.newPage({ viewport: { width, height: 780 } });
@@ -621,8 +608,7 @@ for (const width of [390, 320]) {
   });
 }
 
-// Measured still as well, and at phone width, which is the only place this
-// control is painted at all.
+// The jump-to select is painted only at phone width.
 const stillPhone = await browser.newContext({
   viewport: PHONE,
   reducedMotion: "reduce",
@@ -641,10 +627,10 @@ await check(
   },
 );
 
-// The regression: the swap to a select is gated on JavaScript because nav.js
-// is the select's entire behaviour. Ungated, a phone with scripting off got no
-// category navigation at all, on the viewport where a nine-category list is
-// least scrollable.
+// The swap to a select is gated on JavaScript because nav.js is the select's
+// entire behaviour. Ungated, a phone with scripting off got no category
+// navigation at all, on the viewport where a nine-category list is least
+// scrollable.
 const dumb = await browser.newContext({
   viewport: PHONE,
   javaScriptEnabled: false,
@@ -675,17 +661,17 @@ const openMenu = async () => {
   await m.locator(".nav-burger").click();
   eq(await nav.evaluate((el) => el.open), true, "the menu opened");
   // The dropdown fades in over .16s from visibility:hidden, and focus() on a
-  // hidden element is a no-op that leaves focus on the burger, which is the
-  // other case entirely and would pass for the wrong reason.
+  // hidden element is a no-op that leaves focus on the burger: the other case
+  // entirely, passing for the wrong reason.
   await m
     .locator(".nav-links .menu-link")
     .first()
     .waitFor({ state: "visible" });
 };
 // behavior:'instant' because the stylesheet sets scroll-behavior:smooth, so a
-// plain scrollBy animates and scrollY has barely moved a frame later. And a
-// page that did not move fires no scroll at all, which would let every check
-// below pass without testing anything: hence the assertion that it did.
+// plain scrollBy animates and scrollY has barely moved a frame later. A page
+// that did not move fires no scroll at all and every check below would pass
+// without testing anything, so the move itself is asserted.
 const scrollDown = async () => {
   const moved = await m.evaluate(async () => {
     const before = scrollY;
@@ -730,11 +716,11 @@ await check(
   },
 );
 
-// Artwork that cannot serve both themes. The whole feature is a CSS rule
-// keyed on data-theme, so the markup says nothing about it: what matters is
-// which url() the browser has resolved on each element, and that pressing the
-// theme button moves it. A <picture> would pass a markup test and fail this
-// one, because it answers to the operating system and not to the button.
+// Artwork that cannot serve both themes. The feature is a CSS rule keyed on
+// data-theme, so the markup says nothing about it: what counts is which url()
+// the browser resolved on each element, and that the theme button moves it. A
+// <picture> would pass a markup test and fail this one, since it answers to
+// the operating system and not to the button.
 {
   const t = await browser.newPage();
   await t.goto(THEMED, { waitUntil: "networkidle" });
@@ -765,8 +751,8 @@ await check(
     eq(p.first, "mark-pale.svg", "a themed icon in dark");
   });
 
-  // A negative control: it passes whether or not the feature exists, and is
-  // here to catch a rule written loosely enough to repaint every icon.
+  // A negative control: it passes whether or not the feature exists, and
+  // catches a rule written loosely enough to repaint every icon.
   await check("an icon that themes nothing is left alone", async () => {
     eq((await painted()).plain, "normal", "the untouched icon in dark");
   });
@@ -805,9 +791,8 @@ await check(
     eq(await file(), "normal", "the detail tile in light");
     await t.locator("#theme-toggle").click();
     eq(await file(), "mark-pale.svg", "the detail tile in dark");
-    // Put the theme back: the choice lives in localStorage and outlives the
-    // navigation, so a check that left it on dark would decide what the next
-    // one starts from.
+    // The choice lives in localStorage and outlives the navigation, so
+    // leaving it on dark would decide what the next check starts from.
     await t.locator("#theme-toggle").click();
     await t.goto(THEMED, { waitUntil: "networkidle" });
   });
@@ -835,11 +820,10 @@ await check(
 
 // ---- the leaving dialog ----
 //
-// The server decides which links are guarded, and Go tests hold that. What
-// only a browser can say is whether the dialog a visitor meets behaves like a
-// dialog: modal, escapable, and returning them where they were. All of it
-// comes from <dialog>.showModal(), which is exactly why it is worth checking
-// that the script really calls it rather than rolling its own div.
+// Go tests hold which links are guarded. Only a browser can say whether the
+// dialog a visitor meets behaves like one: modal, escapable, and returning
+// them where they were. All of that comes from <dialog>.showModal(), so what
+// is checked here is that the script calls it rather than rolling its own div.
 {
   const l = await browser.newPage();
   await l.goto(LEAVE, { waitUntil: "networkidle" });
@@ -875,8 +859,8 @@ await check(
     "it is modal, so the page behind it cannot be reached",
     async () => {
       // A real showModal() puts everything else in the inert subtree, which is
-      // what makes the focus trap and the backdrop work. A div pretending to be
-      // a dialog passes every markup check and fails this one.
+      // what makes the focus trap and the backdrop work. A div pretending to
+      // be a dialog passes every markup check and fails this one.
       eq(
         await l.evaluate(
           () =>
@@ -920,12 +904,9 @@ await check(
     eq(await go.getAttribute("rel"), "noopener noreferrer", "the rel");
   });
 
-  // Chromium lets Tab walk off the end of a modal dialog: the press after the
-  // last control leaves the page for the browser's own toolbar, and nothing on
-  // screen moves. A bare <dialog> with three controls does the same, so this is
-  // the platform rather than anything in this markup, and it is worth holding
-  // because one press in four then reads as a dead key. WAI-ARIA's dialog
-  // pattern asks for the wrap.
+  // Chromium lets Tab off the end of a modal dialog, into the browser's own
+  // toolbar, so one press in four moves nothing on screen. A bare <dialog>
+  // does the same. WAI-ARIA's dialog pattern asks for the wrap.
   await check(
     "Tab wraps inside the dialog rather than leaving it",
     async () => {
@@ -960,9 +941,9 @@ await check(
   );
 
   await check("Escape closes it and the focus comes back", async () => {
-    // Asserted open first, and not for tidiness: with no script at all this
-    // check passed on its own, because a dialog that never opened is already
-    // closed and the focus never left the link that was clicked.
+    // Open is asserted first: a dialog that never opened is already closed and
+    // the focus never left the link that was clicked, so with no script at all
+    // this check passed on its own.
     eq(await dialog.evaluate((d) => d.open), true, "dialog.open before Escape");
     await l.keyboard.press("Escape");
     eq(await dialog.evaluate((d) => d.open), false, "dialog.open after Escape");
@@ -992,11 +973,11 @@ await check(
 
   // ---- the same dialog on a phone ----
   //
-  // Measured because it was wrong: the actions are a wrapping row with the
-  // primary pushed to the far end by an auto margin, which reads well on a
-  // wide screen and falls apart the moment it wraps. At 390px Continue landed
-  // alone on a second line, shoved right, with dead space beside it; at 320px
-  // all three stacked at three different widths, the last one still offset.
+  // The actions are a wrapping row with the primary pushed to the far end by
+  // an auto margin, which reads well on a wide screen and falls apart the
+  // moment it wraps. At 390px Continue landed alone on a second line, shoved
+  // right, with dead space beside it; at 320px all three stacked at three
+  // different widths, the last one still offset.
   {
     const ph = await browser.newPage({ viewport: { width: 390, height: 780 } });
     await ph.goto(LEAVE, { waitUntil: "networkidle" });
@@ -1046,9 +1027,8 @@ await check(
     await check(
       "and they are painted in the order they are read in",
       async () => {
-        // Not cosmetic: a column-reverse here would put the primary on top
-        // while a keyboard still tabs copy, stay, continue, which is 2.4.3
-        // broken for the sake of a layout.
+        // A column-reverse would put the primary on top while a keyboard still
+        // tabs copy, stay, continue: 2.4.3 broken for the sake of a layout.
         const b = await boxes();
         if (!(b.copy.y < b.stay.y && b.stay.y < b.go.y)) {
           throw new Error(
@@ -1073,8 +1053,8 @@ await check(
     await ph.close();
   }
 
-  // Wide screens keep the row they had: the utility on the left, the primary
-  // at the far end, which is what the phone layout is a departure from.
+  // Wide screens keep the row: the utility on the left, the primary at the far
+  // end, which is what the phone layout departs from.
   await check("on a wide screen the actions stay on one row", async () => {
     await l.setViewportSize({ width: 1100, height: 900 });
     await l.goto(LEAVE, { waitUntil: "networkidle" });
@@ -1085,10 +1065,10 @@ await check(
       const go = one(".leave-go");
       return {
         // The row's own height, against the tallest thing in it. Comparing
-        // the tops instead looks right and is not: align-items centres them,
-        // and the three are not the same height, so their tops differ by a
-        // few pixels while sharing a row. That comparison is what failed
-        // here on a layout that was correct.
+        // the tops instead looks right and is not: align-items centres three
+        // controls of different heights, so their tops differ by a few pixels
+        // while sharing a row, and that comparison failed on a layout that
+        // was correct.
         rowH: d.querySelector(".leave-acts").getBoundingClientRect().height,
         tallest: Math.max(
           one(".leave-copy").height,
@@ -1112,12 +1092,11 @@ await check(
   });
 
   // The two buttons are controls whose boundary is the only thing saying so,
-  // which is the case 1.4.11 asks 3:1 for. This one opens the dialog itself
-  // rather than through the script: what is under test is the paint, and
-  // making it depend on leave.js would only give it a second way to fail.
-  // Read from the browser rather than
-  // from the stylesheet: --ui-border is a light-dark(), and a computed style
-  // hands back the unresolved function until something actually paints it.
+  // the case 1.4.11 asks 3:1 for. This opens the dialog directly rather than
+  // through leave.js: the paint is what is under test. The colours are read
+  // from the browser and not from the stylesheet, since --ui-border is a
+  // light-dark() and a computed style hands back the unresolved function
+  // until something paints it.
   await check("the dialog's own buttons clear 3:1 in both themes", async () => {
     await l.goto(LEAVE, { waitUntil: "networkidle" });
     for (const theme of ["light", "dark"]) {
@@ -1150,11 +1129,11 @@ await check(
 // ---- the card states ----
 //
 // Four things no markup assertion can see. The contrast helper here is not the
-// one above: it has to composite a translucent veil itself, respect the paint
-// order while doing it, and read colours the browser hands back as oklab() or
-// as color(srgb …) with a channel just outside the gamut in scientific
-// notation. Each of those three produced a plausible wrong number while this
-// design was being drawn, and none of them produced an error.
+// one above: it composites the translucent veil itself, respects the paint
+// order while doing it, and reads colours the browser hands back as oklab() or
+// as color(srgb ...) with a channel just outside the gamut in scientific
+// notation. Each of those three produced a plausible wrong number, and none of
+// them produced an error.
 {
   const st = await browser.newPage();
   await st.goto(STATES, { waitUntil: "networkidle" });
@@ -1171,8 +1150,8 @@ await check(
         `the name of a retired service is a ${tag}, so Tab still reaches it`,
       );
     }
-    // and walk it, because a tag name is markup and this file exists for what
-    // markup cannot say: the name must never take focus
+    // and walk it: a tag name is markup, and what has to hold is that the
+    // name never takes focus
     await st.evaluate(() => document.body.focus());
     for (let i = 0; i < 40; i++) {
       await st.keyboard.press("Tab");
@@ -1191,10 +1170,10 @@ await check(
   });
   // Not by comparing two cards in a row: the grid stretches every card in a
   // row to the tallest, so those two numbers are equal whatever the badge
-  // does. Measured that way this check passed with the badge put back inside
-  // the box, which is the one failure it exists to catch. What it asks instead
-  // is whether the badge is in flow at all: if it is, the card body starts
-  // below it, and that offset is what the grid charges to every neighbour.
+  // does, and measured that way this check passed with the badge back inside
+  // the box, the one failure it exists to catch. It asks instead whether the
+  // badge is in flow: if it is, the card body starts below it, and the grid
+  // charges that offset to every neighbour.
   await check("the badge takes no row inside the card", async () => {
     const drop = await st.evaluate(() => {
       const card = document.querySelector(".card-badge").closest(".card");
@@ -1243,17 +1222,16 @@ await check(
     "a muted card and every badge still clear their thresholds",
     async () => {
       const bad = await st.evaluate(() => {
-        // A number here can be negative and can be in scientific notation: a mix
-        // that lands just outside the gamut serialises as -3.48948e-7, and
-        // [\d.]+ splits that into "3.48948" and "7", read as a blue channel of
-        // 891. It reported a colour with 8:1 as having 1.39:1.
+        // A number here can be negative and can be in scientific notation: a
+        // mix just outside the gamut serialises as -3.48948e-7, and [\d.]+
+        // splits that into "3.48948" and "7", read as a blue channel of 891.
+        // It reported a colour with 8:1 as having 1.39:1.
         const NUM = /-?\d*\.?\d+(?:e[-+]?\d+)?/gi;
         const probe = document.createElement("span");
         probe.style.display = "none";
         document.body.append(probe);
         // oklab() is not sRGB, and half this palette arrives that way because
-        // --accent-ink is itself such a mix. Let the browser convert rather than
-        // writing the conversion here.
+        // --accent-ink is itself such a mix. The browser does the conversion.
         const toSRGB = (v) => {
           if (v.startsWith("rgb") || v.startsWith("color(srgb")) return v;
           probe.style.color = `color-mix(in srgb, ${v} 100%, transparent)`;
@@ -1332,10 +1310,9 @@ await check(
     },
   );
 
-  // The rule between the pill and the state says the two are different kinds
-  // of claim. It must not be drawn with nothing to its left, which is every
-  // disabling state, since none of them is monitored: a stroke hanging off
-  // the start of a line reads as a rendering fault.
+  // The rule between the pill and the state must not be drawn with nothing to
+  // its left, which is every disabling state, since none of them is monitored:
+  // a stroke hanging off the start of a line reads as a rendering fault.
   await check(
     "the rule appears only when a pill precedes the state",
     async () => {

--- a/scripts/icons.mjs
+++ b/scripts/icons.mjs
@@ -14,14 +14,13 @@
 //     cairn-light.svg         cropped to its own edges the way they require.
 //     cairn-dark.svg
 //
-// The suffix names the ink, so -light is the pale one and belongs on a dark
-// background, -dark the deep one and belongs on a light background. It reads
-// backwards to anyone who parses "-light" as "for the light theme", which is
-// why it is the mistake those collections reject most often.
+// The suffix names the ink: -light is the pale one, for a dark background,
+// -dark the deep one, for a light background. Reading it as "for the light
+// theme" is the mistake those collections reject most often.
 //
 // The mark is also inlined in templates/layout.tmpl, as the icon a service
 // falls back to when it declares none. That copy is pinned to favicon.svg by
-// TestTheMarkIsDrawnTheSameInBothPlaces, which is what keeps the two honest.
+// TestTheMarkIsDrawnTheSameInBothPlaces.
 import { chromium } from 'playwright';
 import { mkdirSync, writeFileSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -32,9 +31,8 @@ const ASSETS = join(ROOT, 'src', 'internal', 'render', 'assets');
 const BRAND = join(ROOT, 'docs', 'assets', 'brand');
 mkdirSync(BRAND, { recursive: true });
 
-// The mark: four stones of the same gauge, the top one set down at nine
-// degrees. Four rather than five because five merge into a cone at 16px, and
-// the tilt because a stack built by hand is not square to anything.
+// Four stones of the same gauge, the top one set down at nine degrees. Four
+// rather than five: five merge into a cone at 16px.
 const MARK =
   '<rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/>' +
   '<rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/>' +
@@ -42,12 +40,12 @@ const MARK =
   '<rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/>';
 
 const BRAND_INK = '#247b7b'; // the accent, and the only ink the product uses
-const ON_DARK = '#5fc4c0';   // -light: light ink, for dark backgrounds
-const ON_LIGHT = '#1a5c5c';  // -dark: dark ink, for light backgrounds
+const ON_DARK = '#5fc4c0';   // ships as cairn-light.svg
+const ON_LIGHT = '#1a5c5c';  // ships as cairn-dark.svg
 const PAGE = '#eef0ea';      // the light page colour, under every app icon
 
-// How much of the square the mark covers in the app icons: as full as it can
-// be while its far corners still clear Android's crop circle. Checked below.
+// How much of the square the mark covers in an app icon: as full as it can be
+// while its far corners still clear Android's crop circle. Checked below.
 const FILL = 0.69;
 
 const doc = (viewBox, fill) =>
@@ -55,8 +53,8 @@ const doc = (viewBox, fill) =>
 
 const browser = await chromium.launch();
 
-// Renders the mark to a png. A null background leaves it transparent, which is
-// what a favicon wants and what a home-screen icon must never be.
+// A null background leaves the png transparent: what a favicon wants, and what
+// a home-screen icon must never be.
 async function png(size, fill, bg) {
   const p = await browser.newPage({ viewport: { width: size, height: size }, deviceScaleFactor: 1 });
   await p.setContent(`<!doctype html><meta charset="utf-8"><style>
@@ -69,7 +67,7 @@ async function png(size, fill, bg) {
   return buf;
 }
 
-// An ICO is a small header plus, since Vista, plain pngs. No dependency needed.
+// An ICO is a small header plus, since Vista, plain pngs.
 function ico(images) {
   const dir = Buffer.alloc(6);
   dir.writeUInt16LE(1, 2); // type: icon
@@ -89,10 +87,10 @@ function ico(images) {
   return Buffer.concat([dir, ...entries, ...images.map((i) => i.data)]);
 }
 
-// Measures the ink in viewBox units, so the brand files can be cropped to the
-// mark rather than to its padded square. Measured off a raster rather than
-// computed: the tilted stone and its rounded corners put the analytic box out
-// by about a third of a unit.
+// The ink's own box in viewBox units, so the brand files can be cropped to the
+// mark rather than to its padded square. Off a raster rather than computed:
+// the tilted stone and its rounded corners put an analytic box out by about a
+// third of a unit.
 const probe = await browser.newPage({ viewport: { width: 600, height: 600 } });
 const inkBox = async (markup) => probe.evaluate(async (svg) => {
   const S = 512;
@@ -136,9 +134,9 @@ writeFileSync(join(BRAND, 'cairn-light.svg'), doc(tight, ON_DARK));
 writeFileSync(join(BRAND, 'cairn-dark.svg'), doc(tight, ON_LIGHT));
 
 // --- and the guarantee the manifest makes ---------------------------------
-// The app icons are declared "any maskable", which promises Android that
-// nothing lives outside a circle of 80% of the canvas. That is a property of
-// FILL and of the mark's proportions, so a redrawn mark could quietly break it.
+// The app icons are declared "any maskable", which promises Android that no
+// ink lives outside a circle of 80% of the canvas. That holds by FILL and the
+// mark's proportions, so a redrawn mark can break it silently.
 let failed = false;
 for (const [name, size] of [['icon-192.png', 192], ['icon-512.png', 512], ['touch-icon.png', 180]]) {
   const far = await probe.evaluate(async ([src, S]) => {

--- a/scripts/screenshots.mjs
+++ b/scripts/screenshots.mjs
@@ -1,16 +1,13 @@
 // Regenerates every picture the README shows, from the running demo stack.
 // Run it with `just shots`, which brings the demo up first.
 //
-// Why a script rather than `playwright screenshot`: the CLI has no device
-// scale factor, and these have to be 2x or they look soft on a retina screen.
+// A script rather than `playwright screenshot`: the CLI has no device scale
+// factor, and these look soft on a retina screen below 2x.
 //
-// Four things come out of here. The hero, light and dark, which the README
-// swaps with a <picture>. A detail page and a phone, because the hero shows
-// one screen and the two questions it leaves are "what is behind a card" and
-// "what does this look like in a hand". And the social card, which is the
-// picture GitHub puts on a link when somebody shares the repository: it is
-// the only one that is composed rather than captured, since a page screenshot
-// cropped to 2:1 loses either its header or its cards.
+// Out of here come the hero in light and dark, which the README swaps with a
+// <picture>, a detail page, a phone, and the social card GitHub puts on a
+// shared link. The social card is composed rather than captured: a page
+// screenshot cropped to 2:1 loses either its header or its cards.
 
 import { chromium } from 'playwright';
 import { fileURLToPath } from 'node:url';
@@ -19,12 +16,11 @@ import { readFileSync } from 'node:fs';
 
 const OUT = join(dirname(fileURLToPath(import.meta.url)), '..', 'docs', 'assets');
 const URL = process.env.CAIRN_URL ?? 'http://127.0.0.1:8080/en/';
-// The same site, for the shots that open a page of their own. The two below
-// append a path to it, so what it has to guarantee is the trailing slash, not
-// the locale: this replaced `/en/` with `/en/`, which is nothing, and left
-// `CAIRN_URL=http://host/en` producing `http://host/enwhoami/`.
+// The shots below append a path, so this has to guarantee the trailing slash:
+// without it, `CAIRN_URL=http://host/en` produces `http://host/enwhoami/`.
 const DEMO = URL.endsWith('/') ? URL : URL + '/';
 const SIZE = { width: 1440, height: 1000 };
+const RETINA = 2;
 
 const browser = await chromium.launch();
 
@@ -32,11 +28,11 @@ for (const scheme of ['light', 'dark']) {
   const context = await browser.newContext({
     colorScheme: scheme,
     viewport: SIZE,
-    deviceScaleFactor: 2, // retina: the README is read on laptops
-    // Reduced motion does two things here: no animation caught mid-frame, and
-    // the hosting flags render with their labels out, which is the state the
-    // stylesheet already gives reduced-motion and touch visitors. So the hero
-    // explains what the little house means without staging a fake hover.
+    deviceScaleFactor: RETINA,
+    // Reduced motion holds every animation finished and renders the hosting
+    // flags with their labels out, the state the stylesheet gives reduced
+    // motion and touch visitors. The hero names the little house without
+    // staging a fake hover.
     reducedMotion: 'reduce',
   });
   const page = await context.newPage();
@@ -56,7 +52,6 @@ for (const scheme of ['light', 'dark']) {
   await context.close();
 }
 
-// The detail page and the phone: the two questions the hero leaves open.
 for (const [name, url, viewport] of [
   ['detail', DEMO + 'whoami/', { width: 1100, height: 900 }],
   ['phone', DEMO, { width: 390, height: 844 }],
@@ -64,16 +59,16 @@ for (const [name, url, viewport] of [
   const context = await browser.newContext({
     colorScheme: 'light',
     viewport,
-    deviceScaleFactor: 2,
+    deviceScaleFactor: RETINA,
     reducedMotion: 'reduce',
     isMobile: name === 'phone',
     hasTouch: name === 'phone',
   });
   const page = await context.newPage();
   await page.goto(url, { waitUntil: 'networkidle' });
-  // On a phone the welcome note fills the frame and the directory itself
-  // barely shows. Dismissing it is what a returning visitor sees anyway, and
-  // it is the half worth photographing: the chips and the cards.
+  // On a phone the welcome note fills the frame and the directory barely
+  // shows. Dismissed is what a returning visitor sees, and it leaves the
+  // chips and the cards in shot.
   if (name === 'phone') {
     await page.locator('#about-x').click().catch(() => {});
     await page.waitForTimeout(150);
@@ -85,15 +80,14 @@ for (const [name, url, viewport] of [
   await context.close();
 }
 
-// The two views, composed into one picture rather than left to a two-cell
+// The two views composed into one picture rather than left to a two-cell
 // table. Their aspects are 1.22 and 0.46, and a table equalises neither the
 // heights nor the captions: the phone ran on far past the detail page and left
-// a hole beside it. Matching the heights here means the layout cannot break,
-// whatever the reader's width.
+// a hole beside it. Matched heights here hold at any reader width.
 {
   const context = await browser.newContext({
     viewport: { width: 1400, height: 830 },
-    deviceScaleFactor: 2,
+    deviceScaleFactor: RETINA,
   });
   const page = await context.newPage();
   const root = join(dirname(fileURLToPath(import.meta.url)), '..');
@@ -114,19 +108,16 @@ for (const [name, url, viewport] of [
   await context.close();
 }
 
-// The social card. GitHub renders it at 1280x640 on a shared link, and a page
-// screenshot cropped to that ratio loses either its header or its cards, so
-// this one is composed: the mark, the sentence, and the page itself held at
-// the edge of the frame.
+// The social card: the mark, the sentence, and the page itself held at the
+// edge of the frame. GitHub renders it at 1280x640.
 //
 // Everything is inlined as a data URI. A page built with setContent has an
-// about:blank origin, which blocks every file:// subresource, so a src that
-// points at the repository loads nothing and the card comes out with a broken
-// image where the mark should be.
+// about:blank origin, which blocks every file:// subresource, so a src
+// pointing at the repository loads nothing.
 {
   const context = await browser.newContext({
     viewport: { width: 1280, height: 640 },
-    deviceScaleFactor: 2,
+    deviceScaleFactor: RETINA,
   });
   const page = await context.newPage();
   const root = join(dirname(fileURLToPath(import.meta.url)), '..');
@@ -173,17 +164,16 @@ for (const [name, url, viewport] of [
 }
 
 // Rounded corners, baked in. GitHub strips the style attribute from a README,
-// so a border-radius in the markup does nothing: the only place the corner can
-// live is the file. Transparent outside the radius, so the page shows through
-// and the same file sits right on a light canvas and a dark one.
+// so the only place the corner can live is the file. Transparent outside the
+// radius, so the same file sits right on a light canvas and a dark one.
 //
-// Last, after the social card is composed, so that one keeps the square source
-// it draws inside its own frame.
+// Last, so the social card keeps the square source it draws in its own frame.
 for (const [file, radius] of [
   ['home-light.png', 26],
   ['home-dark.png', 26],
   ['two-views.png', 26],
 ]) {
+  // 1, not RETINA: these sources are already 2x.
   const context = await browser.newContext({ deviceScaleFactor: 1 });
   const page = await context.newPage();
   const src = `data:image/png;base64,${readFileSync(join(OUT, file)).toString('base64')}`;

--- a/scripts/search.mjs
+++ b/scripts/search.mjs
@@ -1,5 +1,4 @@
-// Drives the search in a real browser against a running cairn, because
-// search.js is the one piece of behaviour the Go tests cannot reach: they
+// Drives the search in a real browser against a running cairn. The Go tests
 // assert the markup that ships, not what happens once someone types into it.
 //
 // Run it with `just test-browser`, which builds cairn and serves the example
@@ -17,10 +16,9 @@ await page.goto(URL);
 const q = page.locator('#q');
 const empty = page.locator('#empty');
 // Painted, not merely marked. `.card:not([hidden])` reads the attribute, and
-// the attribute was right the whole time an author `display` rule was quietly
-// overriding the browser's [hidden] and leaving those cards on screen. A test
-// that asks the DOM what it was told cannot catch that; getClientRects asks
-// what the layout actually did.
+// the attribute was right the whole time an author `display` rule overrode
+// [hidden] and left those cards on screen. getClientRects asks what the layout
+// did.
 const painted = sel =>
   page.$$eval(sel, els =>
     els.filter(e => e.getClientRects().length > 0).map(e => e.textContent.trim()),
@@ -43,7 +41,6 @@ const eq = (got, want, label) => {
   if (g !== w) throw new Error(`${label}: got ${g}, want ${w}`);
 };
 
-// The state a visitor starts in, and the one every other case returns to.
 const total = await visible();
 if (total < 2) throw new Error(`the page under test has ${total} cards; it needs several`);
 const first = (await names())[0];
@@ -55,10 +52,9 @@ await check('an untouched page shows every card and no message', async () => {
 });
 
 // What the live region says and what the page shows have to be the same
-// number. This is the assertion the old "fewer cards than before" check was
-// missing: with the [hidden] override in place, filtering on a category that
-// also held a non-match announced "1 result" and painted two, and any
-// count-is-smaller test still passed.
+// number. With the [hidden] override in place, filtering on a category that
+// also held a non-match announced "1 result" and painted two, and a
+// count-is-smaller check still passed.
 await check('the page shows exactly as many cards as it announces', async () => {
   await q.fill(word);
   const said = (await page.locator('#count').textContent()).trim();
@@ -81,8 +77,8 @@ await check('a query that matches nothing says so', async () => {
   eq(await empty.isHidden(), false, 'the empty message is shown');
 });
 
-// The regression: clearing the box is a return to the full list, not a search
-// that found nothing. It used to leave "no results" on screen, and announce it.
+// Clearing the box is a return to the full list, not a search that found
+// nothing. It used to leave "no results" on screen, and announce it.
 await check('clearing the box restores every card, with no message', async () => {
   await q.fill('ejbhdoehfauhefouah');
   await q.fill('');

--- a/scripts/status.mjs
+++ b/scripts/status.mjs
@@ -1,15 +1,13 @@
 // Drives the pill refresh in a real browser against a running cairn. The Go
-// tests assert that the slots and the script ship; what they cannot see is a
-// pill changing in a page nobody reloaded, which is the entire point of
-// status.js and the bug it was written for: cairn reconnects to Gatus, the
-// tab left open on a wall display never does.
+// tests assert that the slots and the script ship; a pill changing in a page
+// nobody reloaded is only visible here. cairn reconnects to Gatus, a tab left
+// open on a wall display does not.
 //
-// The refresh answers itself. cairn here is pointed at a Gatus that does not
-// exist, so every pill starts unknown; the test intercepts the fetch the
-// script makes and hands back the page cairn would have rendered once Gatus
-// answered. That keeps the fixture from depending on a second server, and it
-// is the same bytes either way, since what the script parses is a whole cairn
-// page.
+// cairn is pointed at a Gatus that does not exist, so every pill starts
+// unknown; the test intercepts the fetch the script makes and hands back the
+// page cairn would have rendered once Gatus answered. No second server to
+// stand up, and the same bytes either way, since what the script parses is a
+// whole cairn page.
 //
 // Run it with `just test-browser`, which serves scripts/fixtures/status first.
 //
@@ -35,27 +33,26 @@ const eq = (got, want, label) => {
 
 const browser = await chromium.launch();
 const page = await browser.newPage();
-// Fake time, so a five-second poll is not five seconds of test. Installed
-// before the navigation, which is the only moment it can be.
+// Fake time, so a five-second poll is not five seconds of test. It has to be
+// installed before the navigation.
 await page.clock.install();
 await page.goto(URL);
 
 // The page as cairn first served it, and the only source of the markup fed
-// back in: a swap driven by handwritten HTML would prove the test's markup
-// works, not cairn's.
+// back in: handwritten HTML would prove the test's markup works, not cairn's.
 const original = await page.content();
 let answer = original;
 await page.route(URL, async route => {
-  // Only the script's own request. The navigation above already happened, but
-  // a reload during the run must still reach cairn.
+  // Only the script's own request: a reload during the run must still reach
+  // cairn.
   if (route.request().resourceType() !== 'fetch') return route.fallback();
   await route.fulfill({ status: 200, contentType: 'text/html; charset=utf-8', body: answer });
 });
 
 const pillOf = id =>
   page.$eval(`.status-slot[data-status="${id}"]`, el => el.firstElementChild?.className ?? '');
-// Painted rather than merely present: an empty foot that still draws its
-// padding is exactly the regression the :has() rule exists to stop.
+// An empty foot that still draws its padding is the regression the :has()
+// rule stops.
 const footHeight = id =>
   page.$eval(`.status-slot[data-status="${id}"]`, el => {
     const foot = el.closest('.card-foot');
@@ -118,7 +115,6 @@ await check('a pill under the keyboard is left alone until focus moves on', asyn
     'what the keyboard is on',
   );
 
-  // And once it is no longer focused, the update it was holding back lands.
   await page.locator('.card-name').first().focus();
   await tick();
   eq(await pillOf('alpha'), 'status-pill status-down', "alpha's pill");

--- a/src/cmd/cairn/main.go
+++ b/src/cmd/cairn/main.go
@@ -56,8 +56,6 @@ func main() {
 	}
 
 	cfg, err := config.Load(*cfgDir)
-	// A flag that quietly does nothing is the thing -check spends its life
-	// reporting; the program itself should not ship one.
 	if *hide && !*emit {
 		log.Fatal("-hide-targets only means something with -emit-gatus: it writes into the Gatus config, not into cairn's own")
 	}
@@ -73,8 +71,8 @@ func main() {
 		return
 	}
 	if err != nil {
-		// A dead container helps nobody: serve the getting-started page and
-		// let the watcher swap the real config in the moment it is valid.
+		// Serving beats exiting: the getting-started page goes up and the
+		// watcher swaps the real config in the moment it is valid.
 		log.Print(err)
 		log.Printf("no valid config yet: serving the getting-started page, watching %s", *cfgDir)
 		server.Store(render.StarterModel())
@@ -95,8 +93,6 @@ func main() {
 	log.Fatal(server.Serve(*addr, *cfgDir, *assetsDir))
 }
 
-// oneShot answers -emit-gatus and -emit-icons, which both print a derived file
-// and exit without ever serving anything.
 func oneShot(cfg *config.Config, gatus, hide bool) ([]byte, error) {
 	if gatus {
 		return status.Emit(cfg, hide)

--- a/src/internal/check/check.go
+++ b/src/internal/check/check.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
@@ -44,31 +45,23 @@ func checkWarnings(cfg *config.Config, dir string) []string {
 	out = append(out, topHeadings(cfg)...)
 	out = append(out, unsupportedLocales(cfg)...)
 	out = append(out, mediaWarnings(cfg, filepath.Join(dir, "media"))...)
-	// The canonical, og:url and hreflang links are all built from site.url, so
-	// without it they are simply absent. Nothing fails, the page looks right,
-	// and a multilingual site quietly reads as several duplicates. Skipped
-	// when the operator has already told search engines to stay away.
+	// Nothing fails without site.url, the page looks right, and a multilingual
+	// site quietly reads to a crawler as several duplicates. Skipped when the
+	// operator has already told search engines to stay away.
 	if cfg.Site.URL == "" && !cfg.Noindex() {
 		out = append(out, "site.yaml has no url: pages carry no canonical link, no og:url and no hreflang alternates (set url: https://… to emit them)")
 	}
-	// og:image needs a url and a raster logo, both. With a url but no usable
-	// logo, every link to the site previews as bare text on Mastodon, Slack or
-	// anywhere else, and the page itself gives no hint of it.
-	//
-	// index: false does not silence this the way it silences the canonical
-	// links above. og:image feeds chat unfurls, not crawlers, and a portal
-	// kept out of search results is precisely the one that gets pasted into a
-	// team channel, where a preview is all anyone sees before clicking.
-	// og:image has no theme to follow, so it is the light logo that has to be
-	// a raster, and it alone.
+	// og:image needs a url and a raster logo, both. index: false does not
+	// silence this the way it silences the canonical links above: og:image
+	// feeds chat unfurls, not crawlers, and a portal kept out of search
+	// results is the one that gets pasted into a team channel. og:image has no
+	// theme to follow, so the light logo alone has to be a raster.
 	if cfg.Site.URL != "" && !render.IsRaster(cfg.Site.Logo.Light) {
 		if cfg.Site.Logo.Light == "" {
 			out = append(out, "site.yaml has no logo: links to the site preview with no image (og:image wants a png, jpg, webp or gif)")
 		} else {
-			// Named logo.light when there are two, the way the other logo
-			// warnings are: an operator reading "logo" with a pair in front of
-			// them has to guess which half was judged, and the answer is
-			// always this one.
+			// Named logo.light when there are two: an operator reading "logo"
+			// with a pair in front of them has to guess which half was judged.
 			key := "logo"
 			if cfg.Site.Logo.Themed() {
 				key = "logo.light"
@@ -78,9 +71,9 @@ func checkWarnings(cfg *config.Config, dir string) []string {
 	}
 	out = append(out, unresolvableRefs(cfg)...)
 	out = append(out, fontWarnings(cfg, dir)...)
-	// status.insecure is not a mistake, it is a decision, and -check is where a
-	// decision that leaves no trace on the page gets its trace. Nothing else
-	// says it out loud after the startup line has scrolled away.
+	// status.insecure is a decision rather than a mistake, and it leaves no
+	// trace on the page: -check is the only place it is said out loud once the
+	// startup line has scrolled away.
 	if addr := cfg.Site.StatusAddress(); addr != "" && cfg.Site.Status.Insecure {
 		out = append(out, fmt.Sprintf("status.insecure is on: the certificate %s presents is not verified, so anything answering on that address decides what the pills say and the day that certificate changes stops being visible (a CA bundle verifies instead of trusting; see docs/deployment/airgap.md)", addr))
 	}
@@ -95,12 +88,14 @@ func checkWarnings(cfg *config.Config, dir string) []string {
 	return out
 }
 
-// missingLocales lists the enabled locales a translated field says nothing
-// for. Two shapes come back empty on purpose: a plain string, which covers
-// every locale at once, and an unset field, which is absent rather than
-// half-translated and has a documented fallback of its own.
+// coversEveryLocale holds for a plain string, which answers for every locale
+// at once, and for an unset field, which is absent rather than half-translated
+// and has a documented fallback of its own.
+func coversEveryLocale(l config.LString) bool { return len(l) == 0 || l[""] != "" }
+
+// missingLocales lists the enabled locales a translated field says nothing for.
 func missingLocales(cfg *config.Config, l config.LString) []string {
-	if len(l) == 0 || l[""] != "" {
+	if coversEveryLocale(l) {
 		return nil
 	}
 	var missing []string
@@ -112,8 +107,6 @@ func missingLocales(cfg *config.Config, l config.LString) []string {
 	return missing
 }
 
-// missingTranslations lists every translatable field that covers some of
-// the enabled locales but not all of them. A plain string covers them all.
 func missingTranslations(cfg *config.Config) []string {
 	var out []string
 	warn := func(where string, l config.LString) {
@@ -121,15 +114,11 @@ func missingTranslations(cfg *config.Config) []string {
 			out = append(out, fmt.Sprintf("%s has no %s", where, strings.Join(missing, ", ")))
 		}
 	}
-	// The title is the <title>, so a half-translated one puts the other
-	// language in the browser tab, in the bookmark and in every og:title,
-	// which are the three places nobody proofreads.
 	warn("site title", cfg.Site.Title)
 	warn("site tagline", cfg.Site.Tagline)
 	warn("site about", cfg.Site.About)
-	// Link labels are the operator's own words in the header and the footer,
-	// on every page of the site rather than one. The url identifies the entry
-	// because it is the only field guaranteed to be there and readable.
+	// The url identifies a link entry: it is the only field guaranteed to be
+	// there and readable.
 	for _, l := range cfg.Site.Links {
 		warn(fmt.Sprintf("links entry %q label", l.URL), l.Label)
 	}
@@ -147,9 +136,8 @@ func missingTranslations(cfg *config.Config) []string {
 	for _, c := range cfg.Categories {
 		// A category with no name at all is not a missing translation: the id
 		// becomes the heading in every locale, which is documented and often
-		// what the operator wants. Only a name that answers for some locales
-		// and not others is a gap, and missingLocales already stays quiet
-		// about the unset field.
+		// what the operator wants. missingLocales already stays quiet about an
+		// unset field.
 		warn(fmt.Sprintf("category %q name", c.ID), c.Name)
 		for _, s := range c.Services {
 			warn(fmt.Sprintf("service %q name", s.ID), s.Name)
@@ -164,13 +152,10 @@ func missingTranslations(cfg *config.Config) []string {
 }
 
 // partialStringOverrides finds a strings: entry that answers for some of the
-// site's locales and not the rest.
-//
-// Str resolves the override per locale and falls through to the built-in
-// table on a miss, so {nav.menu: {fr: Sommaire}} on a [fr, en] site gives the
-// French pages the operator's word and the English pages cairn's. It is the
-// one case where someone explicitly asked for different wording and got it on
-// half their site, and nothing on either page shows which half.
+// site's locales and not the rest. Str resolves the override per locale and
+// falls through to the built-in table on a miss, so {nav.menu: {fr: Sommaire}}
+// on a [fr, en] site gives the French pages the operator's word and the
+// English pages cairn's, with nothing on either page showing which is which.
 func partialStringOverrides(cfg *config.Config) []string {
 	known := map[string]bool{}
 	for _, k := range config.StringKeys() {
@@ -178,15 +163,14 @@ func partialStringOverrides(cfg *config.Config) []string {
 	}
 	keys := make([]string, 0, len(cfg.Site.Strings))
 	for k := range cfg.Site.Strings {
-		// A key cairn does not use is already reported by inertSettings as
-		// doing nothing at all. Which locales it covers is beside the point
-		// then, and two warnings over one line is how a check gets skimmed.
+		// A key cairn does not use is already reported by inertSettings, and
+		// two warnings over one line is how a check gets skimmed.
 		if known[k] {
 			keys = append(keys, k)
 		}
 	}
-	// Map iteration is random, and output that reorders between runs cannot
-	// be diffed by the pipeline an operator wires -check into.
+	// Map iteration is random, and output that reorders between runs cannot be
+	// diffed by the pipeline an operator wires -check into.
 	sort.Strings(keys)
 
 	var out []string
@@ -200,12 +184,10 @@ func partialStringOverrides(cfg *config.Config) []string {
 }
 
 // unsupportedLocales names an enabled locale cairn has no interface for.
-//
-// Nothing refuses it and nothing reports it: the pages build, they carry the
-// right lang attribute, and every word cairn contributes (the navigation, the
-// buttons, the search messages) comes out English. The remedy is a strings:
-// block, so the message says so rather than leaving the operator to guess
-// that their only option is dropping the language.
+// Nothing else refuses it or reports it: the pages build, they carry the right
+// lang attribute, and every word cairn contributes comes out English. The
+// remedy is a strings: block, so the message says so rather than leaving the
+// operator to guess that dropping the language is their only option.
 func unsupportedLocales(cfg *config.Config) []string {
 	builtin := map[string]bool{}
 	for _, l := range config.BuiltinLocales() {
@@ -214,9 +196,8 @@ func unsupportedLocales(cfg *config.Config) []string {
 	var out []string
 	for _, loc := range cfg.Site.Locales {
 		// Str looks the base language up after the full tag, so pt-BR finds
-		// the pt table and is dressed in Portuguese. Testing the full tag
-		// alone would warn about every regional variant of a language that
-		// does ship, which is the opposite of helpful.
+		// the pt table. Testing the full tag alone would warn about every
+		// regional variant of a language that does ship.
 		base, _, _ := strings.Cut(loc, "-")
 		if builtin[strings.ToLower(base)] {
 			continue
@@ -234,8 +215,7 @@ type proseField struct {
 }
 
 // proseFields lists every field that takes markdown, in the order a reader
-// meets them. Shared, so a check added to one of them cannot quietly cover a
-// different set from the checks next to it.
+// meets them. Shared, so two checks cannot quietly cover different sets.
 func proseFields(cfg *config.Config) []proseField {
 	out := []proseField{{"site about", cfg.Site.About}}
 	for _, p := range cfg.Site.Pages {
@@ -253,10 +233,9 @@ func proseFields(cfg *config.Config) []proseField {
 }
 
 // topHeadings names the fields written with a level-one heading. cairn renders
-// it as a level two, because the page already has its <h1> and a second one
-// breaks the outline a screen reader navigates by. That is the right call and
-// it is still worth saying: without this line, "#" and "##" produce identical
-// output and the operator has no way to learn why.
+// it as a level two, since the page already has its <h1> and a second one
+// breaks the outline a screen reader navigates by. Without the warning, "#"
+// and "##" produce identical output with nothing to explain it.
 func topHeadings(cfg *config.Config) []string {
 	var out []string
 	for _, t := range proseFields(cfg) {
@@ -278,13 +257,11 @@ func topHeadings(cfg *config.Config) []string {
 // mediaWarnings flags files nothing references, references naming no file,
 // and files heavy enough to hurt the visitors of the pages that show them.
 func mediaWarnings(cfg *config.Config, mediaDir string) []string {
-	// Keyed by the file in media/, valued by where the reference was written,
-	// so the missing-file warning below can name the page to go and fix.
-	used := map[string]string{}
+	usedBy := map[string]string{}
 	// A file in media/ can be written two ways, and both are documented: the
 	// bare name, and the /media/… path it is served at. Recording only the
 	// first made -check announce a file as unreferenced while it sat on the
-	// page, which is worse than saying nothing: it invites deleting it.
+	// page, which invites deleting it.
 	markUsed := func(src, where string) {
 		rel, ok := strings.CutPrefix(src, "/media/")
 		if !ok {
@@ -295,8 +272,8 @@ func mediaWarnings(cfg *config.Config, mediaDir string) []string {
 			}
 			rel = src
 		}
-		if _, seen := used[rel]; !seen {
-			used[rel] = where
+		if _, seen := usedBy[rel]; !seen {
+			usedBy[rel] = where
 		}
 	}
 	texts := proseFields(cfg)
@@ -310,8 +287,7 @@ func mediaWarnings(cfg *config.Config, mediaDir string) []string {
 	// Asked of the parser that renders the page rather than of a regexp of our
 	// own. The regexp knew only the parenthesised spelling, so `![cap][ref]`
 	// with its definition underneath rendered a broken image and -check still
-	// printed ok. One parser, one answer, and it stays true as the markdown
-	// grows.
+	// printed ok.
 	for _, t := range texts {
 		for _, body := range t.body {
 			for _, src := range render.ImageRefs(body) {
@@ -330,7 +306,7 @@ func mediaWarnings(cfg *config.Config, mediaDir string) []string {
 			return nil
 		}
 		rel = filepath.ToSlash(rel)
-		if _, ok := used[rel]; !ok {
+		if _, ok := usedBy[rel]; !ok {
 			out = append(out, fmt.Sprintf("media/%s is not referenced by any service or page", rel))
 		}
 		if info, ierr := d.Info(); ierr == nil && info.Size() > 1<<20 {
@@ -338,24 +314,21 @@ func mediaWarnings(cfg *config.Config, mediaDir string) []string {
 		}
 		return nil
 	})
-	out = append(out, danglingRefs(used, mediaDir)...)
+	out = append(out, danglingRefs(usedBy, mediaDir)...)
 	return out
 }
 
 // danglingRefs is the walk above run backwards: a reference that names no
-// file, rather than a file nothing names.
-//
-// Load opens every images: entry and refuses to boot on a missing one, so an
-// image written in markdown was the only way left to ship a 404. It reads
-// exactly like the images: form in the documentation, it sits in about text,
-// page bodies and service details, and nothing ever opened it.
-func danglingRefs(used map[string]string, mediaDir string) []string {
-	refs := make([]string, 0, len(used))
-	for rel := range used {
+// file, rather than a file nothing names. Load opens every images: entry and
+// refuses to boot on a missing one, so an image written in markdown is the
+// only way left to ship a 404.
+func danglingRefs(usedBy map[string]string, mediaDir string) []string {
+	refs := make([]string, 0, len(usedBy))
+	for rel := range usedBy {
 		refs = append(refs, rel)
 	}
-	// Map iteration is random, and output that reorders between runs cannot be
-	// diffed by the pipeline an operator wires -check into.
+	// Sorted for the same reason as above: -check output has to diff between
+	// runs.
 	sort.Strings(refs)
 
 	var out []string
@@ -369,7 +342,7 @@ func danglingRefs(used map[string]string, mediaDir string) []string {
 		if st, err := os.Stat(p); err == nil && !st.IsDir() {
 			continue
 		}
-		out = append(out, fmt.Sprintf("%s shows %q, which is not there: the page renders a broken image (expected a file at %s)", used[rel], rel, p))
+		out = append(out, fmt.Sprintf("%s shows %q, which is not there: the page renders a broken image (expected a file at %s)", usedBy[rel], rel, p))
 	}
 	return out
 }
@@ -377,9 +350,9 @@ func danglingRefs(used map[string]string, mediaDir string) []string {
 // unresolvableRefs finds paths that look like a file and reach nothing. cairn
 // passes them through untouched, so a browser resolves them against whatever
 // page it is on: `logo: logo.png` becomes /en/logo.png from a page and
-// /logo.png from the manifest, and 404s from both. These stay warnings rather
-// than errors because the damage is a missing image, and refusing to boot over
-// one would replace a working site with the getting-started page.
+// /logo.png from the manifest, and 404s from both. Warnings and not errors:
+// the damage is a missing image, and refusing to boot over one would replace a
+// working site with the getting-started page.
 func unresolvableRefs(cfg *config.Config) []string {
 	var out []string
 	looksLocal := func(v string) bool {
@@ -409,12 +382,8 @@ func unresolvableRefs(cfg *config.Config) []string {
 }
 
 // fontWarnings says when a configured font file is not where the page will
-// fetch it from.
-//
-// A missing font renders nothing broken: the browser falls back through the
-// rest of the family list, and every page looks exactly as it did. That is
-// the shape -check exists for, a config that reads as working and whose one
-// effect silently never happens.
+// fetch it from. A missing font renders nothing broken: the browser falls back
+// through the rest of the family list and every page looks exactly as it did.
 func fontWarnings(cfg *config.Config, dir string) []string {
 	f := cfg.Site.Theme.Font.File
 	if f == "" {
@@ -432,29 +401,21 @@ func fontWarnings(cfg *config.Config, dir string) []string {
 }
 
 // assetsMounted reports whether the -assets directory is there to look in.
-//
 // -check on a laptop keeps the default /assets, which exists in the container
-// and on nobody's machine, so every reference under it would come back
-// missing at once. A page of warnings that are all wrong buries the one that
-// is right and teaches the operator to stop reading the output, so with no
-// directory to consult the checks below say nothing at all.
+// and on nobody's machine, so every reference under it would come back missing
+// at once. A page of warnings that are all wrong buries the one that is right,
+// so with no directory to consult the checks below say nothing at all.
 func assetsMounted() bool {
 	st, err := os.Stat(config.AssetsPath)
 	return err == nil && st.IsDir()
 }
 
-// assetPath maps an /assets/… reference to the file it names, and returns ""
-// for anything that is not one. The rule lives in config, next to the mount
-// path it resolves against, because three copies of it had grown: this one,
-// the manifest measurement, and now the CA bundle.
 func assetPath(ref string) string { return config.AssetFile(ref) }
 
-// caWarnings covers the two ways status.ca ends up meaning something other than
-// what it looks like it means.
-//
-// Neither is a mistake cairn can refuse at load: both are legal configs, and
-// both are ones where the trust an operator thinks they set up is not the trust
-// they got. That is exactly the shape -check exists for.
+// caWarnings covers the two ways status.ca ends up meaning something other
+// than what it looks like it means. Neither is a mistake cairn can refuse at
+// load: both are legal configs where the trust an operator thinks they set up
+// is not the trust they got.
 func caWarnings(cfg *config.Config) []string {
 	st := cfg.Site.Status
 	if cfg.Site.StatusAddress() == "" || st.CA == "" {
@@ -470,21 +431,17 @@ func caWarnings(cfg *config.Config) []string {
 	return out
 }
 
-// missingAssets checks that every /assets/… reference reaches a file.
-//
-// Load already stats each media/ image, so a mistyped screenshot refuses to
-// boot while a mistyped logo boots fine and paints a broken image on every
-// page. These stay warnings for the same reason unresolvableRefs does: the
-// damage is a missing picture, and refusing to boot over one would replace a
-// working site with the getting-started page.
+// missingAssets checks that every /assets/… reference reaches a file. Load
+// already stats each media/ image, so a mistyped screenshot refuses to boot
+// while a mistyped logo boots fine and paints a broken image on every page.
+// Warnings and not errors, for the reason unresolvableRefs gives.
 func missingAssets(cfg *config.Config) []string {
 	if !assetsMounted() {
 		return nil
 	}
-	// absent answers "this names a file in the mount and the file is not
-	// there", and hands back the path so the message can name it: an operator
-	// staring at a correct-looking /assets/logo.png needs to be told which
-	// directory cairn looked in, which is the -assets flag they forgot.
+	// The path comes back so each message can name the directory cairn looked
+	// in: an operator staring at a correct-looking /assets/logo.png needs to
+	// be told, and the answer is the -assets flag they forgot.
 	absent := func(ref string) (string, bool) {
 		p := assetPath(ref)
 		if p == "" {
@@ -506,8 +463,6 @@ func missingAssets(cfg *config.Config) []string {
 			out = append(out, fmt.Sprintf("site.yaml %s %q is not in the assets directory: the browser tab falls back to a blank page icon (expected a file at %s)", f.Key, f.Val, p))
 		}
 	}
-	// The loudest of these: with no authority to verify against, every poll
-	// fails and every pill stays grey, and nothing on the page says why.
 	if p, miss := absent(cfg.Site.Status.CA); miss {
 		out = append(out, fmt.Sprintf("site.yaml status.ca %q is not in the assets directory: cairn has nothing to verify gatus against, so every poll fails and every pill stays grey (expected a file at %s)", cfg.Site.Status.CA, p))
 	}
@@ -521,10 +476,9 @@ func missingAssets(cfg *config.Config) []string {
 			out = append(out, fmt.Sprintf("site.yaml links entry %q icon %q is not in the assets directory: the link renders with a broken image beside its label (expected a file at %s)", l.URL, l.Icon, p))
 		}
 	}
-	// footer icons are deliberately not checked here. inertSettings already
-	// says the key is dropped and never rendered, so whether the file exists
-	// changes nothing a visitor sees, and a second warning about one line is
-	// exactly the noise that gets the first one ignored.
+	// Footer icons are not checked: inertSettings already says the key is
+	// dropped and never rendered, so whether the file exists changes nothing a
+	// visitor sees.
 	return out
 }
 
@@ -533,11 +487,10 @@ func missingAssets(cfg *config.Config) []string {
 // the top of this file are for: dropping one would not fail the build, it
 // would quietly make every png unmeasurable and the check below silent.
 //
-// Anything it cannot decode comes back zero, which is the honest answer for
-// all three ways that happens: an svg has no intrinsic size, a remote file
-// would need an outbound request cairn does not make, and a file that is not
-// there is unknown rather than wrong. Callers skip a zero instead of
-// comparing against it.
+// Anything it cannot decode comes back zero: an svg has no intrinsic size, a
+// remote file would need an outbound request cairn does not make, and a file
+// that is not there is unknown rather than wrong. Callers skip a zero instead
+// of comparing against it.
 func measure(path string) (int, int) {
 	if path == "" {
 		return 0, 0
@@ -554,14 +507,11 @@ func measure(path string) (int, int) {
 	return c.Width, c.Height
 }
 
-// iconSizeClaims compares each icons entry with the file it points at.
-//
-// cairn cannot resize an image, so the operator states each size and the
-// manifest publishes it as fact. A wrong number is invisible everywhere: the
-// manifest validates, the file loads, and a phone simply picks the file for a
-// slot it does not fill, which is how a home-screen icon comes out blurred.
-// The measurement already exists for the favicon, and only this list went
-// unchecked.
+// iconSizeClaims compares each icons entry with the file it points at. cairn
+// cannot resize an image, so the operator states each size and the manifest
+// publishes it as fact. A wrong number is invisible everywhere: the manifest
+// validates, the file loads, and a phone picks the file for a slot it does not
+// fill, which is how a home-screen icon comes out blurred.
 func iconSizeClaims(cfg *config.Config) []string {
 	if !assetsMounted() {
 		return nil
@@ -569,10 +519,9 @@ func iconSizeClaims(cfg *config.Config) []string {
 	var out []string
 	for i, ic := range cfg.Site.Icons {
 		// "any" is a claim about a scalable file, not a measurement, so there
-		// is nothing to disagree with. Everything else that cannot be
-		// measured (an svg, a URL, a file that is not there) comes back zero
-		// from measure and is skipped on the next line; the missing file has
-		// its own warning already.
+		// is nothing to disagree with. Everything else that cannot be measured
+		// comes back zero from measure and is skipped on the next line; a
+		// missing file has its own warning already.
 		if strings.Contains(ic.Sizes, "any") {
 			continue
 		}
@@ -580,17 +529,10 @@ func iconSizeClaims(cfg *config.Config) []string {
 		if w == 0 || h == 0 {
 			continue
 		}
-		measured := fmt.Sprintf("%dx%d", w, h)
 		// One file may legitimately declare several sizes: an ico holds a 16
 		// and a 32, and DecodeConfig reports one of them. Any match is enough.
-		matches := false
-		for _, s := range strings.Fields(ic.Sizes) {
-			if s == measured {
-				matches = true
-				break
-			}
-		}
-		if matches {
+		measured := fmt.Sprintf("%dx%d", w, h)
+		if slices.Contains(strings.Fields(ic.Sizes), measured) {
 			continue
 		}
 		out = append(out, fmt.Sprintf("site.yaml icons entry %d declares sizes %q but %s measures %s: the manifest states the declared size as fact, so a phone picks this file for a slot it does not fill (correct sizes, or supply a file that size)",
@@ -599,10 +541,8 @@ func iconSizeClaims(cfg *config.Config) []string {
 	return out
 }
 
-// categoryConfusion catches the two ways a category id goes wrong without a
-// word from anyone: a service pointing at an id categories.yaml never defines,
-// and two ids that differ only in case, which render as two sections carrying
-// the same name.
+// categoryConfusion catches two category ids that differ only in case, which
+// render as two sections carrying the same name.
 func categoryConfusion(cfg *config.Config) []string {
 	var out []string
 	byLower := map[string][]string{}
@@ -631,8 +571,8 @@ func quoteAll(in []string) []string {
 	return out
 }
 
-// A URI with a scheme: mailto: and tel: are legitimate link targets, so the
-// "resolves nowhere" test must not flag them.
+// A URI with a scheme, mailto: for one, is a legitimate link target, so the
+// "resolves nowhere" test must not flag it.
 var uriRe = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.-]*:`)
 
 // inertSettings finds keys that were written, accepted, and then do nothing.
@@ -641,9 +581,7 @@ var uriRe = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.-]*:`)
 func inertSettings(cfg *config.Config) []string {
 	var out []string
 
-	// Every pill comes from the monitor. Without an address to poll, named
-	// either way, the companion keys have nothing to act on and no pill is
-	// drawn at all.
+	// An address to poll, named either way, is what every pill comes from.
 	if st := cfg.Site.Status; cfg.Site.StatusAddress() == "" {
 		var set []string
 		if st.Page != "" {
@@ -675,26 +613,28 @@ func inertSettings(cfg *config.Config) []string {
 		}
 	}
 
-	// A hosting flag leads somewhere only from a card that wears one, and a
-	// card wears one only when its service says selfhosted. Set the target and
-	// flag nothing with it and the line reads as working from the file.
-	var wears [2]bool
+	// A hosting flag is drawn only from a card whose service says selfhosted,
+	// so a target set with no card wearing it reads as working from the file.
+	var anySelfhosted, anyExternal bool
 	for _, c := range cfg.Categories {
 		for _, s := range c.Services {
 			if s.Selfhosted != nil {
 				if *s.Selfhosted {
-					wears[0] = true
+					anySelfhosted = true
 				} else {
-					wears[1] = true
+					anyExternal = true
 				}
 			}
 		}
 	}
-	for i, f := range []struct{ key, val, kind string }{
-		{"hosting_flag.self", cfg.Site.HostingFlag.Self, "selfhosted: true"},
-		{"hosting_flag.external", cfg.Site.HostingFlag.External, "selfhosted: false"},
+	for _, f := range []struct {
+		key, val, kind string
+		worn           bool
+	}{
+		{"hosting_flag.self", cfg.Site.HostingFlag.Self, "selfhosted: true", anySelfhosted},
+		{"hosting_flag.external", cfg.Site.HostingFlag.External, "selfhosted: false", anyExternal},
 	} {
-		if f.val != "" && !wears[i] {
+		if f.val != "" && !f.worn {
 			out = append(out, fmt.Sprintf("%s is set and no service says %s, so the flag it points from is never drawn", f.key, f.kind))
 		}
 	}
@@ -719,8 +659,7 @@ func inertSettings(cfg *config.Config) []string {
 
 	// An icons list replaces cairn's whole set rather than adding to it, and
 	// Chromium offers "install this site" only when a 192 and a 512 are both
-	// declared. Adding one icon to improve the home screen silently removes
-	// the install prompt.
+	// declared.
 	if len(cfg.Site.Icons) > 0 {
 		has := func(size string) bool {
 			for _, ic := range cfg.Site.Icons {
@@ -737,8 +676,5 @@ func inertSettings(cfg *config.Config) []string {
 		}
 	}
 
-	// A footer icon used to be reported here. It is a load error now: the key
-	// never rendered and schema/site.json never listed it, so a warning about a
-	// value that cannot exist is one more line to read past.
 	return out
 }

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -21,13 +21,16 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// LString is a string translated per locale. A plain YAML string decodes as
-// the value for every locale.
+// LString is a string translated per locale.
 type LString map[string]string
+
+// untranslated keys the plain YAML string form: one wording the operator
+// serves to every locale, a brand name being the usual case.
+const untranslated = ""
 
 func (l *LString) UnmarshalYAML(n *yaml.Node) error {
 	if n.Kind == yaml.ScalarNode {
-		*l = LString{"": n.Value}
+		*l = LString{untranslated: n.Value}
 		return nil
 	}
 	var m map[string]string
@@ -45,39 +48,28 @@ func (l *LString) UnmarshalYAML(n *yaml.Node) error {
 	return nil
 }
 
-// Get is the wording alone, for everything that only prints it. It is written
-// in terms of GetLocale so there is one lookup order rather than two that can
-// drift apart.
 func (l LString) Get(locale, fallback string) string {
 	s, _ := l.GetLocale(locale, fallback)
 	return s
 }
 
 // GetLocale resolves a translated field and reports the locale the wording
-// actually came from.
+// came from, so a page can mark a fallback rather than assert through
+// <html lang> that the sentence is in a language it is not: a screen reader
+// then reads it in the wrong voice, and an Arabic fallback in a
+// left-to-right page is laid out the wrong way round.
 //
-// That second half is what lets a page be honest about a fallback. A field
-// with no translation for the page's locale still renders, in whichever
-// language the config does have, and nothing used to say so: the page then
-// asserts through <html lang> that the sentence is in a language it is not. A
-// screen reader reads it in the wrong voice, and an Arabic fallback inside a
-// left-to-right page is laid out the wrong way round, which moves its
-// punctuation to the wrong end of the line.
+// Order: the exact locale, the untranslated form, the site default, then
+// anything at all in key order so a half-written config still renders.
 //
-// The order is unchanged: the exact locale, the untranslated form, the site
-// default, then anything at all in key order so a half-written config still
-// renders something.
-//
-// The untranslated form is the plain YAML string, kept under "". It reports
-// the locale that was asked for rather than a language of its own: one string
-// written for every locale is the operator saying it serves them all, which is
-// what a brand name is, and calling that a fallback would mark most fields of
-// most sites.
+// The untranslated form reports the locale that was asked for rather than a
+// language of its own, since it serves every locale; calling it a fallback
+// would mark most fields of most sites.
 func (l LString) GetLocale(locale, fallback string) (text, from string) {
 	if s := l[locale]; s != "" {
 		return s, locale
 	}
-	if s := l[""]; s != "" {
+	if s := l[untranslated]; s != "" {
 		return s, locale
 	}
 	if s := l[fallback]; s != "" {
@@ -102,9 +94,8 @@ type FooterLink struct {
 	Icon  string  `yaml:"icon"` // links only: a built-in glyph name, URL or /assets path; a footer entry carrying one is refused
 }
 
-// SitePage is a page cairn serves itself (legal notice, privacy…), linked
-// automatically in the footer after the manual entries. body is an optional
-// intro; sections add titled blocks below it.
+// SitePage is a page cairn serves itself (legal notice, privacy…), linked in
+// the footer after the manual entries.
 type SitePage struct {
 	ID       string        `yaml:"id"`
 	Title    LString       `yaml:"title"`
@@ -120,13 +111,11 @@ type PageSection struct {
 // StatusMap reads a flat array of objects out of any JSON status API: where
 // the array is, which field of each element holds the service name and which
 // holds its state, then the values that mean each level. A path is a dotted
-// walk and nothing more, because anything cleverer is a query language, and a
-// query language in YAML is a second product.
+// walk, nothing more.
 //
 // The value lists are allow-lists: a state in none of them reads as down, so a
 // vendor that adds a word next year cannot make a broken service look green.
-// The exception is unknown, which is read first and means the monitor said
-// nothing at all about that service.
+// Unknown is the exception, read first.
 type StatusMap struct {
 	List        string   `yaml:"list"`
 	Key         string   `yaml:"key"`
@@ -140,8 +129,7 @@ type StatusMap struct {
 }
 
 // SiteIcon is one home-screen icon an operator supplies themselves. cairn
-// cannot resize an image without pulling in a scaler, so an operator who wants
-// the full set names the files and their sizes; nothing here is guessed.
+// resizes nothing, so every file and its size is named rather than derived.
 type SiteIcon struct {
 	Src     string `yaml:"src"`
 	Sizes   string `yaml:"sizes"`   // "512x512", or "any" for an svg
@@ -171,37 +159,31 @@ type Site struct {
 	Credit  *bool              `yaml:"credit"`       // the footer "powered by cairn"; nil means true
 	ShowVer bool               `yaml:"show_version"` // print the running version beside the credit; off by default
 	Strings map[string]LString `yaml:"strings"`
-	// Security fills /.well-known/security.txt. Contact is the only field an
-	// operator writes: Expires, Canonical and Preferred-Languages are cairn's
-	// to compute, which is the whole reason to serve the file rather than let
-	// one go stale in a folder.
+	// Security fills /.well-known/security.txt. These three keys are the
+	// operator's; Expires, Canonical and Preferred-Languages are cairn's to
+	// compute, so the served file cannot go stale.
 	Security struct {
 		Contact    string `yaml:"contact"`    // a URI: mailto:…, https://… or tel:…
 		Policy     string `yaml:"policy"`     // where the disclosure policy lives
 		Encryption string `yaml:"encryption"` // where the public key lives
 	} `yaml:"security"`
-	// HostingFlag is where the self-hosted and external flags lead, when the
-	// operator wants them to lead anywhere. Each value is a page id cairn
-	// serves, an absolute path, or a URL; a page id resolves in the language
-	// the visitor is reading, the way the footer links to those pages already.
-	//
-	// Empty leaves the flags exactly as they were, plain text on the card.
+	// HostingFlag is where the self-hosted and external flags lead. Each value
+	// is a page id cairn serves, an absolute path, or a URL; a page id resolves
+	// in the language the visitor is reading, as the footer links already do.
+	// Empty leaves the flags as plain text on the card.
 	HostingFlag struct {
 		Self     string `yaml:"self"`
 		External string `yaml:"external"`
 	} `yaml:"hosting_flag"`
 	// ServiceLinks is how the two links that lead to a service behave: the
-	// name on a card, and the button on a detail page. Both are off, so a
-	// site that says nothing keeps exactly the page it has today.
+	// name on a card, and the button on a detail page. Both default off.
 	//
-	// The block is `service_links` and not `links`, which is what the feature
-	// request called it: `links` has been the header link list since long
-	// before this, and a key cannot be a sequence and a mapping at once.
+	// The block is `service_links` and not `links`: `links` is already the
+	// header link list, and a key cannot be a sequence and a mapping at once.
 	//
 	// Neither key touches a link cairn serves itself. A "Learn more" page, the
-	// language switcher, a footer entry: those stay where they are, on the
-	// same off-site test the hosting flag already applies. What is being
-	// described is leaving the site, not following a link.
+	// language switcher, a footer entry stay where they are, on the same
+	// off-site test the hosting flag applies.
 	ServiceLinks struct {
 		NewTab  bool         `yaml:"new_tab"`
 		Confirm ConfirmScope `yaml:"confirm"`
@@ -209,28 +191,25 @@ type Site struct {
 	Status struct {
 		Gatus string `yaml:"gatus"`
 		// Provider names the monitor behind the address, and URL is that
-		// address for a monitor that is not Gatus. Gatus keeps its own key
-		// because it had one first: every site running today says gatus: and
-		// has to keep meaning exactly what it meant. The two spellings resolve
-		// through StatusProvider and StatusAddress, and nothing else reads
-		// these three fields.
+		// address for a monitor that is not Gatus. Gatus keeps its own key:
+		// every site running today says gatus: and has to go on meaning what
+		// it meant. Read the two spellings through StatusProvider and
+		// StatusAddress, nowhere else.
 		Provider string `yaml:"provider"`
 		URL      string `yaml:"url"`
-		// Map tells cairn how to read somebody else's status document, and
-		// TokenFile names the file holding the credential for it. Its twin in
-		// the status package is status.Mapping: this package knows about no
-		// other, so server/watch.go copies one into the other the way it
-		// already copies the address and the trust settings.
+		// Map tells cairn how to read somebody else's status document. Its
+		// twin is status.Mapping: this package imports nothing of cairn's, so
+		// server/watch.go copies one into the other the way it already copies
+		// the address and the trust settings.
 		Map StatusMap `yaml:"map"`
-		// TokenFile is a path, never a token. A secret written in site.yaml is
-		// a secret in a config repository; every platform that has secrets
-		// delivers them as a mounted file, which is the shape status.ca takes
-		// already.
+		// TokenFile is a path, never a token: a secret written in site.yaml is
+		// a secret in a config repository. Every platform that has secrets
+		// delivers them as a mounted file.
 		TokenFile   string `yaml:"token_file"`
 		TokenScheme string `yaml:"token_scheme"` // default Bearer; Statuspage wants OAuth
 		// Slug is the published status page a Kuma instance serves statuses
 		// for. Kuma has no endpoint listing every monitor, only one per status
-		// page, so the slug is the address as much as the URL is.
+		// page, so the slug is half the address.
 		Slug     string `yaml:"slug"`
 		Page     string `yaml:"page"`
 		Interval string `yaml:"interval"`
@@ -238,20 +217,18 @@ type Site struct {
 		// makes them display-only, for a Gatus a visitor cannot reach.
 		Linked *bool `yaml:"linked"`
 		// Insecure stops cairn verifying the certificate Gatus presents, for
-		// an internal instance whose authority nothing public signed. A hole
-		// the operator opens deliberately, so cairn says so out loud rather
-		// than only obeying: once at startup, and on every -check.
+		// an internal instance whose authority nothing public signed. It is a
+		// hole in the poll, so cairn logs it at startup and on every -check.
 		Insecure bool `yaml:"insecure"`
 		// CA is a PEM bundle cairn adds to the system roots for that one
 		// connection: an http(s) URL, or an /assets/… path in the mounted
-		// directory. It is the answer to the same problem Insecure is, and the
-		// opposite answer: this one verifies rather than stops checking.
+		// directory. It answers what Insecure answers, by verifying rather
+		// than by stopping the check.
 		//
-		// A URL is fetched, which is why http is allowed here and why saying
-		// so matters. Over http, whatever is on the path to that address
-		// decides what cairn trusts for the poll, which lands in the same
-		// place Insecure does. cairn says which of the two it is at startup
-		// and on every -check.
+		// A URL is fetched, http included. Over http, whatever sits on the
+		// path to that address decides what cairn trusts for the poll, which
+		// lands where Insecure does. cairn says which of the two it is at
+		// startup and on every -check.
 		CA string `yaml:"ca"`
 	} `yaml:"status"`
 }
@@ -269,9 +246,7 @@ type Service struct {
 	// Selfhosted flags where the service runs: true self-hosted, false hosted
 	// elsewhere, nil no flag at all.
 	Selfhosted *bool `yaml:"selfhosted"`
-	// State is where the service stands, declared rather than measured. Empty
-	// is the whole of what cairn rendered before this key existed.
-	State State `yaml:"state"`
+	State      State `yaml:"state"`
 }
 
 // ServiceImage is a preview shown on the detail page. A plain YAML string is
@@ -284,8 +259,8 @@ type ServiceImage struct {
 
 // imageEntry is ServiceImage without its UnmarshalYAML, which decoding the
 // mapping form would otherwise re-enter forever. It sits at package level
-// rather than inside the method so an unknown key in an image entry can be
-// told what an image entry accepts; yaml names this type in its error.
+// rather than inside the method because yaml names this type in its error,
+// and an unknown key has to be told what an image entry accepts.
 type imageEntry ServiceImage
 
 func (i *ServiceImage) UnmarshalYAML(n *yaml.Node) error {
@@ -323,7 +298,7 @@ type Config struct {
 	// FaviconDims is the operator favicon's real size, when it is a raster
 	// sitting in the mounted assets dir. Zero for an svg, for a remote URL,
 	// and when no favicon is set: the manifest then says nothing about size
-	// rather than claiming one, which is what it used to do.
+	// rather than claiming one.
 	FaviconDims [2]int
 }
 
@@ -331,16 +306,14 @@ func (c *Config) DefaultLocale() string { return c.Site.Locales[0] }
 
 // StatusProviders lists the monitors status.provider accepts, sorted.
 //
-// This package imports nothing of cairn's, which is the rule the dependency
-// graph is built on, so the list cannot come from the poller that owns it. It
-// is kept in step by a test over there, where both are in reach: a name in one
-// list and not the other is either a config error nobody can fix or a config
-// that loads clean and then fails every poll.
+// This package imports nothing of cairn's, so the list cannot come from the
+// poller that owns it; a test in the status package keeps the two in step. A
+// name in one list and not the other is either a config error nobody can fix
+// or a config that loads clean and then fails every poll.
 func StatusProviders() []string { return []string{"gatus", "json", "kuma"} }
 
 // StatusAddress is the monitor cairn polls, whichever key named it, and empty
-// when the site has no status at all. Everything that used to ask whether
-// status.gatus was set asks this instead.
+// when the site has no status at all.
 func (s *Site) StatusAddress() string {
 	if s.Status.Gatus != "" {
 		return s.Status.Gatus
@@ -350,7 +323,7 @@ func (s *Site) StatusAddress() string {
 
 // StatusProvider is which monitor that address is. status.gatus implies it, so
 // a config written before providers existed resolves to gatus without saying
-// so, and empty means the site polls nothing.
+// so. Empty means the site polls nothing.
 func (s *Site) StatusProvider() string {
 	if s.StatusAddress() == "" && s.Status.Provider == "" {
 		return ""
@@ -368,12 +341,11 @@ func (c *Config) StatusInterval() time.Duration {
 	return 60 * time.Second
 }
 
-// Noindex reports whether the site asks search engines to stay away.
 func (c *Config) Noindex() bool { return c.Site.Index != nil && !*c.Site.Index }
 
 // StatusLinked reports whether a status pill is a link to the status page.
-// It is, unless the operator says otherwise: cairn cannot tell whether the
-// Gatus it polls is one a visitor can reach, so only they can.
+// cairn cannot tell whether the monitor it polls is one a visitor can reach,
+// so only the operator can turn this off.
 func (c *Config) StatusLinked() bool {
 	return c.Site.Status.Linked == nil || *c.Site.Status.Linked
 }
@@ -383,7 +355,7 @@ func (c *Config) StatusLinked() bool {
 // pt), English, then the key.
 func (c *Config) Str(locale, key string) string {
 	if ls, ok := c.Site.Strings[key]; ok {
-		for _, k := range []string{locale, ""} {
+		for _, k := range []string{locale, untranslated} {
 			if s := ls[k]; s != "" {
 				return s
 			}
@@ -418,39 +390,37 @@ var (
 	// computed-value time: the accent, and every focus ring drawn with it,
 	// silently disappears.
 	accentRe = regexp.MustCompile(`^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$`)
-	// A CSS font-family list goes verbatim into the page's inline <style>,
-	// so it is kept to the characters a family stack is made of: letters,
-	// digits, spaces, quotes and the punctuation between family names. A
-	// semicolon, a brace or a newline could break out of the declaration, and
-	// refusing them is what lets the value be inlined without escaping.
+	// A CSS font-family list goes verbatim into the page's inline <style>, so
+	// it is kept to the characters a family stack is made of. A semicolon, a
+	// brace or a newline could break out of the declaration; refusing them is
+	// what lets the value be inlined without escaping.
 	//
-	// Letter means letter in any script. A font family is a name, and a name
-	// is written in the language it belongs to: Époque, 思源黑体, الجزيرة. An
-	// ASCII-only rule refuses those, and refusing a family refuses the config
-	// it is in, so a site would lose every page to the getting-started one
-	// over a font. None of that widens what can end a declaration.
+	// Letter means letter in any script: a family name is written in the
+	// language it belongs to, as Époque, 思源黑体, الجزيرة are. An ASCII-only
+	// rule refuses those, and a refused family costs the site every page to
+	// the getting-started one. None of that widens what can end a declaration.
 	fontFamilyRe = regexp.MustCompile(`^[\p{L}\p{N} '",._@+-]+$`)
 	// theme.font.file lands in the same inline stylesheet, as the url() of the
-	// @font-face, and needs the same kind of guard for the same reason: a path
-	// can pass every check about where it points and still carry the sequence
-	// that ends a style element. This is the shape of a filename.
+	// @font-face: a path can pass every check about where it points and still
+	// carry the sequence that ends a style element. This is the shape of a
+	// filename.
 	fontFileRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9/._-]*$`)
 	localeRe   = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9-]*$`)
 	idRe       = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
 	// An icon slug: what dashboard-icons publishes, and the only shape that can
 	// safely become both a filename and a URL segment.
-	slugRe = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
-	// A manifest icon size: one or more "WxH", or "any" for a scalable one.
+	slugRe      = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
 	iconSizesRe = regexp.MustCompile(`^(any|[0-9]+x[0-9]+( [0-9]+x[0-9]+)*)$`)
 	// Any URI with a scheme, since security.txt takes mailto:, https:// and
-	// tel: alike. Checking the scheme is what catches a bare email address,
-	// which is the mistake this field invites.
+	// tel: alike. Checking the scheme catches a bare email address, the
+	// mistake that field invites.
 	uriRe = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.-]*:[^\s]+$`)
 )
 
-// isHTTPURL reports an http(s) URL; IsURLOrAbs also accepts a root-absolute
-// /path. Both gate the "is this a link we pass through" checks scattered
-// across config and render.
+// stylesheetBreakers are the characters that can close a style element from
+// inside a url(), where nothing escapes them for us.
+const stylesheetBreakers = "<>"
+
 func isHTTPURL(s string) bool {
 	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
 }
@@ -458,25 +428,21 @@ func isHTTPURL(s string) bool {
 // IsLocalPath reports a root-absolute path that stays on this site.
 //
 // "//cdn.example.org/x" is not one, though it starts with a slash: a browser
-// reads it as a URL on another origin. The backslash form counts as external
-// too, because browsers normalise it to the same thing. Every place that has
-// to prefix a base path or a site URL needs this distinction rather than a
-// bare leading slash, or a protocol-relative logo comes out as
-// "/cairn//cdn.example.org/x", which resolves nowhere.
+// reads it as a URL on another origin, and normalises the backslash form to
+// the same thing. Anything prefixing a base path or a site URL needs that
+// distinction rather than a bare leading slash, or a protocol-relative logo
+// comes out as "/cairn//cdn.example.org/x", which resolves nowhere.
 func IsLocalPath(s string) bool {
 	return strings.HasPrefix(s, "/") &&
 		!strings.HasPrefix(s, "//") && !strings.HasPrefix(s, `/\`)
 }
 
-// isExternalURL reports a link that leaves this site: an explicit scheme, or
-// the protocol-relative form.
 func isExternalURL(s string) bool {
 	return isHTTPURL(s) || strings.HasPrefix(s, "//") || strings.HasPrefix(s, `/\`)
 }
 
 // IsURLOrAbs gates "is this a link we pass through rather than a slug we
-// resolve". It accepts exactly what it always did; it just no longer confuses
-// the two kinds of leading slash on the way.
+// resolve".
 func IsURLOrAbs(s string) bool {
 	return isExternalURL(s) || IsLocalPath(s)
 }
@@ -485,16 +451,13 @@ func IsURLOrAbs(s string) bool {
 // reports whether it names one at all.
 //
 // A file in media/ has two documented spellings, the bare name and the
-// /media/… path it is served at, and they have to mean the same thing here:
-// the bare one was stat'd and the absolute one was not, so the same missing
-// file refused to boot written one way and rendered a 404 written the other.
+// /media/… path it is served at, and both have to mean the same file here:
+// stat'ing only the bare one made a missing file refuse to boot written one
+// way and render a 404 written the other.
 //
-// Everything else stays out of it, because it is not this directory's to
-// serve: a URL, /assets/… from the mounted assets dir, any other absolute
-// path. Note that a value starting with "/media/" cannot be the
-// protocol-relative "//host/x" or its "/\host/x" twin, so the prefix already
-// draws the line IsLocalPath exists to draw. ".." cannot arrive either;
-// parseServices refuses it in every images entry before this runs.
+// Everything else stays out, being none of this directory's to serve: a URL,
+// /assets/… from the mounted assets dir, any other absolute path. ".." cannot
+// arrive; parseServices refuses it in every images entry before this runs.
 func mediaRef(src string) (rel string, ours bool) {
 	if !IsURLOrAbs(src) {
 		return src, true
@@ -504,16 +467,14 @@ func mediaRef(src string) (rel string, ours bool) {
 
 // FontRef maps theme.font.file to the file under the config directory's
 // fonts/ folder, and reports whether the value names one at all. The served
-// URL is "/fonts/" + rel, which is why the two spellings that are already a
-// path mean the file it leads to.
+// URL is "/fonts/" + rel.
 //
-// A font file has three documented spellings that have to mean the same
-// thing: the bare name "custom-font.woff2", the config-relative
-// "fonts/custom-font.woff2", and the "/fonts/custom-font.woff2" path it is
-// served at. Everything else -- a URL, an absolute path outside fonts/ , a
-// "../" climb -- comes back not-ok, and the caller answers with its own
-// message. The backslash form counts as a climb because a browser normalises
-// it to the same thing, the rule IsLocalPath already draws.
+// Three documented spellings mean the same file: the bare name
+// "custom-font.woff2", the config-relative "fonts/custom-font.woff2", and the
+// "/fonts/custom-font.woff2" path it is served at. A URL, an absolute path
+// outside fonts/, a "../" climb come back not-ok and the caller answers with
+// its own message. The backslash form counts as a climb: a browser normalises
+// it to the same thing, the rule IsLocalPath draws.
 func FontRef(file string) (rel string, ok bool) {
 	if file == "" {
 		return "", false
@@ -530,8 +491,8 @@ func FontRef(file string) (rel string, ok bool) {
 // FirstFontFamily is the first entry of a CSS font-family list, the name an
 // @font-face can declare. A list like "Inter, system-ui, sans-serif" names
 // the custom file first, and the @font-face has to use exactly that name for
-// the browser to connect the two; splitting on a comma a quote belongs to
-// would cut a name like "My, Font" in half.
+// the browser to connect the two. Splitting on a comma inside quotes would
+// cut a name like "My, Font" in half.
 func FirstFontFamily(family string) string {
 	var b strings.Builder
 	quote := rune(0)
@@ -555,8 +516,8 @@ func FirstFontFamily(family string) string {
 }
 
 // FontFormat maps a font file's extension to the format hint its @font-face
-// src carries. Empty for a file cairn has no label for, which validation
-// refuses before it ever reaches a page.
+// src carries. Empty for an extension cairn has no label for, which
+// validation refuses before it reaches a page.
 func FontFormat(rel string) string {
 	switch strings.ToLower(filepath.Ext(rel)) {
 	case ".woff2":
@@ -573,8 +534,7 @@ func FontFormat(rel string) string {
 
 // FontFaceName is the name the @font-face for theme.font.file declares: the
 // first family of theme.font.family, quoted if it is not already. The
-// @font-face and the --font-body override have to name the same font, so both
-// come from the one value.
+// @font-face and the --font-body override have to name the same font.
 func FontFaceName(family string) string {
 	return quotedFontName(FirstFontFamily(family))
 }
@@ -654,7 +614,7 @@ func Load(dir string) (*Config, error) {
 		LocalIcons: localIcons(filepath.Join(AssetsPath, "icons")),
 	}
 	// The manifest and /favicon.ico have no theme to follow, so both read the
-	// light one: it is the file a site with one favicon already names.
+	// light one, the file a site with a single favicon names.
 	cfg.FaviconDims = assetDims(site.Favicon.Light)
 	if st, err := os.Stat(filepath.Join(dir, "custom.css")); err == nil && !st.IsDir() {
 		cfg.CustomCSS = true
@@ -664,8 +624,8 @@ func Load(dir string) (*Config, error) {
 
 // AssetFile turns an /assets/… reference into the file it names in the mounted
 // directory, and returns "" for anything that is not one: a URL, a bare slug,
-// or a path that tries to climb out of the mount, which is the rule the file
-// server applies too. It touches no disk, so it answers the same either way.
+// or a path that climbs out of the mount, the rule the file server applies
+// too. It touches no disk, so it answers the same either way.
 func AssetFile(ref string) string {
 	rel, ok := strings.CutPrefix(ref, "/assets/")
 	if !ok || rel == "" || strings.Contains(rel, "..") {
@@ -677,9 +637,9 @@ func AssetFile(ref string) string {
 // assetDims measures a raster the operator dropped in the mounted assets dir,
 // so the manifest can state its real size instead of guessing one.
 //
-// Anything it cannot open comes back zero, on purpose: a remote URL would need
-// an outbound request, which cairn does not make, and an svg has no intrinsic
-// size to report. Both cases are handled by saying nothing rather than wrong.
+// Anything it cannot open comes back zero: a remote URL would need an outbound
+// request, which cairn does not make, and an svg has no intrinsic size. Both
+// say nothing rather than something wrong.
 func assetDims(ref string) [2]int {
 	p := AssetFile(ref)
 	if p == "" {
@@ -738,15 +698,15 @@ func strictDecode(n *yaml.Node, out any) error {
 
 // defaultSite is what a directory with no site.yaml means, and equally the
 // base a site.yaml decodes onto: every key in the file is optional, so the
-// two have to agree. One function so they cannot stop agreeing.
+// two have to agree.
 func defaultSite() Site {
-	s := Site{Title: LString{"": "cairn"}, Locales: []string{"en"}}
+	s := Site{Title: LString{untranslated: "cairn"}, Locales: []string{"en"}}
 	s.Theme.Accent = "#247b7b"
 	return s
 }
 
-// parseSite decodes site.yaml over those defaults. An empty file is a legal
-// site.yaml, so io.EOF means "nothing set", not "broken".
+// parseSite decodes site.yaml over those defaults. An empty file is legal, so
+// io.EOF means "nothing set", not "broken".
 func parseSite(file string, data []byte) (Site, error) {
 	site := defaultSite()
 	dec := yaml.NewDecoder(bytes.NewReader(data))
@@ -811,31 +771,25 @@ func parseServices(file string, data []byte) ([]Service, error) {
 			return nil, fmt.Errorf("config: %s line %d: service missing id (expected: id: my-tool)", file, item.Line)
 		case !idRe.MatchString(s.ID):
 			return nil, fmt.Errorf("config: %s line %d: invalid id %q, ids become URLs (expected lowercase letters, digits and dashes, e.g. my-tool)", file, item.Line, s.ID)
-		// The two disabling states have no destination worth naming, so the url
-		// stops being required for them and only for them. Retiring a service
-		// has to be adding a line rather than deleting one, so a url left
-		// beside `state: retired` is kept and simply not linked.
+		// The two disabling states are the only ones a url is optional for. A
+		// url left beside `state: retired` is kept and simply not linked, so
+		// retiring a service is adding a line rather than deleting one.
 		case !IsURLOrAbs(s.URL) && !s.State.Disables():
 			return nil, fmt.Errorf("config: %s line %d: service %q missing or invalid url (expected: url: https://…, or state: soon / state: retired, which do not need one)", file, item.Line, s.ID)
 		case len(s.Name) == 0:
 			return nil, fmt.Errorf("config: %s line %d: service %q missing name (expected: name: My tool  or  name: {fr: …, en: …})", file, item.Line, s.ID)
-			// A slug becomes a path segment on the icon CDN and a filename in the
-			// script -emit-icons writes, which the docs tell you to pipe into sh.
-			// Anything outside this shape could never resolve upstream anyway, so
-			// refusing it costs nothing and closes the shell off entirely.
 		}
 		// Both halves of a themed icon are held to the same shape: each one
-		// becomes a path segment on the CDN and a filename in the -emit-icons
-		// script all the same.
+		// becomes a path segment on the icon CDN and a filename in the script
+		// -emit-icons writes, which the docs tell you to pipe into sh.
 		for _, ic := range s.Icon.Refs() {
 			if !IsURLOrAbs(ic) && !slugRe.MatchString(ic) {
 				return nil, fmt.Errorf("config: %s line %d: service %q: icon %q is not a slug, a URL or an /assets path (a slug is lowercase letters, digits, dashes, e.g. hedgedoc)", file, item.Line, s.ID, ic)
 			}
 		}
 		// The dark icon is written into the page's stylesheet, so it answers
-		// to the same rule the dark logo does. A slug cannot carry either
-		// character; a URL or a path can.
-		if s.Icon.Themed() && strings.ContainsAny(s.Icon.Dark, "<>") {
+		// to the same rule the dark logo does.
+		if s.Icon.Themed() && strings.ContainsAny(s.Icon.Dark, stylesheetBreakers) {
 			return nil, fmt.Errorf("config: %s line %d: service %q: icon.dark %q carries %q or %q, and the dark icon is written into the page's stylesheet where nothing escapes it (expected a slug like github-light, or /assets/github-white.svg)", file, item.Line, s.ID, s.Icon.Dark, "<", ">")
 		}
 		for _, img := range s.Images {

--- a/src/internal/config/confirm.go
+++ b/src/internal/config/confirm.go
@@ -8,15 +8,12 @@ import (
 
 // ConfirmScope says which service links raise the leaving dialog.
 //
-// A bool would have been enough to turn the dialog on, and not enough to say
-// what most operators actually want. cairn already knows, per service, whether
-// the host runs the thing or merely points at it, and that is the line the
-// warning belongs on: a visitor being sent to somebody else's site is the case
-// worth a sentence, while being sent to the host's own Nextcloud is not. So
-// the key takes that answer rather than a yes.
+// cairn knows per service whether the host runs the thing or merely points at
+// it, and that is the line the warning belongs on: a visitor sent to somebody
+// else's site is the case worth a sentence, the host's own Nextcloud is not.
 //
-// `true` is accepted and means `all`, because a reader who has seen new_tab
-// above will write it and should not be met with a type error.
+// `true` is accepted and means `all`, so a reader who has seen new_tab above
+// is not met with a type error.
 type ConfirmScope string
 
 const (
@@ -46,10 +43,9 @@ func (c *ConfirmScope) UnmarshalYAML(n *yaml.Node) error {
 // Wants reports whether a service raises the dialog. hostKind is the card's
 // own flag: "self", "external", or empty when the config says nothing.
 //
-// Under `external`, a service with no flag at all does not qualify. That is
-// the literal reading and the safe one: cairn refuses to guess that silence
-// means somebody else's site, when silence is what a config says before the
-// operator has thought about it.
+// Under `external`, a service with no flag does not qualify: silence is what a
+// config says before the operator has thought about it, not a statement that
+// the address belongs to somebody else.
 func (c ConfirmScope) Wants(hostKind string) bool {
 	switch c {
 	case ConfirmAll:

--- a/src/internal/config/icons.go
+++ b/src/internal/config/icons.go
@@ -3,8 +3,7 @@ package config
 // Icon resolution. A bare slug resolves to a local file when the operator
 // has one in <assets>/icons/, and to dashboard-icons on jsdelivr otherwise,
 // the convention Homepage and Homarr already use. -emit-icons prints the
-// downloads needed to go fully self-hosted, so the page makes no
-// third-party request at all.
+// downloads needed to go fully self-hosted, leaving no third-party request.
 
 import (
 	"bytes"
@@ -20,8 +19,6 @@ var AssetsPath = "/assets"
 
 const iconCDN = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/"
 
-// IconURL resolves a service icon: URLs and absolute paths pass through,
-// a slug prefers the operator's own file, then the CDN.
 func IconURL(cfg *Config, icon string) string {
 	if icon == "" || IsURLOrAbs(icon) {
 		return icon
@@ -32,8 +29,8 @@ func IconURL(cfg *Config, icon string) string {
 	return iconCDN + icon + ".svg"
 }
 
-// localIcons maps slug -> served path for every image in <assets>/icons/;
-// an svg wins over other formats of the same name.
+// localIcons maps slug -> served path for every image in <assets>/icons/; an
+// svg wins over another format of the same name.
 func localIcons(dir string) map[string]string {
 	out := map[string]string{}
 	entries, _ := os.ReadDir(dir)
@@ -57,7 +54,7 @@ func CdnSlugs(cfg *Config) []string {
 	for _, c := range cfg.Categories {
 		for _, s := range c.Services {
 			// Both halves: a site self-hosting its icons needs the dark one
-			// downloaded too, or half its cards go to the CDN after all.
+			// downloaded too, or half its cards go to the CDN.
 			for _, ic := range s.Icon.Refs() {
 				if IsURLOrAbs(ic) {
 					continue
@@ -89,8 +86,8 @@ func EmitIconsScript(cfg *Config) []byte {
 	b.WriteString("# into icons/, and cairn serves them from there automatically.\n")
 	b.WriteString("set -e\nmkdir -p icons\n")
 	for _, slug := range CdnSlugs(cfg) {
-		// slugRe already keeps a shell metacharacter out of here; quoting the
-		// value anyway means a future loosening of that rule cannot turn this
+		// slugRe already keeps a shell metacharacter out of here. Quoting
+		// anyway keeps a future loosening of that rule from turning this
 		// script, which the docs pipe into sh, into an execution vector.
 		fmt.Fprintf(&b, "curl -fsSL -o %s %s\n", shellQuote("icons/"+slug+".svg"), shellQuote(iconCDN+slug+".svg"))
 	}

--- a/src/internal/config/locales.go
+++ b/src/internal/config/locales.go
@@ -5,11 +5,10 @@ import (
 	"strings"
 )
 
-// The built-in UI strings, one small table per language. Adding a language
-// is exactly one block here plus nothing else: every key must exist (a test
-// enforces completeness against the English table), and site.yaml `strings`
-// can still override any entry. Content lookup falls back through the base
-// language, so pt-BR content finds the pt table automatically.
+// The built-in UI strings, one small table per language. Adding a language is
+// one block here and nothing else: every key must exist (a test checks each
+// table against the English one), and site.yaml `strings` overrides any entry.
+// Content lookup falls back through the base language, so pt-BR finds pt.
 
 var builtinStrings = map[string]map[string]string{
 	"en": {
@@ -327,9 +326,9 @@ var builtinStrings = map[string]map[string]string{
 }
 
 // StringKeys lists every UI string an operator may override, sorted. A key
-// outside this set is a typo that silently does nothing: Str falls through to
-// the built-in table, so the page looks exactly as it would with no override
-// at all. -check compares against this.
+// outside this set silently does nothing: Str falls through to the built-in
+// table, so the page looks as it would with no override at all. -check
+// compares against this.
 func StringKeys() []string {
 	out := make([]string, 0, len(builtinStrings["en"]))
 	for k := range builtinStrings["en"] {
@@ -349,9 +348,9 @@ func BuiltinLocales() []string {
 	return out
 }
 
-// rtlLocales lists the base language codes written right to left. None of the
-// built-in UI languages is among them, but a site's own content can be, and
-// the html dir attribute is what makes the whole layout follow.
+// rtlLocales lists the base language codes written right to left. No built-in
+// UI language is among them, but a site's own content can be, and the html dir
+// attribute is what makes the whole layout follow.
 var rtlLocales = map[string]bool{
 	"ar": true, "arc": true, "ckb": true, "dv": true, "fa": true, "he": true,
 	"ku": true, "ps": true, "sd": true, "ug": true, "ur": true, "yi": true,
@@ -368,19 +367,17 @@ func LocaleDir(locale string) string {
 
 // IsLocale reports a well-formed locale tag.
 //
-// Every locale that reaches a page has already passed this pattern once:
-// site.locales is checked when site.yaml loads, and so is every key of a
-// per-locale mapping. It is exported so the one place that writes a locale
-// into markup without the template escaper can check it there too, at the
-// point where it matters, rather than trust an invariant established three
-// files away.
+// Every locale that reaches a page has passed this pattern once already:
+// site.locales when site.yaml loads, and every key of a per-locale mapping.
+// Exported so the one place that writes a locale into markup without the
+// template escaper can check it there rather than trust an invariant
+// established three files away.
 func IsLocale(s string) bool { return localeRe.MatchString(s) }
 
 // SameLanguage reports whether two locale tags name the same language, a
 // regional variant counting as its base: pt-BR content on a pt page is
 // Portuguese either way, read aloud by the same voice. Only a real change of
-// language is worth marking, and a site that writes pt for pt-BR should not
-// collect a lang attribute on every field for it.
+// language is worth a lang attribute.
 func SameLanguage(a, b string) bool {
 	ab, _, _ := strings.Cut(a, "-")
 	bb, _, _ := strings.Cut(b, "-")

--- a/src/internal/config/starter.go
+++ b/src/internal/config/starter.go
@@ -2,8 +2,8 @@ package config
 
 // The getting-started page: what cairn serves instead of dying when the
 // config directory is empty or invalid at boot. It goes through the normal
-// rendering pipeline (an in-memory config whose welcome note carries the
-// instructions), so it looks like the product and needs nothing special.
+// rendering pipeline, as an in-memory config whose welcome note carries the
+// instructions.
 
 const StarterAbout = `## Almost there
 

--- a/src/internal/config/state.go
+++ b/src/internal/config/state.go
@@ -8,10 +8,9 @@ import (
 )
 
 // State is where a service stands, as the operator declares it. It is not the
-// status: the status is what a monitor measured a moment ago and it changes on
-// its own, while this changes when somebody edits a file. The two live side by
-// side on a card, so the docs draw that line in one sentence and this comment
-// repeats it for whoever reads the code first.
+// status: the status is what a monitor measured a moment ago and changes on
+// its own, while this changes when somebody edits a file. The two sit side by
+// side on a card.
 type State string
 
 const (
@@ -24,7 +23,7 @@ const (
 )
 
 // states is the closed set, in the order the refusal prints them: the two that
-// disable first, since they are the ones that change more than a label.
+// disable come first, being the ones that change more than a label.
 var states = []State{StateSoon, StateRetired, StateBeta, StateDeprecated, StateNew}
 
 // Disables reports whether the state takes the destination away. Those two are

--- a/src/internal/config/themed.go
+++ b/src/internal/config/themed.go
@@ -9,18 +9,16 @@ import (
 // ThemedRef is an image that may be drawn differently in the two themes: a
 // logo, a favicon, a service icon.
 //
-// Most artwork needs one file. A monochrome mark needs two, and the reason is
-// measurable rather than a matter of taste: on cairn's tile, a black mark
-// reads 1.40:1 against the dark theme and a white one 1.24:1 against the
-// light, where the rules ask 3:1. One of the two is always close to invisible.
+// Most artwork needs one file. A monochrome mark needs two: on cairn's tile a
+// black mark reads 1.40:1 against the dark theme and a white one 1.24:1
+// against the light, where the rules ask 3:1, so one of the two is always
+// close to invisible.
 //
-// A plain string is the field every config written so far carries, and it goes
-// on meaning exactly what it meant: one image, both themes. The pair names the
-// theme each file appears in, rather than the ink it is drawn with. That is
-// deliberate: the icon collections suffix the ink instead, so
-// dashboard-icons' github-light.svg is the pale one for a dark background, and
-// a key named dark: holding a file named -light is confusing exactly once,
-// where a key that named the ink would be confusing every time.
+// A plain string stays what it has always been: one image, both themes. The
+// pair names the theme each file appears in, not the ink it is drawn with. The
+// icon collections suffix the ink instead, so dashboard-icons' github-light.svg
+// is the pale one for a dark background: a dark: key holding a -light file is
+// confusing once, where a key naming the ink is confusing every time.
 type ThemedRef struct {
 	Light string
 	Dark  string
@@ -40,8 +38,7 @@ func (t *ThemedRef) UnmarshalYAML(n *yaml.Node) error {
 			return fmt.Errorf("line %d: %q is not a theme; the two keys are light and dark, naming the theme each image appears in", n.Line, k)
 		}
 	}
-	// Half a pair paints nothing in one theme and leaves no trace of why, so
-	// it stops here rather than at the first visitor who switches.
+	// Half a pair paints nothing in one theme and leaves no trace of why.
 	if m["light"] == "" || m["dark"] == "" {
 		return fmt.Errorf("line %d: needs both light and dark; write one plain value instead if the same image serves both themes", n.Line)
 	}
@@ -53,14 +50,13 @@ func (t *ThemedRef) UnmarshalYAML(n *yaml.Node) error {
 // decides between plain markup and a rule in the page's stylesheet.
 func (t ThemedRef) Themed() bool { return t.Dark != "" && t.Dark != t.Light }
 
-// ThemedField is one half of a themed image, carrying the name to blame. A
-// refusal has to point at the line to fix, and "logo" is not that line when
-// only the dark one is wrong.
+// ThemedField is one half of a themed image with the key a refusal must name:
+// "logo" is not the line to fix when only the dark one is wrong.
 type ThemedField struct{ Key, Val string }
 
 // Fields expands a themed image into the values to check, naming the variant
 // only when there are two to tell apart, so a site with one logo still reads
-// "logo" in every message it has ever produced.
+// "logo" in every message.
 func (t ThemedRef) Fields(key string) []ThemedField {
 	if !t.Themed() {
 		return []ThemedField{{key, t.Light}}
@@ -68,8 +64,6 @@ func (t ThemedRef) Fields(key string) []ThemedField {
 	return []ThemedField{{key + ".light", t.Light}, {key + ".dark", t.Dark}}
 }
 
-// Refs lists the values actually written, for the checks and the emitters that
-// have to walk every image an operator named.
 func (t ThemedRef) Refs() []string {
 	switch {
 	case t.Light == "":

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -9,10 +9,7 @@ import (
 	"time"
 )
 
-// validateSite normalizes and checks the site.yaml fields (defaults, hex
-// accent, URLs, links, pages). definedIn is the service-id -> file map, used
-// to reject page ids that collide with a service id.
-func validateSite(site *Site, definedIn map[string]string) error {
+func validateSite(site *Site, serviceFiles map[string]string) error {
 	if len(site.Locales) == 0 {
 		site.Locales = []string{"en"}
 	}
@@ -62,9 +59,9 @@ func validateSite(site *Site, definedIn map[string]string) error {
 		}
 	}
 	// status.ca is a trust anchor, so a value cairn cannot reach is refused
-	// here rather than discovered on the first poll: the failure mode is grey
-	// pills and one log line, which is the shape of problem this file exists
-	// to stop. http is deliberate; the loudness that pays for it is elsewhere.
+	// here rather than discovered on the first poll, where the whole failure
+	// is grey pills and one log line. http stays allowed; the warning that
+	// pays for it lives elsewhere.
 	if ca := site.Status.CA; ca != "" {
 		if err := checkLinkScheme("status.ca", ca, imageSchemes, "http://…, https://… or an /assets path"); err != nil {
 			return err
@@ -73,10 +70,10 @@ func validateSite(site *Site, definedIn map[string]string) error {
 			return fmt.Errorf("config: site.yaml: status.ca %q is neither a URL nor a file under the mounted assets dir (expected e.g. https://pki.example.org/ca.crt or /assets/ca.crt)", ca)
 		}
 	}
-	// A hosting flag leads to a page cairn serves, to a path, or to a URL.
-	// The page id is the interesting case: it is what lets the link follow the
-	// visitor's language, and it is the one that can be a typo, so a name that
-	// matches no page stops the load and lists the ones that do.
+	// A hosting flag leads to a page cairn serves, to a path, or to a URL. A
+	// page id is the one that follows the visitor's language and the one that
+	// can be a typo, so a name matching no page stops the load and lists the
+	// ones that do.
 	for _, f := range []struct{ key, val string }{
 		{"hosting_flag.self", site.HostingFlag.Self},
 		{"hosting_flag.external", site.HostingFlag.External},
@@ -102,13 +99,11 @@ func validateSite(site *Site, definedIn map[string]string) error {
 		}
 	}
 	// logo and favicon are the two image fields nothing else validates: a value
-	// that is not a URL only earns a -check warning, since a missing file is a
-	// plausible typo. An executable scheme is not, so it stops the load. The
-	// favicon is the sharp case: it reaches the manifest as JSON, which no
+	// that is not a URL only earns a -check warning, a missing file being a
+	// plausible typo, while an executable scheme stops the load. The favicon
+	// is the sharp case: it reaches the manifest as JSON, which no
 	// html/template escaping covers, and comes back from /favicon.ico as a
-	// Location header.
-	// Both halves of a themed pair go through it: the dark one reaches the
-	// same manifest and the same Location header the light one does.
+	// Location header. Both halves of a themed pair reach both.
 	for _, f := range append(site.Logo.Fields("logo"), site.Favicon.Fields("favicon")...) {
 		if err := checkLinkScheme(f.Key, f.Val, imageSchemes, "https://… or an /assets path"); err != nil {
 			return err
@@ -120,8 +115,8 @@ func validateSite(site *Site, definedIn map[string]string) error {
 	if err := checkDarkImage("favicon", site.Favicon); err != nil {
 		return err
 	}
-	// security.txt is a line-based format, so a newline in any value would let
-	// a typo forge a field. Reject that here rather than escape it later.
+	// security.txt is a line-based format: a newline in any value would let a
+	// typo forge a field.
 	for _, f := range []struct{ key, val string }{
 		{"security.contact", site.Security.Contact},
 		{"security.policy", site.Security.Policy},
@@ -133,12 +128,10 @@ func validateSite(site *Site, definedIn map[string]string) error {
 		if strings.ContainsAny(f.val, "\r\n") {
 			return fmt.Errorf("config: site.yaml: %s must be one line", f.key)
 		}
-		// uriRe takes any scheme, because security.txt takes mailto:, https:
-		// and tel: alike, so it is the one URL check here that an executable
-		// scheme walks straight through. Catch it before uriRe has a chance to
-		// bless it, or the researcher this file is written for gets a dead
-		// link. tel: stays legal here and nowhere else: this file is plain
-		// text, so nothing blanks it, and RFC 9116 names it.
+		// uriRe takes any scheme, so it is the one URL check here an
+		// executable scheme walks straight through. Catch it first. tel:
+		// stays legal here and nowhere else: this file is plain text, so
+		// nothing blanks it, and RFC 9116 names it.
 		if err := checkContactScheme(f.key, f.val); err != nil {
 			return err
 		}
@@ -157,10 +150,9 @@ func validateSite(site *Site, definedIn map[string]string) error {
 	// -base-path itself, so a path written here is carried twice: an operator
 	// serving example.org/cairn who writes the full public URL ends up with
 	// canonical links, hreflang alternates and a whole sitemap pointing at
-	// example.org/cairn/cairn/. Nothing else would ever say so, and search
-	// engines act on it, so this is an error rather than a warning: a fresh
-	// start then serves the getting-started page with the reason logged, and a
-	// reload keeps the previous pages. cairn never exits on a bad config.
+	// example.org/cairn/cairn/. Search engines act on it, so this is an error
+	// rather than a warning: a fresh start then serves the getting-started
+	// page with the reason logged, and a reload keeps the previous pages.
 	if u, err := url.Parse(site.URL); site.URL != "" && err == nil && strings.Trim(u.Path, "/") != "" {
 		return fmt.Errorf("config: site.yaml: url %q must be the domain alone, with no path (serving under example.org/cairn is what -base-path is for, and cairn adds that prefix itself)", site.URL)
 	}
@@ -168,34 +160,30 @@ func validateSite(site *Site, definedIn map[string]string) error {
 		if len(l.Label) == 0 || l.URL == "" {
 			return fmt.Errorf("config: site.yaml: every links entry needs label and url (expected: - {label: Wiki, url: https://…})")
 		}
-		// mailto: is a legitimate target here, which is why this field gets the
-		// link list rather than the image one.
+		// mailto: is a legitimate target here, so this field gets the link
+		// list rather than the image one.
 		if err := checkLinkScheme("links url", l.URL, linkSchemes, "https://…, mailto:… or an absolute path"); err != nil {
 			return err
 		}
 		if ic := l.Icon; ic != "" && !IsURLOrAbs(ic) {
-			// Any scheme at all lands here: it is not a URL, not an /assets path
-			// and not a glyph name, so this refusal already covers the ones
-			// above and a second gate would only say the same thing twice.
+			// Any scheme at all lands here, being neither a URL nor an /assets
+			// path, so this refusal already covers the schemes checked above.
 			if _, ok := Glyphs[ic]; !ok {
 				return fmt.Errorf("config: site.yaml: links icon %q is not a built-in glyph (%s), a URL or an /assets path", ic, strings.Join(GlyphNames(), ", "))
 			}
 		}
 	}
-	// Footer entries used to be validated nowhere at all: an entry with no url
-	// rendered an empty href, which is a footer link that looks live and
-	// reloads the page, and one with no label rendered as nothing visible at
-	// all. links has always demanded both, and there was never a reason for
-	// the two lists to disagree.
+	// A footer entry needs what a links entry needs: no url renders an empty
+	// href, a link that looks live and reloads the page, and no label renders
+	// nothing visible at all.
 	for _, l := range site.Footer {
 		if len(l.Label) == 0 || l.URL == "" {
 			return fmt.Errorf("config: site.yaml: every footer entry needs label and url (expected: - {label: Legal, url: /legal})")
 		}
-		// icon is a header-link key. A footer entry took it without complaint
-		// and never rendered it, which -check reported as inert; schema/site.json
-		// has never listed it at all, so the editor said one thing and the
-		// loader another. Refusing it is what makes those two agree, and it says
-		// the useful half out loud: there is a list where the icon does work.
+		// icon is a header-link key. A footer entry renders none, and
+		// schema/site.json does not list it, so accepting one had the editor
+		// and the loader saying different things. The refusal names the list
+		// where an icon does work.
 		if l.Icon != "" {
 			return fmt.Errorf("config: site.yaml: footer entry %q has an icon: only header links render one (move the entry to links, or drop the icon)", l.URL)
 		}
@@ -232,8 +220,8 @@ func validateSite(site *Site, definedIn map[string]string) error {
 			return fmt.Errorf("config: site.yaml: page %q needs a title and a body or sections", p.ID)
 		case pageIDs[p.ID]:
 			return fmt.Errorf("config: site.yaml: duplicate page id %q", p.ID)
-		case definedIn[p.ID] != "":
-			return fmt.Errorf("config: site.yaml: page id %q collides with the service id defined in %s", p.ID, definedIn[p.ID])
+		case serviceFiles[p.ID] != "":
+			return fmt.Errorf("config: site.yaml: page id %q collides with the service id defined in %s", p.ID, serviceFiles[p.ID])
 		}
 		pageIDs[p.ID] = true
 		for _, s := range p.Sections {
@@ -247,12 +235,12 @@ func validateSite(site *Site, definedIn map[string]string) error {
 
 // validateStatusAddress settles which monitor cairn polls and where.
 //
-// There are two ways to name it and they must not both be taken: status.gatus,
-// which every site running today uses and which implies its own provider, and
+// Two keys can name it and they must not both be taken: status.gatus, which
+// every site running today uses and which implies its own provider, and
 // status.url with status.provider for a monitor that is not Gatus. Each
 // ambiguity below is refused with the key to fix rather than resolved by
-// guessing, because guessing wrong means pills drawn from an address the
-// operator did not mean.
+// guessing, since a wrong guess draws pills from an address the operator did
+// not mean.
 func validateStatusAddress(site *Site) error {
 	st := &site.Status
 	if st.Provider != "" && !slices.Contains(StatusProviders(), st.Provider) {
@@ -274,8 +262,7 @@ func validateStatusAddress(site *Site) error {
 	}
 	// Kuma reads by status page and has no endpoint listing every monitor, so
 	// the slug is half the address rather than an extra. Anywhere else it is a
-	// key that would silently do nothing, which is worth an error while there
-	// is still someone reading the file.
+	// key that would silently do nothing.
 	switch p := site.StatusProvider(); {
 	case p == "kuma":
 		if st.Slug == "" && st.URL != "" {
@@ -286,28 +273,28 @@ func validateStatusAddress(site *Site) error {
 	}
 	// A mapping is the whole configuration of the json provider and means
 	// nothing to any other. Both halves are refused here rather than left to
-	// -check, because a mapping that silently does nothing is the failure this
-	// file exists to catch while somebody is still reading it.
-	empty := st.Map.List == "" && st.Map.Key == "" && st.Map.State == "" &&
+	// -check: a mapping that silently does nothing is what this file exists to
+	// catch.
+	noMapping := st.Map.List == "" && st.Map.Key == "" && st.Map.State == "" &&
 		len(st.Map.Up) == 0 && len(st.Map.Degraded) == 0 && len(st.Map.Maintenance) == 0 &&
 		len(st.Map.Unknown) == 0
 	switch p := site.StatusProvider(); {
 	case p == "json":
-		if empty && st.URL != "" {
+		if noMapping && st.URL != "" {
 			return fmt.Errorf("config: site.yaml: status.map is needed with status.provider: json (it says how to read the document: list, the path to the array; key and state, the fields of each element; then up, degraded and maintenance, the values that mean each)")
 		}
 		for _, f := range []struct{ key, val string }{{"key", st.Map.Key}, {"state", st.Map.State}} {
-			if !empty && f.val == "" {
+			if !noMapping && f.val == "" {
 				return fmt.Errorf("config: site.yaml: status.map.%s is needed (it names the field of each element holding the service %s; status.map.list is the only optional path, and empty means the document is the array)", f.key, f.key)
 			}
 		}
-	case !empty && p != "":
+	case !noMapping && p != "":
 		return fmt.Errorf("config: site.yaml: status.map means nothing to status.provider: %s (only json reads a document through a mapping)", p)
 	}
 	// The assets directory is served to every visitor: GET /assets/token.txt
-	// on a running cairn returns the file. status.ca under /assets stays legal
-	// and the asymmetry is deliberate: a CA certificate is the public half of
-	// an authority, and a token is not the public half of anything.
+	// on a running cairn returns the file. status.ca under /assets stays legal,
+	// a CA certificate being the public half of an authority where a token is
+	// the public half of nothing.
 	if tf := st.TokenFile; tf != "" {
 		if AssetFile(tf) != "" || strings.HasPrefix(tf, "/assets/") {
 			return fmt.Errorf("config: site.yaml: status.token_file %q is inside the assets directory, which cairn serves to every visitor: the token would be published rather than stored (mount it somewhere else, as /run/secrets/status-token)", tf)
@@ -322,12 +309,11 @@ func validateStatusAddress(site *Site) error {
 // The schemes cairn will actually emit. html/template puts http, https,
 // mailto and paths in an href or a src, and replaces every other scheme with
 // #ZgotmplZ, so a value carrying one renders as a link that goes nowhere and
-// says nothing. tel: fails exactly the way javascript: does, and just as
-// quietly; the only difference between them is intent.
+// says nothing. tel: fails exactly the way javascript: does, and as quietly.
 //
-// An allow-list rather than a list of the dangerous ones. A deny-list is only
-// as current as the last time somebody thought about it, and the question that
-// decides this is not which schemes are hostile but which ones cairn can emit.
+// An allow-list rather than a list of the dangerous ones: a deny-list is only
+// as current as the last time somebody thought about it, and the question here
+// is which schemes cairn can emit, not which ones are hostile.
 var (
 	linkSchemes = []string{"http", "https", "mailto"}
 	// An image is a file, so mailto: has no business naming one.
@@ -336,21 +322,19 @@ var (
 	// scoped to links rather than applied to the whole file: that file is
 	// plain text, never markup, so nothing blanks anything on the way out and
 	// RFC 9116 names tel: itself. Only the schemes a browser can be talked
-	// into executing are refused there, and data: is among them because
-	// data:text/html carries a whole document, script and all.
+	// into executing are refused there, data: among them, since data:text/html
+	// carries a whole document, script and all.
 	unsafeSchemes = []string{"javascript", "vbscript", "data"}
 )
 
 // urlScheme returns the scheme a browser would read from s, lowercased, and ""
 // when there is none, which is every relative and root-absolute path.
 //
-// It reads the value the way a browser does rather than the way it is written.
 // A browser removes every tab, newline and carriage return from a URL and
 // strips leading control characters and spaces before it looks at the scheme,
 // so "java\tscript:alert(1)", " javascript:…" and "JavaScript:…" are all the
 // same URL as the plain one. Matching the literal text would refuse the
-// obvious spelling and pass the three that matter, which is worse than not
-// checking: it reads as a check that works.
+// obvious spelling and pass the three that matter.
 func urlScheme(s string) string {
 	s = strings.Map(func(r rune) rune {
 		if r == '\t' || r == '\n' || r == '\r' {
@@ -368,11 +352,9 @@ func urlScheme(s string) string {
 	return strings.ToLower(s[:i])
 }
 
-// checkLinkScheme refuses a value cairn cannot put in an href or a src.
-//
-// It is an error rather than a warning because the alternative is what this
-// replaces: the page renders, the link is there, it does nothing when clicked,
-// and no log line anywhere mentions it.
+// checkLinkScheme refuses a value cairn cannot put in an href or a src. An
+// error rather than a warning: the alternative is a page that renders, a link
+// that does nothing when clicked, and no log line mentioning it.
 func checkLinkScheme(field, val string, allowed []string, accepted string) error {
 	sc := urlScheme(val)
 	if sc == "" || slices.Contains(allowed, sc) {
@@ -390,16 +372,13 @@ func checkContactScheme(field, val string) error {
 }
 
 // isQuotedFontName reports whether a CSS family name carries its own quotes,
-// which is what a name with spaces needs before it can stand on its own in an
-// @font-face.
+// which a name with spaces needs before it can stand alone in an @font-face.
 func isQuotedFontName(name string) bool {
 	return len(name) >= 2 &&
 		(name[0] == '"' && name[len(name)-1] == '"' ||
 			name[0] == '\'' && name[len(name)-1] == '\'')
 }
 
-// quotedFontName is isQuotedFontName's inverse: it returns the name wrapped
-// in double quotes unless it already is.
 func quotedFontName(name string) string {
 	if isQuotedFontName(name) {
 		return name
@@ -407,24 +386,20 @@ func quotedFontName(name string) string {
 	return `"` + name + `"`
 }
 
-// checkDarkImage guards the one half of a themed image that leaves the markup
+// checkDarkImage guards the half of a themed image that leaves the markup
 // behind. The light one goes into an src attribute, where html/template
 // escapes it; the dark one is written into the page's inline stylesheet as the
-// url() of a content rule, and nothing escapes a stylesheet for us.
+// url() of a content rule, which nothing escapes.
 //
-// Two characters are all it takes. A path that is not a climb, names no other
+// Two characters are all it takes: a path that is not a climb, names no other
 // origin and ends in .svg can still carry "</style>", and the browser ends the
-// style element there and reads the rest as markup. That is exactly the shape
-// theme.font.file was accepted with, so it is worth refusing by the same rule
-// rather than by a second look at where the value points.
-//
-// Only the dark half is held to it: it is the new surface, and nothing an
-// existing site serves today changes meaning.
+// style element there and reads the rest as markup. Only the dark half is held
+// to this, so nothing an existing site serves changes meaning.
 func checkDarkImage(key string, ref ThemedRef) error {
 	if !ref.Themed() {
 		return nil
 	}
-	if strings.ContainsAny(ref.Dark, "<>") {
+	if strings.ContainsAny(ref.Dark, stylesheetBreakers) {
 		return fmt.Errorf("config: site.yaml: %s.dark %q carries %q or %q, and the dark image is written into the page's stylesheet where nothing escapes it: an image URL has no use for either (expected e.g. /assets/logo-white.svg)", key, ref.Dark, "<", ">")
 	}
 	return nil

--- a/src/internal/config/yamlerr.go
+++ b/src/internal/config/yamlerr.go
@@ -40,9 +40,9 @@ func yamlWord(t string) string {
 	if w, ok := words[t]; ok {
 		return w
 	}
-	// yaml.v3 qualifies our own types with the package they live in, which is
-	// an implementation detail the operator never needs and which silently
-	// changed the day the packages were split. Match on the bare name.
+	// yaml.v3 qualifies our own types with the package they live in, which the
+	// operator never needs and which changed when the packages were split.
+	// Match on the bare name.
 	if bare := dropPackage(t); bare != t {
 		if w, ok := words[bare]; ok {
 			return w
@@ -65,9 +65,9 @@ func dropPackage(t string) string {
 	return prefix + t
 }
 
-// yamlKeys lists the keys a struct accepts, in the order they are declared.
-// An inline struct contributes its own keys dotted onto its name, because
-// "theme.accent" is how the operator writes it.
+// yamlKeys lists the keys a struct accepts, in declaration order. An inline
+// struct contributes its own keys dotted onto its name, because "theme.accent"
+// is how the operator writes it.
 func yamlKeys(t reflect.Type) []string {
 	var out []string
 	for i := range t.NumField() {
@@ -89,10 +89,8 @@ func yamlKeys(t reflect.Type) []string {
 
 // yamlShapes maps every named struct reachable from a config file to itself,
 // so an "unknown key" error can offer the keys of the entry that actually
-// failed. It is built by reflection rather than written down: the hand-kept
-// list had drifted (it had never gained show_version), a nested entry could
-// only ever be offered the top-level keys, and a service entry got no list at
-// all. None of those can happen to a list nothing maintains.
+// failed. Reflection rather than a written list: the hand-kept one had
+// drifted, and a nested entry could only ever be offered the top-level keys.
 var yamlShapes = func() map[string]reflect.Type {
 	shapes := map[string]reflect.Type{}
 	var walk func(reflect.Type)
@@ -124,8 +122,6 @@ func entryErr(err error) string {
 	return innerLineRe.ReplaceAllString(err.Error(), "")
 }
 
-// unknownKey phrases the refusal for the entry the operator actually mistyped:
-// which kind of entry it is, and what it does accept.
 func unknownKey(field, typ string) string {
 	out := fmt.Sprintf("unknown key %q", field)
 	shape, ok := yamlShapes[dropPackage(typ)]

--- a/src/internal/render/assets/about.js
+++ b/src/internal/render/assets/about.js
@@ -8,8 +8,8 @@
     document.documentElement.setAttribute('data-noabout', '');
     const h = document.documentElement.getAttribute('data-about') || 'off';
     const secure = location.protocol === 'https:' ? '; secure' : '';
-    // scope the cookie to the mount point, so a sub-path install does not
-    // write across the whole domain (data-base mirrors -base-path)
+    // scoped to the mount point, so a sub-path install does not write across
+    // the whole domain (data-base mirrors -base-path)
     const path = (document.documentElement.dataset.base || '') + '/';
     document.cookie = `about=${h}; path=${path}; max-age=31536000; samesite=lax${secure}`;
   });

--- a/src/internal/render/assets/leave.js
+++ b/src/internal/render/assets/leave.js
@@ -1,14 +1,5 @@
-// The dialog a visitor meets before a link that leaves this site, when the
-// operator has asked for one with service_links.confirm.
-//
-// The markup does the hard parts. <dialog>.showModal() traps focus, closes on
-// Escape, exposes aria-modal and returns focus to whatever was focused before,
-// all from the browser. The continue button is an anchor with a real href, so
-// following it needs no scripted navigation and no popup permission.
-//
-// Which links are guarded is decided on the server: this script only reacts to
-// data-leave. Without it every one of them is an ordinary link and the visitor
-// simply arrives, which is the no-JavaScript behaviour cairn keeps everywhere.
+// Guards the links the server marked with data-leave. Without this script they
+// are ordinary links and the visitor simply arrives.
 (function () {
   var dialog = document.getElementById("leave");
   if (!dialog || typeof dialog.showModal !== "function") return;
@@ -20,10 +11,9 @@
   var stay = dialog.querySelector(".leave-stay");
   var copyLabel = copy ? copy.textContent : "";
 
-  // The origin and the rest are separated rather than printed as one string,
-  // because the origin is the part that decides who you are talking to and a
-  // long path is very good at pushing it out of sight.
-  function split(href) {
+  // The origin is what says who you are about to talk to, and a long path is
+  // very good at pushing it out of sight.
+  function splitOrigin(href) {
     try {
       var u = new URL(href, location.href);
       return [u.origin, href.slice(href.indexOf(u.origin) + u.origin.length)];
@@ -32,15 +22,24 @@
     }
   }
 
+  function isPlainClick(e) {
+    return !(
+      e.defaultPrevented ||
+      e.metaKey ||
+      e.ctrlKey ||
+      e.shiftKey ||
+      e.altKey ||
+      e.button !== 0
+    );
+  }
+
   document.addEventListener("click", function (e) {
     var a = e.target.closest ? e.target.closest("a[data-leave]") : null;
-    if (!a) return;
-    // A modified click is the visitor already choosing where this opens, and
-    // taking that over to show a dialog about tabs would be its own rudeness.
-    if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+    // A modified click is the visitor already choosing where this opens.
+    if (!a || !isPlainClick(e)) return;
     e.preventDefault();
 
-    var parts = split(a.href);
+    var parts = splitOrigin(a.href);
     host.textContent = parts[0];
     rest.textContent = parts[1];
     go.href = a.href;
@@ -51,9 +50,9 @@
   if (copy) {
     copy.addEventListener("click", function () {
       var done = copy.getAttribute("data-done");
-      // Only over https or on localhost. Where it is missing the address is
-      // still on screen and still selectable, which is why nothing here hides
-      // the button: it stays honest by simply not changing its label.
+      // navigator.clipboard is https and localhost only. Where it is missing
+      // the button stays put and its label stays unchanged: the address is on
+      // screen and selectable either way.
       if (!navigator.clipboard) return;
       navigator.clipboard.writeText(go.href).then(function () {
         copy.textContent = done;
@@ -61,32 +60,31 @@
     });
   }
 
-  if (stay) stay.addEventListener("click", function () { dialog.close(); });
+  if (stay)
+    stay.addEventListener("click", function () {
+      dialog.close();
+    });
 
-  // The one thing showModal() does not give us. Chromium lets Tab walk off the
-  // end of a modal dialog: the press after the last control leaves the page for
-  // the browser's own toolbar, so nothing on screen moves and one press in four
-  // reads as a dead key. A bare <dialog> with three buttons does the same, so
-  // this is the platform and not the markup. WAI-ARIA's dialog pattern asks for
-  // the wrap, and three controls are few enough that the visitor notices the
-  // gap. Painted, not merely present: a control the layout dropped is not a
-  // place to send the focus.
+  // Chromium lets Tab off the end of a modal dialog, into the browser's own
+  // toolbar, so one press in four moves nothing on screen. A bare <dialog>
+  // does the same. WAI-ARIA's dialog pattern asks for the wrap.
   dialog.addEventListener("keydown", function (e) {
     if (e.key !== "Tab") return;
-    var stops = [];
+    var painted = [];
     var all = dialog.querySelectorAll("a[href], button:not([disabled])");
     for (var i = 0; i < all.length; i++) {
-      if (all[i].getClientRects().length) stops.push(all[i]);
+      // a control the layout dropped is not a place to send the focus
+      if (all[i].getClientRects().length) painted.push(all[i]);
     }
-    if (!stops.length) return;
-    var edge = e.shiftKey ? stops[0] : stops[stops.length - 1];
+    if (!painted.length) return;
+    var last = painted[painted.length - 1];
+    var edge = e.shiftKey ? painted[0] : last;
     if (document.activeElement !== edge) return;
     e.preventDefault();
-    (e.shiftKey ? stops[stops.length - 1] : stops[0]).focus();
+    (e.shiftKey ? last : painted[0]).focus();
   });
 
-  // A click on the backdrop lands on the dialog element itself, since its
-  // children cover the rest of it.
+  // The backdrop is the dialog element itself: its children cover the rest.
   dialog.addEventListener("click", function (e) {
     if (e.target === dialog) dialog.close();
   });

--- a/src/internal/render/assets/nav.js
+++ b/src/internal/render/assets/nav.js
@@ -1,8 +1,10 @@
-// Scroll chrome: hide the header on the way down and bring it back on the way
-// up, reveal the back-to-top button past a screen, and wire the "jump to
-// category" select. All progressive: without JS the header just stays put, the
-// button stays hidden, and the select is inert.
+// Scroll chrome for the header, the back-to-top button and the jump-to-category
+// select. All progressive: without JS the header stays put, the button stays
+// hidden and the select is inert.
 (() => {
+  const NEAR_TOP = 80;   // still counts as the top of the page
+  const JITTER = 4;      // below this a scroll is not a direction
+
   const header = document.querySelector('header');
   const totop = document.querySelector('.totop');
   const nav = document.querySelector('.nav');
@@ -11,9 +13,8 @@
 
   // A scroll dismisses the open menu, which is right for a pointer and wrong
   // for a keyboard: tabbing to a menu link the browser has to scroll into view
-  // fires this handler, and closing the menu underneath both takes away what
-  // the user was tabbing through and drops focus to <body>, so the next Tab
-  // restarts at the skip link. Focus on the burger itself is still the pointer
+  // fires this handler, and closing the menu drops focus to <body>, so the next
+  // Tab restarts at the skip link. Focus on the burger itself is the pointer
   // case: clicking it leaves focus there, and the summary survives the close.
   const keyboardInside = () => {
     const a = document.activeElement;
@@ -24,9 +25,8 @@
     const y = scrollY;
     if (nav && nav.open && !keyboardInside()) nav.open = false;
     if (header) {
-      // near the top or scrolling up: show; scrolling down past a bit: hide
-      if (y < 80 || y < last - 4) header.classList.remove('header-hidden');
-      else if (y > last + 4) header.classList.add('header-hidden');
+      if (y < NEAR_TOP || y < last - JITTER) header.classList.remove('header-hidden');
+      else if (y > last + JITTER) header.classList.add('header-hidden');
     }
     if (totop) totop.classList.toggle('show', y > innerHeight * 0.9);
     last = y;

--- a/src/internal/render/assets/search.js
+++ b/src/internal/render/assets/search.js
@@ -18,9 +18,8 @@
     // presses a button or opens a <details>. Nobody starts a query with one.
     if (e.metaKey || e.ctrlKey || e.altKey || e.key.length !== 1 || e.key === ' ') return;
     const a = document.activeElement;
-    // The tag list has to hold every element that does something with a plain
-    // key, not just the text fields: stealing focus from a focused button ate
-    // its activation.
+    // Every element that does something with a plain key, not just the text
+    // fields: stealing focus from a focused button ate its activation.
     if (a === input || /^(INPUT|TEXTAREA|SELECT|BUTTON|SUMMARY|A)$/.test(a.tagName) || a.isContentEditable) return;
     // focus on keydown: the default action then types the character here
     input.focus();
@@ -40,22 +39,21 @@
     const label = n === 1 ? count.dataset.single : count.dataset.plural.replace('%d', n);
     count.textContent = name ? `${label}, ${name}` : label;
   };
-  const cards = Array.from(document.querySelectorAll('.card'), (el, dom) => {
+  const cards = Array.from(document.querySelectorAll('.card'), (el, pos) => {
     const main = el.querySelector('.card-main').cloneNode(true);
     main.querySelectorAll('.visually-hidden, .status-pill, .card-more').forEach(n => n.remove());
     return {
       el,
-      dom,                                    // original position, the tie-breaker
-      cat: cats.indexOf(el.closest('.cat')),  // which category row it lives in
-      label: el.querySelector('.card-name').textContent.trim(), // as written, for the announcement
+      pos,
+      cat: cats.indexOf(el.closest('.cat')),
+      label: el.querySelector('.card-name').textContent.trim(),
       name: norm(el.querySelector('.card-name').textContent),
       text: norm(main.textContent + ' ' + (el.dataset.tags || '')),
     };
   });
   const empty = document.getElementById('empty');
 
-  // The visible matches, in the order they now read on screen, and the index of
-  // the "selected" one (the one Enter opens). -1 when nothing is selected.
+  // the visible matches in on-screen order; sel is the one Enter opens, -1 none
   let matches = [];
   let sel = -1;
 
@@ -73,8 +71,8 @@
     const q = norm(input.value).trim();
     const words = q.split(/\s+/).filter(Boolean);
     // Name matches win: when the query hits a service's name, show only those,
-    // so a full name doesn't drag in cards that merely mention it. Fall back to
-    // the full text (descriptions, tags) only when no name matches.
+    // so a full name does not drag in cards that merely mention it. The full
+    // text (descriptions, tags) is the fallback.
     const nameHit = c => words.every(w => c.name.includes(w));
     const byName = words.length > 0 && cards.some(nameHit);
     const hit = byName ? nameHit : c => words.every(w => c.text.includes(w));
@@ -88,26 +86,23 @@
       c.el.classList.remove('sel');
       if (ok && words.length) {
         c.score = score(c);
-        c.el.style.order = String(-c.score); // the better the match, the further left in its row
+        c.el.style.order = String(-c.score); // the better the match, the earlier in its row
         hits.push(c);
       } else {
         c.el.style.order = '';
       }
     }
-    // read them in on-screen order: category by category, best score first,
-    // original order breaking ties
-    hits.sort((a, b) => a.cat - b.cat || b.score - a.score || a.dom - b.dom);
+    // on-screen order: category, then score, then original position
+    hits.sort((a, b) => a.cat - b.cat || b.score - a.score || a.pos - b.pos);
     matches = hits;
 
     for (const s of cats) s.hidden = !s.querySelector('.card:not([hidden])');
-    // "No results" answers a search that found nothing. An empty box is not a
-    // search: clearing the field brings every card back, and `matches` is empty
-    // then for the keyboard's sake, not because nothing matched. Reading it as
-    // a result made the message appear on the way back to the full list, and
-    // #empty carries role="status", so it was announced too.
+    // An empty box is not a search that found nothing: clearing the field
+    // brings every card back, and `matches` is empty then for the keyboard's
+    // sake. #empty carries role="status", so reading it as a result announced
+    // "no results" on the way back to the full list.
     empty.hidden = !(words.length && matches.length === 0);
-    // Preselect the strongest match: it also sits first-left in its category, so
-    // typing a name lands you on that one card, top-left of its row.
+    // the strongest match, which also sits first in its category row
     sel = -1;
     if (matches.length) {
       let best = 0;
@@ -119,9 +114,9 @@
 
   input.addEventListener('input', apply);
 
-  // ponytail: a class + a real link click, not a full ARIA combobox. The live
-  // region above carries the count and the pick, which is what a listbox would
-  // announce anyway; upgrade only if real screen-reader testing asks for it.
+  // A class and a real link click, not a full ARIA combobox: the live region
+  // above carries the count and the pick, which is what a listbox would
+  // announce anyway.
   input.addEventListener('keydown', e => {
     if (e.key === 'Escape') { input.value = ''; apply(); return; }
     if (!matches.length) return;

--- a/src/internal/render/assets/status.js
+++ b/src/internal/render/assets/status.js
@@ -1,10 +1,9 @@
-// The pages are static HTML. Without this, a tab left open on a wall display
-// keeps showing whatever Gatus said the moment it was opened: cairn learns
-// that a service came back, and the one screen everybody looks at never does.
+// The pages are static HTML, so a tab left open on a wall display keeps showing
+// whatever the monitor said the moment it was opened.
 //
-// It refetches the page it is already on and swaps the status pills out of the
-// answer, nothing else. No API, no partial endpoint, no state of its own: the
-// server already renders exactly the markup wanted, and the response is a
+// This refetches the page it is already on and swaps the status pills out of
+// the answer, nothing else. No API, no partial endpoint, no state of its own:
+// the server already renders the markup wanted, and the request is a
 // conditional GET that comes back 304 most of the time.
 (function () {
   var every = (Number(document.currentScript.dataset.poll) || 60) * 1000;
@@ -26,26 +25,25 @@
         if (!html) return;
         // Parsed, never assigned: DOMParser builds an inert document with no
         // browsing context, and what moves across is a .status-slot element
-        // cairn's own template rendered. No markup is ever built from a
-        // string here, so there is no sink for one to be injected into.
+        // cairn's own template rendered. No markup is built from a string
+        // here, so there is no sink to inject into.
         var fresh = slots(new DOMParser().parseFromString(html, 'text/html'));
         var live = slots(document);
         Object.keys(live).forEach(function (id) {
           if (!(id in fresh)) return;
-          // Replacing an unchanged pill would restart the online dot's pulse
-          // every interval, which is a beacon blinking for no reason.
+          // replacing an unchanged pill restarts the online dot's pulse every
+          // interval, a beacon blinking for no reason
           if (live[id].outerHTML === fresh[id].outerHTML) return;
-          // A pill is a link. Pulling it out from under the keyboard would
-          // drop focus to the top of the document mid-read; the pill can
-          // wait, the visitor's place cannot.
+          // A pill is a link: pulling it out from under the keyboard drops
+          // focus to the top of the document mid-read.
           if (live[id].contains(document.activeElement)) return;
           live[id].replaceWith(fresh[id]);
         });
       })
       .catch(function () {
-        // cairn is unreachable or answered nonsense. The pills stay as they
-        // are and the next tick tries again: this is the one thing on the
-        // page that has no business raising an error at the visitor.
+        // Unreachable or nonsense: the pills stay as they are and the next
+        // tick tries again. This has no business raising an error at the
+        // visitor.
       });
   }
 

--- a/src/internal/render/assets/style.css
+++ b/src/internal/render/assets/style.css
@@ -1,8 +1,7 @@
 @font-face {
-  /* Fraunces, cut down from the upstream variable font: Latin ranges only, and
-     the SOFT and WONK axes pinned to the single values used below. That halves
-     the file (118 -> 62 KB) while keeping opsz, so headings still get their
-     proper optical size. Rebuild: see docs/reference.md#the-display-font. */
+  /* Fraunces, subset from the upstream variable font: Latin ranges only, SOFT
+     and WONK pinned to the values used below, opsz kept so headings still get
+     their optical size. 118 -> 62 KB. Rebuild: docs/reference.md#the-display-font. */
   font-family: "Fraunces";
   /* relative to this stylesheet, so it resolves under any -base-path */
   src: url("fonts/fraunces.woff2") format("woff2");
@@ -11,59 +10,50 @@
   font-display: swap;
 }
 
-/* The browser's own [hidden] rule is display:none, but any author rule with a
-   display beats it, and plenty below set one. That is not academic: .card sets
-   display:flex, so search marked non-matching cards hidden and left them on
-   screen while the live region announced "1 result". The same slip left the
-   theme toggle and the dismiss button clickable and inert without JavaScript,
-   since both ship hidden and are un-hidden by their script.
-
-   !important is the point here rather than a shortcut: this restores a browser
-   invariant that later rules must not be able to take back. Every script that
-   reveals a control clears the attribute (theme.js, about.js, search.js). */
+/* The browser's own [hidden] rule is display:none, and any author rule with a
+   display beats it: .card sets display:flex, so search marked non-matching
+   cards hidden and left them on screen while the live region announced
+   "1 result". The same slip left the theme toggle and the dismiss button
+   clickable and inert without JavaScript. !important restores the invariant so
+   a later rule cannot take it back; every script that reveals a control clears
+   the attribute (theme.js, about.js, search.js). */
 [hidden] {
   display: none !important;
 }
 
 :root {
-  /* Mineral palette: cool weathered stone, not warm cream. Every variable
-     carries its light and dark value; the browser preference picks one, and
-     forcing a theme (the header toggle) is just color-scheme below. */
+  /* Mineral palette: cool weathered stone, not warm cream. */
   color-scheme: light dark;
   --bg: light-dark(#eef0ea, #14181a);
   --card: light-dark(#fbfbf9, #1b2123);
   --fg: light-dark(#1b2220, #e6e9e5);
   --muted: light-dark(#5c6461, #98a19d);
   --faint: light-dark(#e8e7df, #212829);
-  /* --border is decoration: card outlines, rules, the trail's spine. WCAG
-     1.4.11 does not reach it, and it used to sit at 1.21:1 against --bg in
-     light and 1.34:1 in dark, which is a hairline that survives a good screen
-     in a dim room and disappears on a cheap one in daylight. Around 2:1 is a
-     deliberate middle: no rule asks for it, and a card whose edge you cannot
-     find is still a card you cannot scan. Measured: light 1.84:1 on --bg and
-     2.04:1 on --card, dark 2.02:1 and 1.84:1. */
+  /* Decoration: card outlines, rules, the trail's spine. WCAG 1.4.11 does not
+     reach it. At 1.21:1 against --bg in light and 1.34:1 in dark it was a
+     hairline that disappeared on a cheap screen in daylight; around 2:1 is the
+     floor. Measured: light 1.84:1 on --bg and 2.04:1 on --card, dark 2.02:1
+     and 1.84:1. */
   --border: light-dark(#b4b3a8, #434c4a);
-  /* The boundary that *is* the control, where nothing else says where to click
-     or type, and where 1.4.11 does ask for 3:1. Kept separate from --border so
-     the decoration above can be chosen for looks and this one cannot. Measured
-     against both neighbours: light 3.31:1 on --bg and 3.67:1 on --card, dark
-     3.63:1 and 3.31:1. */
+  /* The boundary that is the control, where nothing else says where to click or
+     type and 1.4.11 does ask 3:1. Separate from --border so the decoration
+     above can be chosen for looks and this one cannot. Measured against both
+     neighbours: light 3.31:1 on --bg and 3.67:1 on --card, dark 3.63:1 and
+     3.31:1. */
   --ui-border: light-dark(#7f8482, #6b7270);
   --accent: #247b7b;                                       /* set inline from theme.accent */
   --accent-ink: light-dark(color-mix(in oklab, var(--accent) 85%, #000), color-mix(in oklab, var(--accent) 72%, #fff));
   --up: light-dark(#2e8b57, #4cb47c);
   --down: light-dark(#c0392b, #e0685b);
-  /* Two more states, for the monitors that report more than a bool. Measured
-     against the pill's own fill on both themes, which is the only neighbour a
-     dot has: degraded 4.29:1 light and 5.95:1 dark, maintenance 4.99:1 and
-     5.85:1. WCAG 1.4.11 asks 3:1 of a graphic that carries meaning, and the
-     browser test holds all four. */
+  /* Two more states, for monitors that report more than a bool. WCAG 1.4.11
+     asks 3:1 of a graphic that carries meaning. Measured against the pill's own
+     fill, the only neighbour a dot has: degraded 4.29:1 light and 5.95:1 dark,
+     maintenance 4.99:1 and 5.85:1. */
   --degraded: light-dark(#a86a00, #cf9020);
   --maintenance: light-dark(#2f6fb5, #5aa0e0);
   /* A status token paints a dot, a graphic that needs 3:1. Used raw as a word
      it fails: green measured 4.10:1 and amber 4.29:1 against a card. Each is
-     pushed until it can carry text, the way --accent-ink is the accent pushed.
-     Measured after: beta 8.20:1, deprecated 8.07:1, soon 7.69:1. */
+     pushed until it carries text: beta 8.20:1, deprecated 8.07:1, soon 7.69:1. */
   --ink-beta: light-dark(color-mix(in oklab, var(--up) 72%, #000), color-mix(in oklab, var(--up) 82%, #fff));
   --ink-deprecated: light-dark(color-mix(in oklab, var(--degraded) 74%, #000), color-mix(in oklab, var(--degraded) 88%, #fff));
   --ink-soon: light-dark(color-mix(in oklab, var(--maintenance) 78%, #000), color-mix(in oklab, var(--maintenance) 85%, #fff));
@@ -76,6 +66,8 @@
 
   --radius: .9rem;
   --maxw: 66rem;
+  /* the sticky header on narrow screens; .skip has to paint one above it */
+  --z-header: 40;
 }
 
 :root[data-theme="light"] { color-scheme: light; }
@@ -154,14 +146,13 @@ header { padding-block: 1.4rem; }
 .menu-link svg { width: .95rem; height: .95rem; opacity: .85; flex: none; }
 .menu-link img { width: 1rem; height: 1rem; flex: none; }
 
-/* nav: the header links live in a <details>. On desktop the wrapper is
-   transparent (display:contents) so the links flow inline and the burger is
-   hidden; the mobile block turns it into a real burger + dropdown. */
+/* The header links live in a <details>: transparent on desktop so they flow
+   inline, a burger and a dropdown in the mobile block. */
 .nav { display: contents; }
 .nav-burger { display: none; }
-/* closed <details> hides its content: newer engines via content-visibility on
-   the ::details-content wrapper, older ones via display:none. Undo both so the
-   links show inline on desktop; the mobile block shows/hides via .nav-links. */
+/* A closed <details> hides its content: newer engines through
+   content-visibility on ::details-content, older ones through display:none.
+   Both are undone here; the mobile block shows and hides via .nav-links. */
 .nav::details-content { content-visibility: visible; display: contents; }
 .nav-links {
   display: flex;
@@ -272,8 +263,8 @@ header { padding-block: 1.4rem; }
   position: relative;
   margin: 2.2rem 0 2.4rem;
   /* Logical, not physical: the close button sits at inset-inline-end, so under
-     RTL a right-hand padding stayed on the right while the button moved left
-     and landed on the text. */
+     RTL a physical end padding stayed put while the button moved across and
+     landed on the text. */
   padding-block: 1.3rem;
   padding-inline: 1.5rem 3.4rem;
   background: var(--card);
@@ -283,13 +274,11 @@ header { padding-block: 1.4rem; }
 }
 .about p { line-height: 1.7; margin: 0 0 .85rem; }
 .about p:last-of-type { margin-bottom: 0; }
-/* The same fold as the host flag, and deliberately the same: a glyph at rest,
-   the word unfurled beside it on hover or focus. It used to swap display
-   between the two, which is the one way of writing this that cannot be
-   animated, since display does not interpolate; and it took the cross away at
-   the instant the pointer landed on it, so the button emptied itself to show
-   its own label. Clipping a nowrap row keeps both parts on screen and gives
-   the width something to travel. */
+/* The same fold as the host flag: a glyph at rest, the word unfurled beside it
+   on hover or focus. Swapping display between the two cannot be animated, since
+   display does not interpolate, and it took the cross away at the instant the
+   pointer landed on it. Clipping a nowrap row keeps both parts on screen and
+   gives the width something to travel. */
 .about-x {
   position: absolute;
   top: .8rem;
@@ -297,15 +286,15 @@ header { padding-block: 1.4rem; }
   display: inline-flex;
   align-items: center;
   gap: .32rem;
-  height: 1.9rem;
-  /* Folded it is a disc, not a pill: the same 1.9rem across as it is tall.
-     Which forces the padding, since the border, the glyph and two paddings
-     have to add up to exactly that: .8rem of glyph and 2px of border leave
-     .55rem a side minus the pixel the border took. Round it up and the box
-     goes oval; leave the pixel in and the cross sits 1px shy of centre. */
-  max-width: 1.9rem;
+  /* Folded it is a disc, not a pill: as wide as it is tall. The border, the
+     glyph and the two paddings have to add up to exactly that, border pixel
+     included, or the box goes oval and the cross sits off centre. */
+  --x-disc: 1.9rem;
+  --x-glyph: .8rem;
+  height: var(--x-disc);
+  max-width: var(--x-disc);
   overflow: hidden;
-  padding: 0 calc(.55rem - 1px);
+  padding: 0 calc((var(--x-disc) - var(--x-glyph)) / 2 - 1px);
   border: 1px solid var(--border);
   border-radius: 999px;
   background: var(--faint);
@@ -318,7 +307,7 @@ header { padding-block: 1.4rem; }
   transition: max-width .3s cubic-bezier(.2, .7, .3, 1), color .16s, border-color .16s;
 }
 /* flex: none, or the glyph is what gives way when the box is clipped */
-.about-x svg { width: .8rem; height: .8rem; flex: none; }
+.about-x svg { width: var(--x-glyph); height: var(--x-glyph); flex: none; }
 .about-x span { opacity: 0; transition: opacity .18s; }
 .about-x:hover, .about-x:focus-visible {
   max-width: 14rem;
@@ -327,22 +316,21 @@ header { padding-block: 1.4rem; }
 }
 .about-x:hover span, .about-x:focus-visible span { opacity: 1; }
 .about-x:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-/* No (hover: none) rule here, and that is the one place this parts company
-   with the flag. The flag sits in the card foot, in flow, so a permanently
-   unfurled label costs nothing. This button is absolute over the note, which
-   reserves 3.4rem of end padding for it folded: unfurled on every phone it
-   would lay its own label across the first line of the welcome text. A touch
-   visitor gets the cross, which is what the button means anyway. */
-/* width lives on the wrapper: as a flex item it would otherwise size to the
-   box's max-content and leave the box shy of the right edge */
+/* No (hover: none) rule here, unlike the flag. The flag sits in the card foot,
+   in flow, so an unfurled label costs nothing. This button is absolute over the
+   note, which reserves 3.4rem of end padding for it folded: unfurled on a phone
+   it would lay its label across the first line of the welcome text. */
+
+/* Width on the wrapper: as a flex item the box would otherwise size to its own
+   max-content and stop short of the inline end. */
 .search {
   margin-inline-start: auto;
   width: min(14.5rem, 100%);
   transition: width .2s ease;
 }
 .search:focus-within { width: min(19rem, 100%); }
-/* the bar renders on every page for layout parity; asleep it turns gray.
-   On the home page the script wakes it, elsewhere it stays decorative. */
+/* The bar renders on every page for layout parity. Only the home page has a
+   script to wake it; elsewhere it stays disabled and decorative. */
 .search-box:has(input:disabled) {
   background: var(--faint);
   box-shadow: none;
@@ -363,11 +351,9 @@ header { padding-block: 1.4rem; }
   transition: border-color .15s, box-shadow .15s;
 }
 /* An input's outline is the whole of what says where to type, so WCAG 1.4.11
-   wants 3:1 there. It exempts inactive components, and that is not a shortcut
-   here, it is the shape of the thing: the bar renders disabled and decorative
-   on every page but the home page, purely for layout parity, and nobody can
-   type in it. So the strong border goes exactly where the control is awake and
-   the quiet one stays exactly where it is asleep.
+   wants 3:1 there. It exempts inactive components, which is what the bar is on
+   every page but the home page, so the strong border goes where the control is
+   awake and the quiet one stays where it is asleep.
    :where() holds this at .search-box's own specificity so :focus-within below
    still gets to paint the border accent. */
 .search-box:where(:has(input:enabled)) { border-color: var(--ui-border); }
@@ -436,10 +422,10 @@ header { padding-block: 1.4rem; }
 
 /* ---- category trail ---- */
 
-/* A fixed rail beside the content: one diamond per category on a vertical
-   line, waypoints on the trail. Shown only where the margin can hold it. */
+/* A fixed rail beside the content: one diamond per category on a vertical line.
+   Shown only where the margin can hold it. */
 .toc { display: none; }
-.toc-jump { display: none; } /* the mobile jump-to select; shown in the mobile block */
+.toc-jump { display: none; } /* shown in the mobile block */
 @media (min-width: 88rem) {
   .toc {
     display: block;
@@ -526,9 +512,8 @@ html { scrollbar-gutter: stable; }
   transform: translateY(-3px);
   box-shadow: var(--shadow-lift);
 }
-/* the keyboard-selected match: the card Enter opens while searching. The ring
-   pings outward like the online indicator's beacon; the accent border keeps
-   the selection legible between pulses (and when motion is reduced). */
+/* The keyboard-selected match, the card Enter opens. The accent border keeps
+   the selection legible between beacon pulses and when motion is reduced. */
 .card.sel {
   border-color: var(--accent);
   box-shadow: 0 0 0 2px color-mix(in oklab, var(--accent) 55%, transparent), var(--shadow-lift);
@@ -569,23 +554,21 @@ html { scrollbar-gutter: stable; }
 }
 .card-foot .status-pill { margin-inline-start: auto; }
 /* status.js swaps what is inside the slot, so the slot has to be in the markup
-   before there is anything to swap. It takes no part in the layout: a pill
-   inside it is still a direct flex item of the foot, and the margin above
-   still pushes it to the end. */
+   before there is anything to swap. display:contents keeps a pill inside it a
+   direct flex item of the foot, so the margin above still pushes it to the
+   end. */
 .status-slot { display: contents; }
-/* Which leaves a foot that holds neither a flag nor a pill drawing its bottom
-   padding around nothing. That is a real card: a site with a status page, for
-   a service the status page does not monitor. */
+/* A foot holding neither a flag nor a pill would draw its bottom padding around
+   nothing: a site with a status page, for a service it does not monitor. */
 .card-foot:not(:has(.flag, .status-pill)) { display: none; }
 
 /* Host flag: an icon at rest that unfurls its label on hover or focus. The
    label stays in the DOM (clipped, not removed) for screen readers; on touch
-   and under reduced motion it simply shows expanded.
-   As a span it is not raised above the stretched-link overlay, so a click on
-   it opens the service like the rest of the card. As a link, which it becomes
-   when hosting_flag names a target, it has to be raised, and that is a
-   deliberate reversal: a third target inside the card, entered knowingly, and
-   only on the sites that ask for it. */
+   and under reduced motion it shows expanded.
+   As a span it stays under the stretched-link overlay, so a click on it opens
+   the service like the rest of the card. As a link, which it becomes when
+   hosting_flag names a target, it is raised above: a third target inside the
+   card, only on the sites that ask for it. */
 .flag {
   display: inline-flex;
   align-items: center;
@@ -602,17 +585,16 @@ html { scrollbar-gutter: stable; }
   white-space: nowrap;
   transition: max-width .3s cubic-bezier(.2, .7, .3, 1), color .2s, border-color .2s;
 }
-/* overflow visible: the cloud glyph's right lobe reaches the viewBox edge and
-   its stroke would be clipped flat; the flag's own padding absorbs the spill. */
+/* overflow visible: the cloud glyph reaches the viewBox edge and its stroke
+   would be clipped flat; the flag's own padding absorbs the spill. */
 .flag svg { width: .9rem; height: .9rem; flex: none; overflow: visible; }
 .flag-label { opacity: 0; padding-inline-end: .14rem; transition: opacity .18s; }
 .flag-self { color: var(--accent-ink); border-color: color-mix(in oklab, var(--accent) 32%, var(--border)); }
 a.flag { position: relative; z-index: 1; text-decoration: none; }
 a.flag:hover { background: var(--accent-ink); border-color: var(--accent-ink); color: var(--card); }
 a.flag:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-/* A link has to be reachable at rest, so it does not hide behind its own
-   fold: an unfurled label is the hover state, the icon alone is what a thumb
-   arrives on. 2rem wide by the padding and the glyph is the floor. */
+/* A link has to be reachable at rest, behind its own fold: the icon alone is
+   what a thumb arrives on, and 2rem by the padding and the glyph is the floor. */
 a.flag { min-height: 1.5rem; }
 .card:hover .flag, .card:focus-within .flag { max-width: 14rem; }
 .card:hover .flag-label, .card:focus-within .flag-label { opacity: 1; }
@@ -623,18 +605,17 @@ a.flag { min-height: 1.5rem; }
 @media (prefers-reduced-motion: reduce) {
   .flag { transition: none; max-width: 14rem; }
   .flag-label { transition: none; opacity: 1; }
-  /* the dismiss button loses the travel but keeps the fold, unlike the flag
-     just above: see the note on why it does not unfurl on touch either */
+  /* the dismiss button keeps the fold and loses only the travel, unlike the
+     flag above: it is absolute over the note and has no room to unfurl */
   .about-x, .about-x span { transition: none; }
   header, .nav-links { transition: none; }
 }
-/* Where a service stands, declared and not measured, which is why it carries
-   no dot: the dot in the foot is what says a machine looked. It hangs on the
-   top border rather than taking a row inside the card, because the grid
-   stretches a row to its tallest card and a row inside would charge 27px to
-   every card beside it, measured. Out here it lives in the gap between rows,
-   which existed already. .card declares no overflow, so nothing has to be
-   opened for it. */
+/* Where a service stands, declared and not measured, so it carries no dot: the
+   dot in the foot is what says a machine looked. It hangs on the top border
+   rather than taking a row inside the card, because the grid stretches a row to
+   its tallest card and a row inside charged 27px to every card beside it,
+   measured. Out here it lives in the gap between rows, and .card declares no
+   overflow to open. */
 .card-badge {
   position: absolute;
   z-index: 2;
@@ -658,13 +639,11 @@ a.flag { min-height: 1.5rem; }
 .card-badge-soon { color: var(--ink-soon); border-color: color-mix(in oklab, var(--maintenance) 40%, var(--border)); }
 /* .card-badge-retired needs no rule: --muted above is already its colour. */
 
-/* The two disabling states. A film over the card rather than a lighter text:
-   the card, the icon and the two chips recede together, which is what makes it
-   read as gone at a glance.
-   Nothing readable goes under the film. Measured: at 45% no text reaches
-   4.5:1, not even painted near black, because the veil lifts ink and
-   background together. So the words stay above it and the film is what is
-   behind them. */
+/* The two disabling states. A film over the card rather than lighter text: the
+   card, the icon and the two chips recede together.
+   Nothing readable goes under the film. Measured: at 45% no text reaches 4.5:1,
+   not even painted near black, because the veil lifts ink and background
+   together. The words stay above it and the film sits behind them. */
 .card-off {
   box-shadow: none;
   background: color-mix(in oklab, var(--card) 30%, var(--bg));
@@ -685,9 +664,8 @@ a.flag { min-height: 1.5rem; }
   background: color-mix(in oklab, var(--bg) 45%, transparent);
 }
 .card-off .card-text { position: relative; z-index: 2; }
-/* The flag and the glyph kept their full-strength fill and ring while the card
-   behind them dropped away, and a bright chip on a receded card is what read
-   as wrong. They lose their own surfaces instead. Both measure 5.39:1 after. */
+/* A full-strength chip on a receded card read as wrong, so the flag and the
+   glyph lose their own fill and ring too. Both measure 5.39:1 after. */
 .card-off .flag {
   position: relative;
   z-index: 2;
@@ -697,8 +675,7 @@ a.flag { min-height: 1.5rem; }
 }
 /* z-index alone. .card-more is already absolutely positioned and adding
    position:relative overrides that: the glyph leaves the card through the
-   inline start and adds a line to its height. Done twice while drawing this,
-   an hour apart, which is why a browser check holds it. */
+   inline start and adds a line to its height. A browser check holds it. */
 .card-off .card-more {
   z-index: 2;
   background: transparent;
@@ -713,20 +690,18 @@ a.flag { min-height: 1.5rem; }
   color: inherit;
   text-decoration: none;
 }
-/* stretched link: the whole card follows the service link, so the pill and
-   "learn more" (raised above it) stay independently clickable. */
+/* Stretched link: the whole card follows the service link. The pill and the
+   detail glyph are raised above it and stay independently clickable. */
 .card-name::after { content: ""; position: absolute; inset: 0; z-index: 0; }
 .card:has(.card-name:focus-visible) { outline: 2px solid var(--accent); outline-offset: 2px; }
 .card-desc { color: var(--muted); font-size: .95rem; }
 
 /* The detail link: a glyph in the card's corner, raised above the stretched
-   link like the status pill. It sits there rather than at the end of the
-   description for two reasons. Inline, it was 90 by 16, under the 24 by 24
-   WCAG 2.2 asks of a target, and no padding would fix that without pushing the
-   prose around. In the card foot, which was the other candidate, it squeezed
-   the host flag: on a 320px phone the flag is unfurled and "Self-hosted" came
-   out as "Self-". The corner is the one place on a card that belongs to
-   nothing else. */
+   link like the status pill. Inline at the end of the description it measured
+   90 by 16, under the 24 by 24 WCAG 2.2 asks of a target, and no padding fixes
+   that without pushing the prose around. In the card foot it squeezed the host
+   flag: on a 320px phone the flag is unfurled and "Self-hosted" came out as
+   "Self-". The corner belongs to nothing else. */
 .card-more {
   position: absolute;
   inset-block-start: .85rem;
@@ -734,42 +709,38 @@ a.flag { min-height: 1.5rem; }
   z-index: 1;
   display: grid;
   place-items: center;
-  /* Whole pixels, both of them, and that is the whole point. A card grid lands
-     on fractional track widths (325.33px on the demo), so each card sits at a
-     different subpixel phase: .438 for one, .766 for the next. The ring is
-     painted on the box edges and the glyph is centred inside it, and when the
-     gap between them is fractional the two round to different sides, so the
-     glyph reads half a pixel off centre, left on one card and right on the
-     next. Measured: 1 device pixel of disagreement at .95rem, and 0 at 16px,
-     on every card and every phase. 28 minus 16 is 12, so the gap is 6 on each
-     side and there is nothing left to round. */
-  width: 28px;
-  height: 28px;
+  /* Whole pixels on both, so the gap between them is a whole number too: 28
+     minus 16 leaves 6 a side with nothing to round. A card grid lands on
+     fractional track widths (325.33px on the demo), so each card sits at its
+     own subpixel phase, and a fractional gap rounds the ring and the glyph to
+     different sides. Measured: 1 device pixel of disagreement at .95rem, 0 at
+     16px, on every card and every phase. */
+  --ring: 28px;
+  --ring-glyph: 16px;
+  width: var(--ring);
+  height: var(--ring);
   border: 1px solid var(--border);
   border-radius: 999px;
   background: var(--card);
   color: var(--muted);
   transition: color .16s, border-color .16s;
 }
-/* Hover fills rather than tints. The card is one big link, so the pointer is
-   already a hand everywhere on it: a cursor says nothing extra when it reaches
-   a control, and the old treatment only moved the border from 2.04:1 to
-   2.82:1 against the card, which is invisible next to the card lifting at the
-   same moment. A fill is the one signal the card does not already give.
+/* Hover fills rather than tints. The whole card is a link, so the pointer is
+   already a hand here, and tinting the border moved it from 2.04:1 to 2.82:1
+   against the card, invisible next to the card lifting at the same moment.
    --accent-ink rather than --accent: it is the accent already adjusted per
    theme to read against the card, so the fill measures 6.82:1 in light and
-   5.47:1 in dark, and the card-coloured mark on it measures the same, whatever
-   accent the operator chose. */
+   5.47:1 in dark, and the card-coloured mark on it the same, whatever accent
+   the operator chose. */
 .card-more:hover { background: var(--accent-ink); border-color: var(--accent-ink); color: var(--card); }
 .card-more:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-.more-glyph { width: 16px; height: 16px; }
+.more-glyph { width: var(--ring-glyph); height: var(--ring-glyph); }
 /* Room for it, so a long name does not run underneath. */
 .card:has(.card-more) .card-name { padding-inline-end: 2.2rem; }
 
 /* ---- status dots ---- */
 
-/* Status pill: dot + label, links to Gatus. The dot breathes like a beacon
-   when online; offline is static and marked; unknown is a neutral hollow. */
+/* Status pill: a dot and a label, linked to the status page when there is one. */
 .status-pill {
   display: inline-flex;
   align-items: center;
@@ -784,15 +755,14 @@ a.flag { min-height: 1.5rem; }
   text-decoration: none;
   white-space: nowrap;
 }
-/* Only a pill that leads somewhere answers to a pointer. A display-only one
-   (status.linked: false) is not a control, so it does not pretend to be. */
+/* Only a pill that leads somewhere answers to a pointer: a display-only one
+   (status.linked: false) is not a control. */
 .card-foot a.status-pill:hover { background: var(--accent-ink); border-color: var(--accent-ink); color: var(--card); }
 a.status-pill:hover { color: var(--fg); border-color: color-mix(in oklab, var(--accent) 40%, var(--border)); }
 a.status-pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .card .status-pill { flex: none; }
-/* Raised above the card's stretched link so a click reaches the status page
-   instead of the service. A display-only pill stays underneath, and the click
-   opens the service like anywhere else on the card. */
+/* Raised above the card's stretched link so a click reaches the status page. A
+   display-only pill stays underneath and the click opens the service. */
 .card a.status-pill { position: relative; z-index: 1; }
 
 .status-pill .dot { width: .55rem; height: .55rem; flex: none; border-radius: 50%; }
@@ -801,9 +771,8 @@ a.status-pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 
 .status-down { border-color: color-mix(in oklab, var(--down) 35%, var(--border)); }
 .status-degraded .dot { background: var(--degraded); }
 /* Blue against green is the pairing hardest to tell apart, and the dot is nine
-   pixels across. The label already carries the meaning without colour, which is
-   what 1.4.1 asks; the square is the redundancy for the glance rather than the
-   read. */
+   pixels across. The label carries the meaning without colour, which is what
+   1.4.1 asks; the square is the redundancy for the glance. */
 .status-maintenance .dot { background: var(--maintenance); border-radius: 1px; }
 .status-unknown .dot { background: transparent; box-shadow: inset 0 0 0 1.6px var(--muted); }
 
@@ -818,11 +787,10 @@ a.status-pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 
 /* ---- detail page ---- */
 
 .detail { max-width: 44rem; margin-inline: auto; padding-block: 1.4rem 1rem; }
-/* The way back out of a detail page. It was a bare text link 51 by 23, under
-   the 24 by 24 WCAG 2.2 asks of a target, and its arrow was a CSS ::before,
-   which some screen readers read out and a stylesheet that fails to load takes
-   with it. It is a chip now, the same rounded outline the pills and the flag
-   already wear, with the arrow inline in the markup as decoration. */
+/* The way back out of a detail page. As a bare text link it measured 51 by 23,
+   under the 24 by 24 WCAG 2.2 asks of a target, and its arrow was a CSS
+   ::before, which some screen readers read out and a stylesheet that fails to
+   load takes with it. A chip now, with the arrow inline in the markup. */
 .back {
   display: inline-flex;
   align-items: center;
@@ -846,16 +814,15 @@ a.status-pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 
 .detail-head .tile img { width: 2.3rem; height: 2.3rem; }
 .detail-head .tile svg { width: 2rem; height: 2rem; }
 .detail-title { display: flex; flex-direction: column; gap: .6rem; align-items: flex-start; }
-/* No card here, so no badge: the state sits under the title where the pill
-   lives, and shares its row. On a line of its own it read as an orphan. The
-   pill leads: it is the heavier object, and small caps read better trailing it
-   than leading it. */
+/* No card here, so no badge: the state shares the pill's row under the title.
+   On a line of its own it read as an orphan, and the pill leads as the heavier
+   object. */
 .detail-state-row { display: flex; align-items: center; gap: .7rem; flex-wrap: wrap; }
-/* A rule between them, saying the two are different kinds of claim: one was
-   measured, one was declared. Only when something is actually to its left,
-   though. A disabling state has no pill at all, and a slot the monitor has not
-   answered yet is empty, and either would leave a stroke hanging off nothing.
-   :empty is live, so the rule arrives with the pill status.js swaps in. */
+/* A rule between them: one claim was measured, the other declared. Only when
+   the slot before it holds something, though. A disabling state has no pill,
+   and a slot the monitor has not answered yet is empty, and either would leave
+   a stroke hanging off nothing. :empty is live, so the rule arrives with the
+   pill status.js swaps in. */
 .detail-state-row .status-slot:not(:empty) + .detail-state {
   padding-inline-start: .8rem;
   border-inline-start: 1px solid var(--border);
@@ -906,9 +873,8 @@ a.status-pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 
   box-shadow: var(--shadow);
   transition: transform .15s, box-shadow .15s;
 }
-/* Sized in em so it follows the label rather than a fixed pixel value, and
-   mirrored right-to-left the way the back arrow is: an arrow leaving its
-   frame points the other way when the text does. */
+/* Sized in em so it follows the label, and mirrored under RTL like the back
+   arrow: an arrow leaving its frame points the other way when the text does. */
 .btn-glyph { width: 1.05em; height: 1.05em; flex: none; }
 [dir="rtl"] .btn-glyph { transform: scaleX(-1); }
 
@@ -916,10 +882,9 @@ a.status-pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 
 .btn:focus-visible { outline: 2px solid var(--fg); outline-offset: 2px; }
 
 /* ---- leaving the site ----
-   A native <dialog>, so ::backdrop, the focus trap and Escape are the
-   browser's job. Nothing here positions it: a modal dialog is centred by the
-   UA already, and reproducing that by hand is how a dialog ends up off screen
-   on a short viewport. */
+   A native <dialog>, so ::backdrop, the focus trap and Escape are the browser's
+   job. Nothing here positions it: a modal dialog is centred by the UA already,
+   and reproducing that by hand puts it off screen on a short viewport. */
 .leave {
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -932,10 +897,9 @@ a.status-pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 
 .leave::backdrop { background: light-dark(rgba(20, 30, 28, .38), rgba(0, 0, 0, .62)); }
 .leave h2 { font-family: var(--font-display); font-size: 1.25rem; margin: 0 0 .6rem; }
 .leave-body { margin: 0 0 1rem; color: var(--muted); }
-/* The address, and the reason it is split in two: the origin is the part
-   that says who you are about to talk to, and a long path is very good at
-   pushing it out of sight. anywhere, not break-all, so a hostname breaks at
-   its dots rather than mid-label. */
+/* The address, split in two because the origin says who you are about to talk
+   to and a long path pushes it out of sight. anywhere, not break-all, so a
+   hostname breaks at its dots rather than mid-label. */
 .leave-url {
   margin: 0 0 1.4rem;
   padding: .7rem .9rem;
@@ -947,14 +911,14 @@ a.status-pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 
 .leave-host { font-weight: 600; }
 .leave-rest { color: var(--muted); }
 .leave-acts { display: flex; flex-wrap: wrap; gap: .6rem; align-items: center; }
-/* The two that are not the primary action read as buttons rather than as
-   links, and they clear 24px in both directions without a chip's ceremony. */
+/* The two that are not the primary action read as buttons rather than links,
+   and clear 24px in both directions without a chip's ceremony. */
 .leave-copy, .leave-stay {
   font: inherit;
   min-height: 2.5rem;
   padding: .55rem 1rem;
-  /* --ui-border, not --border: this outline is the only thing saying these
-     two are controls, which is the case 1.4.11 asks 3:1 for. */
+  /* --ui-border, not --border: this outline is the only thing saying these two
+     are controls, which is the case 1.4.11 asks 3:1 for. */
   border: 1px solid var(--ui-border);
   border-radius: .55rem;
   background: transparent;
@@ -964,26 +928,16 @@ a.status-pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 
 .leave-copy:hover, .leave-stay:hover { background: var(--bg); }
 .leave-copy:focus-visible, .leave-stay:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 /* The continue link borrows .btn, which carries a 1.4rem top margin for the
-   detail page it was drawn for; in a row of buttons that margin is a step. */
+   detail page; in a row of buttons that margin is a step. */
 .leave-acts .btn { margin-top: 0; margin-inline-start: auto; }
-/* Narrow: stack them, each filling the row.
-
-   The row above is a wide-screen idea and it does not degrade, it breaks. The
-   auto margin parks the primary at the far end, which reads well until the row
-   wraps: at 390px Continue landed alone on a second line shoved right, with
-   dead space beside it, and at 320px all three sat at three different widths
-   with the last still offset. Measured, both.
-
-   44rem rather than the width where three buttons stop fitting, because that
-   width is a property of the words in them: "Copy the address" and "Adresse
-   kopieren" wrap at different viewports, and a breakpoint tuned to English
-   would be wrong in six other languages. This is the breakpoint the rest of
-   the site already turns on, and above it the row always fits.
-
-   Order is left alone on purpose. A column-reverse would put the primary on
-   top while the keyboard still tabs copy, stay, continue, which trades 2.4.3
-   for a layout. Stacked in reading order the primary lands at the bottom,
-   nearest the thumb, which is where a phone wants it anyway. */
+/* Narrow: stack them, each filling the row. The auto margin above parks the
+   primary at the far end, which breaks once the row wraps: measured at 390px,
+   Continue landed alone on a second line with dead space beside it, and at
+   320px all three sat at three different widths. 44rem rather than the width
+   where three buttons stop fitting: that width is a property of the words in
+   them, and a breakpoint tuned to English would be wrong in six other
+   languages. The order stays: column-reverse would put the primary on top while
+   the keyboard still tabs copy, stay, continue, trading 2.4.3 for a layout. */
 @media (max-width: 44rem) {
   .leave-acts { flex-direction: column; align-items: stretch; }
   .leave-acts .btn { margin-inline-start: 0; justify-content: center; }
@@ -1012,12 +966,12 @@ a.status-pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 
 .page { padding-bottom: 2.5rem; }
 .page-intro { color: var(--muted); }
 .page-sec { margin-top: 2rem; }
-/* The section label, worn by the hosted page's own section titles and by a
-   markdown ## alike. Child, not descendant, on .detail, or it would also
-   repaint the .page-sec titles nested inside and hand them a top margin the
-   section already provides. The [lang] step is the wrapper the prose template
-   adds when a field falls back to another language: without it, exactly the
-   pages that need the most help rendered their headings as browser defaults. */
+/* The section label, worn by a hosted page's own section titles and by a
+   markdown ## alike. Child, not descendant, on .detail, or it repaints the
+   .page-sec titles nested inside and hands them a top margin the section
+   already provides. The [lang] step is the wrapper the prose template adds when
+   a field falls back to another language: without it, exactly the pages that
+   need the most help rendered their headings as browser defaults. */
 .page-sec h2,
 :is(.detail, .detail > [lang]) > h2,
 .about h2 {
@@ -1042,84 +996,72 @@ a.status-pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 
 
 /* ---- rich text (markdown) ----
 
-   Three containers, one scope. .about is the welcome note, .detail is a
-   service page, and a hosted page is <article class="detail page">, so
-   :is(.about, .detail) already reaches all three and everything below follows
-   it rather than styling bare elements, which would leak into the header, the
-   cards and the footer.
+   Three containers, one scope. .about is the welcome note, .detail is a service
+   page, and a hosted page is <article class="detail page">, so
+   :is(.about, .detail) reaches all three. Everything below follows it rather
+   than styling bare elements, which would leak into the header, the cards and
+   the footer. */
 
-   The voice is deliberately quiet: cairn is a directory page, and prose is the
-   short note beside the links, not the point of the site. */
-
-/* Long unbreakable words are what push a page sideways: a linkified bare URL,
-   a path in inline code, an id in a table cell. break-word (not anywhere)
-   breaks only the word that would otherwise overflow and leaves min-content
-   widths alone, so tables still size themselves the way tables do. */
+/* Long unbreakable words push a page sideways: a linkified bare URL, a path in
+   inline code, an id in a table cell. break-word, not anywhere: it breaks only
+   the word that would overflow and leaves min-content widths alone, so tables
+   still size themselves the way tables do. */
 :is(.about, .detail) { overflow-wrap: break-word; }
 
-/* Was :is(p, li, figcaption) a, which is where the prose used to live. A link
-   in a table cell or in a heading then got no accent and only the browser's
-   default underline, and the same descendant rule reached down into <p><a
-   class="back">, repainting the quiet back link accent and underlined against
-   its own rule. Scope by container, and name the three anchors inside these
-   articles that are controls rather than prose. */
+/* Scoped by container, not by :is(p, li, figcaption) a: that left a link in a
+   table cell or a heading with the browser's default underline and no accent,
+   and it reached down into <p><a class="back">, repainting the quiet back link
+   against its own rule. The three anchors named here are controls, not prose. */
 :is(.about, .detail) a:not(.btn, .back, .status-pill) {
   color: var(--accent-ink);
   text-decoration: underline;
   text-underline-offset: 2px;
 }
 
-/* Headings. h2 keeps the small uppercase section label set further up, which
-   is the house voice for "a new section starts here" and is what ## has
-   rendered as all along; the rest of the scale is built to sit around it.
+/* Headings. h2 keeps the small uppercase section label set further up, which is
+   what ## has rendered as all along, and the rest of the scale sits around it.
    Left to the browser, h1 came out as 2em of bold body font, louder than the
-   page's own title right above it, and h6 came out smaller than body text.
-   h4 down collapse into one rule: a directory page has no use for four more
-   sizes, and giving them one keeps the deep ones legible. */
-/* No h1 here on purpose, and no rule for one: the renderer demotes a single #
-   to a level two, because the page already has its own top heading. A style
-   for an element that can no longer be emitted would read as a promise. */
+   page's own title right above it, and h6 smaller than body text. h4 down share
+   one rule: a directory page has no use for four more sizes.
+   No h1 rule: the renderer demotes a single # to a level two, since the page
+   already has its own top heading. */
 :is(.about, .detail) :is(h3, h4, h5, h6) { margin: 1.7rem 0 .5rem; line-height: 1.3; }
 :is(.about, .detail) h3 { font-size: 1rem; font-weight: 650; }
 :is(.about, .detail) :is(h4, h5, h6) { font-size: .95rem; font-weight: 600; color: var(--muted); }
 
-/* The note's own padding sets its top edge. Without this, a note opening with
-   a heading got the padding and the heading's margin one after the other and
-   sat visibly lower in the card than one opening with a paragraph; padding
-   does not collapse with a child's margin. The dismiss button is absolutely
-   positioned, so the first block of prose is whatever follows it, and one
-   step further in when the note fell back to another language and the prose
-   template wrapped it to say so. */
+/* The note's own padding sets its top edge: padding does not collapse with a
+   child's margin, so a note opening with a heading got both one after the other
+   and sat visibly lower than one opening with a paragraph. The dismiss button
+   is absolutely positioned, so the first block of prose is whatever follows it,
+   one step further in when the prose template wrapped a fallback language. */
 .about > .about-x + *,
 .about > [lang] > :first-child { margin-top: 0; }
-/* Space below the last block is the card's padding to give. p:last-of-type
-   used to say this and now says something else entirely: with lists and
-   tables in the mix the last <p> is often mid-note, and every paragraph that
-   ended a list item or a quote matched it too and lost its spacing. */
+/* Space below the last block is the card's padding to give. p:last-of-type used
+   to say this: with lists and tables in the mix the last <p> is often mid-note,
+   and every paragraph ending a list item or a quote matched it too. */
 :is(.about, .about > [lang]) > :last-child { margin-bottom: 0; }
 
 :is(.about, .detail) ul { margin: 0 0 .9rem; padding-inline-start: 1.15rem; }
-/* ol had no rule at all, so it kept the browser's 40px indent and sat visibly
-   further in than the ul above it. Wider than the ul because the marker is
-   drawn in this padding and a two-digit number needs the room. */
+/* Without a rule, ol kept the browser's 40px indent and sat visibly further in
+   than the ul above it. Wider than the ul because the marker is drawn in this
+   padding and a two-digit number needs the room. */
 :is(.about, .detail) ol { margin: 0 0 .9rem; padding-inline-start: 1.6rem; }
 :is(.about, .detail) li { line-height: 1.7; margin-bottom: .3rem; }
 :is(.about, .detail) li::marker { color: var(--accent-ink); }
-/* A nested list closes with the item that holds it. It was inheriting the
-   margin-bottom above, which left a blank line inside the parent item. */
+/* A nested list closes with the item that holds it: inheriting the margin-bottom
+   above left a blank line inside the parent item. */
 :is(.about, .detail) li :is(ul, ol) { margin-block: .25rem 0; }
 
-/* GFM task lists. goldmark marks these with the checkbox and nothing else, no
-   class to hook, so the item is found by what it holds: without this the
-   bullet stayed and the item read as two markers side by side. The box hangs
-   back into the list's own indent, so wrapped lines line up under the text
-   rather than under the box. */
+/* GFM task lists. goldmark marks these with the checkbox and no class to hook,
+   so the item is found by what it holds: without this the bullet stayed and the
+   item read as two markers side by side. The box hangs back into the list's own
+   indent, so wrapped lines line up under the text rather than under the box. */
 :is(.about, .detail) li:has(> input[type="checkbox"]) { list-style: none; }
 :is(.about, .detail) li > input[type="checkbox"] { margin-inline: -1.15rem .35rem; }
 
-/* A quote reads as a quote by its rule, not by an indent. goldmark's
-   blockquote arrives with the browser's bare 40px margins, so a quote that
-   followed a list looked like one more level of that list. */
+/* A quote reads as a quote by its rule, not by an indent: goldmark's blockquote
+   arrives with the browser's bare 40px margins, so a quote after a list looked
+   like one more level of it. */
 :is(.about, .detail) blockquote {
   margin: 0 0 .9rem;
   padding-inline-start: 1rem;
@@ -1132,10 +1074,9 @@ a.status-pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 
    widget; this is the hairline the header rule and the waypoints already use. */
 :is(.about, .detail) hr { margin: 1.6rem 0; border: 0; border-top: 1px solid var(--border); }
 
-/* The chrome below is for a word inside a sentence. As a descendant selector
-   it also caught every <code> inside a <pre>, and a fenced block came out as a
-   stack of bordered, padded boxes, one per painted line. The block owns the
-   chrome now and the code inside it owns none. */
+/* The chrome below is for a word inside a sentence. As a descendant selector it
+   also caught every <code> inside a <pre>, and a fenced block came out as a
+   stack of bordered, padded boxes, one per painted line. */
 :is(.about, .detail) code {
   font-size: .88em;
   background: var(--faint);
@@ -1149,12 +1090,10 @@ a.status-pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 
   background: var(--faint);
   border: 1px solid var(--border);
   border-radius: .6rem;
-  /* A fenced block is the one run of text nobody can rewrap, so it scrolls
-     itself rather than pushing the whole page sideways. */
+  /* a fenced block cannot be rewrapped, so it scrolls rather than the page */
   overflow-x: auto;
-  /* Sized rather than left alone: monospace at the browser's default size
-     draws a visible step smaller than the prose around it, and the two would
-     not agree on what one line is worth. */
+  /* Sized rather than left alone: monospace at the browser's default draws a
+     visible step smaller than the prose around it. */
   font-size: .88em;
   line-height: 1.55;
 }
@@ -1166,14 +1105,9 @@ a.status-pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 
   font-size: inherit;
 }
 
-/* Tables. goldmark emits a bare <table> with no wrapper, and a table is the
-   one block that cannot rewrap: enough columns and it pushed the document
-   sideways on a phone. display:block makes the table its own scroll
-   container, which is the only way to get one without an element to wrap it
-   in. The cost is real and worth naming: some engines read the table role off
-   the computed display, so a wrapper <div> in the renderer is the fix that
-   does not pay it. Chromium keeps the role either way. */
-/* The wrapper scrolls, not the table. display:block on a <table> is the usual
+/* Tables. goldmark emits a bare <table> with no wrapper, and a table cannot
+   rewrap: enough columns and it pushed the document sideways on a phone. The
+   wrapper scrolls, not the table: display:block on a <table> is the usual
    one-liner and it strips the table role from the accessibility tree in Chrome
    and Safari, so the cells stop being announced as a table. The renderer emits
    this div with tabindex, because a region that scrolls has to be reachable
@@ -1192,21 +1126,20 @@ a.status-pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 
   padding: .45rem .7rem;
   border-bottom: 1px solid var(--border);
   /* Cells opt out of the break-word above: the table has a scroll container of
-     its own, so a long path or an env var keeps its shape and the table
-     scrolls. Left in, one id squeezed its whole column into a ladder of broken
-     syllables while the rest of the table sat half empty. */
+     its own, so a long path or an env var keeps its shape. Left in, one id
+     squeezed its whole column into a ladder of broken syllables while the rest
+     of the table sat half empty. */
   overflow-wrap: normal;
 }
 /* The browser centres a header cell. Only the ones GFM did not align, or this
-   would beat the align attribute: an attribute is a presentational hint, and
-   any author rule at all outranks it. */
+   beats the align attribute: a presentational hint loses to any author rule. */
 :is(.about, .detail) th:not([align]) { text-align: start; }
 :is(.about, .detail) thead th { color: var(--muted); }
 
 /* An image written inside a sentence carries the intrinsic width the media
-   resolver measured, so a 512px screenshot ran straight off a 340px column.
-   height:auto is the other half: cap the width attribute and leave the height
-   attribute alone and the picture comes out squashed. */
+   resolver measured, so a 512px screenshot ran off a 340px column. height:auto
+   is the other half: cap the width and leave the height attribute alone and the
+   picture comes out squashed. */
 :is(.about, .detail) :is(p, li, td, th) img { max-width: 100%; height: auto; }
 
 /* ---- empty state ---- */
@@ -1235,8 +1168,7 @@ footer {
 .powered { display: inline-flex; align-items: center; gap: .45rem; margin-inline-start: auto; font-size: .82rem; color: var(--muted); }
 .powered .foot-mark { width: .95rem; height: .95rem; }
 .powered a { color: var(--accent-ink); font-weight: 500; }
-/* the optional build stamp: present for whoever needs it, quiet enough that
-   the footer still reads as one line */
+/* the optional build stamp, quiet enough that the footer still reads as one line */
 .foot-version { font-size: .95em; color: var(--muted); font-variant-numeric: tabular-nums; }
 .powered a.foot-version { color: var(--muted); font-weight: 400; }
 .powered a.foot-version:hover { color: var(--fg); }
@@ -1248,10 +1180,9 @@ footer {
   position: absolute;
   inset-inline-start: -999px;
   top: .5rem;
-  /* Above the header, which is sticky at z-index 40 on narrow screens: at 2
-     the first Tab stop was painted over and the skip link, whose whole job is
-     to be seen first, was invisible on a phone. */
-  z-index: 41;
+  /* one above the sticky header: at 2 the first Tab stop was painted over and
+     the skip link, whose whole job is to be seen first, was invisible */
+  z-index: calc(var(--z-header) + 1);
   padding: .5rem 1rem;
   background: var(--card);
   border: 1px solid var(--border);
@@ -1275,10 +1206,8 @@ footer {
   * { transition: none !important; animation: none !important; }
 }
 
-/* ---- print: the version that ends up on the fridge ---- */
-
-/* back-to-top: a fixed pill, mobile-only, shown once you have scrolled a
-   screen (where scroll-driven animations exist; otherwise always on). */
+/* back-to-top: a fixed pill, mobile only, revealed by nav.js past a screen of
+   scroll. */
 .totop {
   display: none;
   position: fixed;
@@ -1308,18 +1237,18 @@ footer {
   html { scroll-behavior: smooth; }
 }
 
-/* ---- mobile (below 44rem): a burger for the header links (the search stays
-   put), the category trail as a wrapping chip row, finger-sized targets, a
-   one-column footer, and the back-to-top button. ---- */
+/* ---- mobile (below 44rem): a burger for the header links, the category trail
+   as a wrapping chip row, finger-sized targets, a one-column footer, and the
+   back-to-top button ---- */
 @media (max-width: 44rem) {
   .wrap { padding-inline: 1.15rem; }
 
   /* auto-hiding sticky header: nav.js toggles .header-hidden by scroll
-     direction (down hides, up shows), so a long page keeps search in reach */
+     direction, so a long page keeps search in reach */
   header {
     position: sticky;
     top: 0;
-    z-index: 40;
+    z-index: var(--z-header);
     padding-block: .9rem;
     background: var(--bg);
     border-bottom: 1px solid var(--border);
@@ -1328,8 +1257,8 @@ footer {
   header.header-hidden { transform: translateY(-100%); }
   .cat { scroll-margin-top: 4.5rem; }
 
-  /* the header links fold behind a burger; the search stays visible beside it.
-     Drop the desktop divider and even the rhythm so the row sits centered. */
+  /* the header links fold behind a burger, the search stays beside it, and the
+     desktop divider goes so the row sits centered */
   .menu { flex-wrap: nowrap; align-items: center; gap: .6rem; margin-top: .9rem; padding-block: 0; border-top: 0; }
   .nav { display: inline-flex; position: relative; flex: none; }
   .nav-burger {
@@ -1382,13 +1311,13 @@ footer {
   .theme-toggle { width: 2.75rem; height: 2.75rem; }
   .langs a { display: inline-flex; align-items: center; min-height: 2.75rem; }
   .search-box input { padding-block: .55rem; }
-  /* 44px for the thumb, and still a disc: the width is capped by the fold, so
-     raising the height alone left a 30 by 44 oval with the cross 3px from the
-     clip. Same arithmetic as the desktop rule, at this height. */
+  /* 44px for the thumb, and still a disc: the fold caps the width, so raising
+     the height alone left a 30 by 44 oval with the cross 3px from the clip. */
   .about-x {
-    height: 2.75rem;
-    max-width: 2.75rem;
-    padding-inline: calc(.975rem - 1px);
+    --x-disc: 2.75rem;
+    height: var(--x-disc);
+    max-width: var(--x-disc);
+    padding-inline: calc((var(--x-disc) - var(--x-glyph)) / 2 - 1px);
   }
 
   /* the category trail becomes a wrapping chip row under the intro */
@@ -1412,12 +1341,11 @@ footer {
   }
 
   /* Above ~7 categories the chips give way to a compact jump-to select, but
-     only where something can drive it: the select's entire behaviour lives in
+     only where something can drive it: the select's behaviour lives entirely in
      nav.js, so with JavaScript off this swap left a phone with no category
-     navigation at all, on the viewport where the list matters most. The
-     pre-paint script in <head> stamps data-js before first render, so gating
-     on it costs no flash of the wrong one, and the fallback needs no markup:
-     .toc.many simply stays a chip row. */
+     navigation at all. The pre-paint script in <head> stamps data-js before
+     first render, so gating on it costs no flash of the wrong one, and the
+     fallback needs no markup: .toc.many stays a chip row. */
   [data-js] .toc.many { display: none; }
   [data-js] .toc-jump { display: block; margin: 1.5rem 0 .3rem; }
   .toc-select {
@@ -1425,8 +1353,7 @@ footer {
     max-width: 22rem;
     min-height: 2.75rem;
     padding: .3rem .9rem;
-    /* a form control, so its boundary is the control: --ui-border, not
-       --border, for the same 3:1 reason as the search box */
+    /* a form control, so --ui-border and its 3:1, like the search box */
     border: 1px solid var(--ui-border);
     border-radius: .7rem;
     background: var(--card);
@@ -1435,10 +1362,8 @@ footer {
     font-size: .9rem;
   }
 
-  /* nav.js reveals the back-to-top button (via .show) past a screen of scroll */
   .totop { display: grid; }
 
-  /* footer: one clean column, logo grouped with the credit */
   .foot { flex-direction: column; align-items: flex-start; gap: 1.1rem; padding-block: 1.6rem 2rem; }
   .foot-links { flex-direction: column; gap: .9rem; }
   .powered { margin-inline-start: 0; }
@@ -1463,15 +1388,14 @@ footer {
     word-break: break-all;
   }
   .shot { break-inside: avoid; }
-  /* On screen a fenced block and a wide table scroll. Paper does not scroll,
-     so whatever hung off the right edge would simply be missing: the block
-     wraps instead, and the table goes back to being laid out as a table. */
+  /* Paper does not scroll, so whatever hung off the edge would simply be
+     missing: the block wraps instead, and the table is laid out as a table. */
   :is(.about, .detail) pre { overflow-x: visible; white-space: pre-wrap; }
   :is(.about, .detail) .table-wrap { overflow-x: visible; }
   :is(.about, .detail) table { width: 100%; }
 }
 
-/* Right-to-left: the layout follows from the logical properties above, only
-   the two literal arrows have to be turned around by hand. */
-/* One glyph, mirrored, rather than a second character to keep in step. */
+/* Right-to-left follows from the logical properties above; only the two literal
+   arrows are turned around by hand, one glyph mirrored rather than a second
+   character to keep in step. */
 [dir="rtl"] .back-glyph { transform: scaleX(-1); }

--- a/src/internal/render/assets/theme.js
+++ b/src/internal/render/assets/theme.js
@@ -7,17 +7,14 @@
   const dark = () => (root.dataset.theme
     ? root.dataset.theme === 'dark'
     : matchMedia('(prefers-color-scheme: dark)').matches);
-  // A toggle that never says whether it is pressed is a button and no state to
-  // a screen reader (WCAG 4.1.2). Pressed means dark. The server cannot render
+  // A toggle that never says whether it is pressed reads as a plain button to a
+  // screen reader (WCAG 4.1.2); pressed means dark. The server cannot render
   // it: the button ships hidden, and by the time it is revealed the pre-paint
-  // script may already have applied a stored theme, so only here is the
-  // current one known.
-  // A themed favicon is the one piece of artwork this stylesheet cannot
-  // reach, so it ships as a second <link> whose media query answers to the
-  // system. Pressing the button has to override that the way it overrides
-  // everything else, and the only handle is the query itself: "all" always
-  // matches, "not all" never does, and dropping back to the original hands
-  // the decision to the system again.
+  // script may already have applied a stored theme.
+  // The favicon is the one piece of artwork the stylesheet cannot reach, so it
+  // ships as a second <link> whose media query answers to the system. The only
+  // handle on it is the query itself: "all" always matches, "not all" never
+  // does, and the original hands the decision back to the system.
   const favDark = document.querySelector('link[rel="icon"][media]');
   const favQuery = favDark && favDark.media;
   const syncFavicon = () => {

--- a/src/internal/render/assets/toc.js
+++ b/src/internal/render/assets/toc.js
@@ -10,8 +10,7 @@
 
   const spy = () => {
     const visible = sections.filter(s => !s.hidden);
-    // active: the last section whose top has crossed the upper viewport,
-    // or the final one once the page bottom is reached
+    // the last section whose top has crossed, or the final one at page bottom
     let active = visible[0];
     for (const s of visible) {
       if (s.getBoundingClientRect().top <= innerHeight * 0.4) active = s;

--- a/src/internal/render/asseturl.go
+++ b/src/internal/render/asseturl.go
@@ -8,32 +8,20 @@ import (
 	"strings"
 )
 
-// Assets are served under a name that carries a digest of what is inside them,
-// so `style.css` goes out as `style.a1b2c3d4.css`.
+// Assets carry a digest of their own bytes in their name: style.a1b2c3d4.css.
+// Pages are no-cache and update on restart, so before this an upgrade left the
+// new page pointing at yesterday's cached stylesheet until a hard refresh.
 //
-// The problem it solves is the one an operator meets on every upgrade: pages
-// are served no-cache and update the moment cairn restarts, while the
-// stylesheet beside them was cached for a day under a name that never changes.
-// The page was new, the CSS was yesterday's, and only a hard refresh fixed it.
+// A name that changes with the bytes is what makes a year-long cache safe:
+// nothing is ever replaced under the same name. In the name rather than in a
+// query string, because a query leaves an intermediary free to key its cache
+// on the path alone and pin the stale file for that whole year.
 //
-// Since the name changes exactly when the bytes change, the page that points
-// at it is already fresh, and a browser meeting a name it has never seen has
-// no choice but to fetch it. That is also what makes it safe to cache these
-// for a year: nothing has to expire, because nothing is ever replaced under
-// the same name.
-//
-// The digest is in the name rather than in a query string on purpose. A query
-// is easier to write, and it leaves an intermediary free to key its cache on
-// the path alone, which would pin a stale file for the whole year rather than
-// for a day. A different name is a different object to everything in the path.
-//
-// One gap, named rather than hidden: the display font keeps its plain name.
-// The stylesheet reaches it with a relative url(), and no stamping here can
-// follow into a CSS file's own bytes, so stamping the <link rel=preload> alone
-// would leave the two pointing at different urls and the browser fetching 64
-// KB twice, having preloaded a file the stylesheet then does not ask for.
-// Covering it properly means rewriting the stylesheet on the way out; it has
-// changed once in the project's life, so it waits until that is worth it.
+// The display font keeps its plain name. The stylesheet reaches it with a
+// relative url(), which no stamping out here can follow into, so stamping the
+// preload alone would make the two disagree and fetch 64 KB twice. Covering it
+// means rewriting the stylesheet on the way out, and the font has changed once
+// in the project's life.
 var (
 	assetURL  = map[string]string{} // style.css -> style.a1b2c3d4.css
 	assetReal = map[string]string{} // style.a1b2c3d4.css -> style.css
@@ -55,10 +43,8 @@ func init() {
 			return nil
 		}
 		sum := sha256.Sum256(b)
-		// Eight hex is 32 bits. This is a cache key, not a security boundary:
-		// the file it names is decided by the table below, so a collision
-		// would serve one of two files cairn itself ships, and never anything
-		// an outsider chose.
+		// 32 bits, a cache key and not a security boundary: a collision picks
+		// between two files cairn itself ships, never one an outsider chose.
 		digest := hex.EncodeToString(sum[:4])
 		ext := path.Ext(name)
 		stamped := strings.TrimSuffix(name, ext) + "." + digest + ext
@@ -68,9 +54,8 @@ func init() {
 	})
 }
 
-// AssetURL is the path a page should point at for one of cairn's own assets.
-// A name cairn does not ship comes back untouched, so a typo arrives at the
-// 404 it deserves instead of resolving to something else.
+// AssetURL returns the stamped path for one of cairn's own assets. A name
+// cairn does not ship comes back untouched, so a typo reaches its 404.
 func AssetURL(name string) string {
 	if stamped, ok := assetURL[name]; ok {
 		return BasePath + "/static/" + stamped
@@ -78,24 +63,20 @@ func AssetURL(name string) string {
 	return BasePath + "/static/" + name
 }
 
-// AssetPath turns a stamped name back into the file to open, and refuses a
-// digest cairn did not issue. The plain name is deliberately not resolved
-// here: the file server still answers it directly, on the shorter cache, so
-// anything that hardcoded /static/style.css goes on working.
+// AssetPath turns a stamped name back into the file to open and refuses a
+// digest cairn did not issue. Plain names are not resolved here: the file
+// server answers those directly on the shorter cache, so anything that
+// hardcoded /static/style.css goes on working.
 func AssetPath(stamped string) (string, bool) {
 	real, ok := assetReal[stamped]
 	return real, ok
 }
 
-// stampStatic rewrites a root-absolute path naming one of cairn's own assets
-// into the stamped form, and leaves everything else exactly as it was.
-//
-// It exists because the touch icon and the manifest's icons are built in Go
-// rather than written in a template, so they never met the asset function and
-// went out unstamped: an operator who changed cairn's icon set had every
-// visitor keep the old one for a day, for no reason the font's had. An
-// operator's own icon is not touched, because cairn does not ship those bytes
-// and has no digest of them to offer.
+// stampStatic rewrites a root-absolute path naming one of cairn's own assets,
+// and leaves everything else alone. The touch icon and the manifest icons are
+// built in Go rather than in a template, so they never meet the asset function
+// and would otherwise go out unstamped. An operator's own icon is left as is:
+// cairn does not ship those bytes and has no digest to offer.
 func stampStatic(p string) string {
 	name, ok := strings.CutPrefix(p, "/static/")
 	if !ok {

--- a/src/internal/render/markdown.go
+++ b/src/internal/render/markdown.go
@@ -2,29 +2,24 @@ package render
 
 // cairn renders the long text fields (about, pages, details) with goldmark:
 // CommonMark plus the GFM extensions (tables, strikethrough, autolinks, task
-// lists). Three things are narrowed from goldmark's defaults on purpose, and
-// each has its own test because losing one silently is the failure mode here:
+// lists). Three things are narrowed from goldmark's defaults, each with its own
+// test, since losing one silently is the failure mode here:
 //
 //   - Raw HTML is not a syntax. The HTML block parser and the inline raw-HTML
 //     parser are taken out of the parser, so "<b>x</b>" written in a config
 //     field is ordinary text and comes out escaped, rather than as markup
 //     (goldmark with WithUnsafe) or as goldmark's "<!-- raw HTML omitted -->"
-//     comment, which would swallow what the operator wrote. A config file can
-//     never break the page or the CSP.
-//   - Link schemes are an allow-list, not goldmark's deny-list. goldmark
-//     blanks the href of javascript:, vbscript:, file: and non-image data:
-//     URLs and lets everything else through, so ftp:, tel:, chrome: or any
-//     invented scheme would become live links. cairn keeps what a directory
-//     page has a reason to link: http, https, mailto and anything scheme-less
-//     (paths, anchors, relative). Anything else renders as the words the
-//     writer wrote, with no anchor around them.
+//     comment, which swallows what the operator wrote. A config file cannot
+//     break the page or the CSP.
+//   - Link schemes are an allow-list, not goldmark's deny-list. goldmark blanks
+//     the href of javascript:, vbscript:, file: and non-image data: URLs and
+//     lets everything else through, so ftp:, tel:, chrome: or any invented
+//     scheme would become a live link. cairn keeps http, https, mailto and
+//     anything scheme-less (paths, anchors, relative); the rest renders as the
+//     words the writer wrote, with no anchor around them.
 //   - An image alone in a block is a <figure class="shot"> carrying the width
 //     and height the media resolver knows, so the page does not jump while the
-//     image loads. goldmark would render a bare inline <img> inside a <p>.
-//
-// Everything else is goldmark's own output, which is the point of the change:
-// headings, ordered and nested lists, blockquotes, code blocks, rules and
-// tables used to render as literal text.
+//     image loads. goldmark renders a bare inline <img> inside a <p>.
 
 import (
 	"bytes"
@@ -45,26 +40,22 @@ import (
 	"github.com/yuin/goldmark/util"
 )
 
-// mdCtx carries the per-render options: the css class of plain paragraphs
-// and the image resolver (src -> url, width, height; 0x0 when unknown).
+// mdCtx carries the per-render options: the css class of plain paragraphs and
+// the image resolver, which answers src -> url, width, height, and 0x0 when it
+// does not know the size.
 type mdCtx struct {
 	pClass string
 	media  func(string) (string, int, int)
 }
 
-// mdCtxKey hands one mdCtx to the AST transformer. The goldmark instance is
-// built once and shared, so the per-field options travel with the parse rather
-// than with the parser, and the transformer resolves media sizes and the
-// paragraph class into the tree while it still has them.
+// The goldmark instance is built once and shared, so the per-field options
+// travel with the parse context rather than with the parser.
 var mdCtxKey = parser.NewContextKey()
 
-// md is the shared converter. The custom renderer sits at priority 100 against
-// goldmark's own at 1000: the lowest number registers last and wins.
 var md = newMarkdown()
 
-// mdParserOptions is the syntax cairn accepts, with the two raw-HTML parsers
-// removed so HTML is text rather than markup. Shared, so the parser that finds
-// image references cannot drift from the one that renders them.
+// mdParserOptions is shared with mdRefParser, so the parser that finds image
+// references cannot drift from the one that renders them.
 func mdParserOptions() []parser.Option {
 	return []parser.Option{
 		parser.WithBlockParsers(mdWithout(parser.DefaultBlockParsers(), parser.NewHTMLBlockParser())...),
@@ -78,22 +69,23 @@ func newMarkdown() goldmark.Markdown {
 		goldmark.WithParser(parser.NewParser(mdParserOptions()...)),
 		goldmark.WithParserOptions(parser.WithASTTransformers(util.Prioritized(mdTransformer{}, 100))),
 		goldmark.WithRendererOptions(
+			// Priority 100 against goldmark's own 1000: the lowest number
+			// registers last and wins.
 			renderer.WithNodeRenderers(util.Prioritized(mdRenderer{}, 100)),
 			// A table column with an alignment renders style="text-align:…" by
-			// default, and cairn's CSP is style-src 'self' with one hash for
-			// the accent block: the browser would drop that attribute and log
-			// a violation on every page. The align attribute says the same
-			// thing, is not a style, and is what CSP has no opinion about.
+			// default, and cairn's CSP is style-src 'self' with one hash for the
+			// accent block: the browser drops that attribute and logs a
+			// violation on every page. The align attribute says the same thing
+			// and is not a style.
 			extension.WithTableCellAlignMethod(extension.TableCellAlignAttribute),
 		),
 		goldmark.WithExtensions(extension.GFM),
 	)
 }
 
-// mdWithout drops one parser from a default list. goldmark hands out the same
-// pointer every time for these, so identity is enough and the rest of the list
-// stays whatever the version we build against says it is: a parser added
-// upstream keeps working, and only the one named here disappears.
+// goldmark hands out the same pointer every time for the default parsers, so
+// identity is enough to drop one and a parser added upstream survives the
+// filter.
 func mdWithout(vs []util.PrioritizedValue, drop any) []util.PrioritizedValue {
 	out := make([]util.PrioritizedValue, 0, len(vs))
 	for _, v := range vs {
@@ -104,9 +96,8 @@ func mdWithout(vs []util.PrioritizedValue, drop any) []util.PrioritizedValue {
 	return out
 }
 
-// mdBlocks renders a field to one HTML string per top-level block. The
-// templates iterate the slice, so a block is still the unit: rendering each
-// child of the document on its own keeps that shape without a second parse.
+// mdBlocks renders a field to one HTML string per top-level block, which is the
+// unit the templates iterate.
 func mdBlocks(src string, ctx mdCtx) []template.HTML {
 	if strings.TrimSpace(src) == "" {
 		return nil
@@ -131,11 +122,9 @@ func mdBlocks(src string, ctx mdCtx) []template.HTML {
 	return out
 }
 
-// mdSafeURL allows the schemes a directory page has a reason to link:
-// anything scheme-less (paths, anchors, relative), http(s) and mailto.
-//
-// This is the whole link policy. goldmark's own IsDangerousURL is a deny-list
-// and would pass ftp:, tel:, chrome: or jar: straight through, so cairn checks
+// mdSafeURL is the whole link policy: anything scheme-less (paths, anchors,
+// relative), http(s) and mailto. goldmark's own IsDangerousURL is a deny-list
+// that passes ftp:, tel:, chrome: and jar: straight through, so cairn checks
 // first and goldmark's check never gets to matter.
 func mdSafeURL(u string) bool {
 	l := strings.ToLower(u)
@@ -147,10 +136,9 @@ func mdSafeURL(u string) bool {
 	return !strings.Contains(u, ":")
 }
 
-// mdFigure is what an image alone in a block becomes. The url and the size are
-// resolved while the transformer still holds the mdCtx; the node's children
-// are the caption, so it keeps whatever inline markup the caption was written
-// with.
+// mdFigure is what an image alone in a block becomes. Its url and size are
+// resolved while the transformer still holds the mdCtx, and its children are
+// the caption, so the caption keeps whatever inline markup it was written with.
 type mdFigure struct {
 	ast.BaseBlock
 	URL  string
@@ -167,10 +155,13 @@ type mdTransformer struct{}
 
 func (mdTransformer) Transform(doc *ast.Document, _ text.Reader, pc parser.Context) {
 	ctx, _ := pc.Get(mdCtxKey).(mdCtx)
+	mdRewriteTopLevelParagraphs(doc, ctx)
+	mdDemoteTopHeadings(doc)
+	mdResolveRemainingImages(doc, ctx)
+}
 
-	// Whole-block images become figures, and every other top-level paragraph
-	// takes the field's paragraph class. Both are top-level only: a paragraph
-	// inside a list item is not the page intro.
+// Top-level only: a paragraph inside a list item is not the page intro.
+func mdRewriteTopLevelParagraphs(doc *ast.Document, ctx mdCtx) {
 	for n := doc.FirstChild(); n != nil; {
 		next := n.NextSibling()
 		if p, ok := n.(*ast.Paragraph); ok {
@@ -182,32 +173,29 @@ func (mdTransformer) Transform(doc *ast.Document, _ text.Reader, pc parser.Conte
 		}
 		n = next
 	}
+}
 
-	// A level-one heading becomes a level two.
-	//
-	// The page already has its <h1>: the site title on the home page, the page
-	// title on a hosted one, the service name on a detail page. A second one
-	// breaks the document outline, and a screen reader user navigating by
-	// heading level lands on two competing tops with no way to tell which is
-	// the page.
-	//
-	// This is not cairn overruling the operator. Someone writing "# Notes" in a
-	// page body wants a heading for their text, not a second title for the
-	// document, and the title they did ask for is the one in the config. Only
-	// the top level moves, so "##" still renders exactly what it always did and
-	// no existing page changes shape. -check says so, because two levels
-	// rendering identically is otherwise a puzzle rather than a rule.
+// The page already has its <h1>: the site title on the home page, the page title
+// on a hosted one, the service name on a detail page. A second one breaks the
+// document outline, and a screen reader user navigating by heading level lands
+// on two competing tops with no way to tell which is the page. Only the top
+// level moves, so "##" renders what it always did and no existing page changes
+// shape. -check reports the demotion, since two levels rendering identically is
+// otherwise a puzzle rather than a rule.
+func mdDemoteTopHeadings(doc *ast.Document) {
 	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if h, ok := n.(*ast.Heading); ok && entering && h.Level == 1 {
 			h.Level = 2
 		}
 		return ast.WalkContinue, nil
 	})
+}
 
-	// Images still inline after that pass resolve the same way, so an image in
-	// the middle of a sentence points at the same file as one on its own line
-	// and carries the same anti-jump attributes. The walk only collects: the
-	// refused ones are edited out of the tree afterwards, not underneath it.
+// Runs after the figure pass, so what is left is inline: an image in the middle
+// of a sentence points at the same file as one on its own line and carries the
+// same anti-jump attributes. The walk only collects, since a refused image is
+// edited out of the tree afterwards rather than underneath the walk.
+func mdResolveRemainingImages(doc *ast.Document, ctx mdCtx) {
 	var imgs []*ast.Image
 	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if img, ok := n.(*ast.Image); ok && entering {
@@ -230,10 +218,10 @@ func (mdTransformer) Transform(doc *ast.Document, _ text.Reader, pc parser.Conte
 	}
 }
 
-// mdFigureOf turns a paragraph holding one image and nothing else into a
-// figure, and answers nil for anything else, including an image the resolver
-// refused: that one falls through to mdUnwrap and keeps its caption as text,
-// the same bargain a refused link gets.
+// mdFigureOf wants a paragraph holding one image and nothing else, and answers
+// nil for everything else, an image the resolver refused included: that one
+// falls through to mdUnwrap and keeps its caption as text, the same bargain a
+// refused link gets.
 func mdFigureOf(p *ast.Paragraph, ctx mdCtx) *mdFigure {
 	if p.ChildCount() != 1 {
 		return nil
@@ -269,9 +257,9 @@ func mdUnwrap(n ast.Node) {
 	parent.RemoveChild(parent, n)
 }
 
-// mdMedia resolves an image source. The resolver answers with a local /media/
-// path and is trusted; without one (mdText, and tests) the source is still an
-// operator string and goes through the same scheme allow-list as a link.
+// mdMedia trusts the resolver, which answers with a local /media/ path. With no
+// resolver (mdText, and tests) the source is still an operator string and goes
+// through the same scheme allow-list as a link.
 func mdMedia(src string, ctx mdCtx) (string, int, int) {
 	if ctx.media != nil {
 		return ctx.media(src)
@@ -291,18 +279,14 @@ func (r mdRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
 	reg.Register(east.KindTable, r.renderTable)
 }
 
-// renderTable wraps the table in the element that scrolls, instead of making
-// the table itself scroll.
+// renderTable wraps the table in the element that scrolls, instead of making the
+// table itself scroll. display:block on the table is the one-line way to stop a
+// wide table pushing the page sideways, and Chrome and Safari drop the table
+// role from the accessibility tree with it: the cells stop being announced as a
+// table and read as loose text. A wrapper keeps display:table and its semantics.
 //
-// The one-line way to stop a wide table pushing the page sideways is
-// display:block on the table, and it costs more than it looks: Chrome and
-// Safari drop the table role from the accessibility tree with it, so the rows
-// and cells stop being announced as a table at all and a screen reader reads
-// the cells as loose text. A wrapper keeps display:table and its semantics.
-//
-// tabindex is not decoration either. A region that scrolls has to be
-// scrollable by keyboard, and a div with overflow is not focusable on its own,
-// so someone who cannot use a pointer would never reach the right-hand columns.
+// A div with overflow is not focusable on its own, so without tabindex a visitor
+// who cannot use a pointer never reaches the right-hand columns.
 func (mdRenderer) renderTable(w util.BufWriter, _ []byte, _ ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
 		_, _ = w.WriteString(`<div class="table-wrap" tabindex="0"><table>`)
@@ -314,8 +298,8 @@ func (mdRenderer) renderTable(w util.BufWriter, _ []byte, _ ast.Node, entering b
 
 func (mdRenderer) renderLink(w util.BufWriter, _ []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	n := node.(*ast.Link)
-	// The children still render, so a refused link keeps its words and loses
-	// only the anchor. Destination is the decoded target: goldmark resolves
+	// The children still render, so a refused link keeps its words and loses only
+	// the anchor. Destination is the decoded target: goldmark resolves
 	// "&#106;avascript:" before it reaches here, so the allow-list sees the
 	// scheme the browser would see.
 	if !mdSafeURL(string(n.Destination)) {
@@ -371,8 +355,7 @@ func (mdRenderer) renderFigure(w util.BufWriter, _ []byte, node ast.Node, enteri
 		return ast.WalkContinue, nil
 	}
 	_, _ = w.WriteString(`<figure class="shot"><img src="` + html.EscapeString(n.URL) + `" alt="" loading="lazy"`)
-	// Width and height are what stop the page shifting as images arrive; they
-	// are left out rather than guessed when the resolver does not know them.
+	// Left out rather than guessed when the resolver does not know them.
 	if n.W > 0 {
 		_, _ = fmt.Fprintf(w, ` width="%d" height="%d"`, n.W, n.H)
 	}
@@ -400,16 +383,14 @@ func mdText(s string) string {
 	return strings.Join(strings.Fields(html.UnescapeString(mdTagRe.ReplaceAllString(b.String(), ""))), " ")
 }
 
-// mdRefParser has the syntax and none of the transformations. ImageRefs wants
-// the images the operator wrote, before the resolver has had a chance to
-// refuse one, and running the render parser here finds nothing at all: with no
-// media resolver every image is unwrapped out of the tree before a walk can
-// see it. Measured, not assumed.
+// mdRefParser has the syntax and none of the transformations. The render parser
+// finds nothing here: with no media resolver every image is unwrapped out of the
+// tree before a walk can see it.
 var mdRefParser = parser.NewParser(mdParserOptions()...)
 
-// HasTopHeading reports whether a field was written with a level-one heading,
-// either "# Title" or the setext underline. It reads the untransformed tree, so
-// it sees what the operator wrote rather than the h2 the renderer emits.
+// HasTopHeading reads the untransformed tree, so it sees the level-one heading
+// the operator wrote, "# Title" or the setext underline, rather than the h2 the
+// renderer emits.
 func HasTopHeading(src string) bool {
 	if src == "" {
 		return false
@@ -427,14 +408,10 @@ func HasTopHeading(src string) bool {
 }
 
 // ImageRefs lists every image destination a markdown field references, in the
-// order it references them.
-//
-// It exists so -check and the renderer cannot disagree about what an image is.
-// The check used to run its own regexp, `!\[…\]\(…\)`, which knows only the
-// parenthesised spelling: `![cap][ref]` with `[ref]: gone.png` underneath
-// rendered two broken images and -check still printed ok. Asking the parser
-// that actually renders the page is the only way that stays true as the
-// markdown grows, and it costs nothing, since the parse is the same one.
+// order it references them, so -check and the renderer cannot disagree about
+// what an image is. A regexp for `!\[…\]\(…\)` knows only the parenthesised
+// spelling and misses `![cap][ref]` with `[ref]: gone.png` underneath, which
+// renders as an image all the same.
 //
 // Destinations are returned raw, exactly as written. Resolving one against
 // media/ or the assets mount is the caller's business, and cairn resolves them

--- a/src/internal/render/render.go
+++ b/src/internal/render/render.go
@@ -23,9 +23,9 @@ var Embedded embed.FS
 
 var tmpls = template.Must(template.New("").Funcs(template.FuncMap{
 	"upper": strings.ToUpper,
-	// asset resolves one of cairn's own files to the stamped name it is
-	// served under, base path included, so a template never writes /static/
-	// by hand and never has to remember .Prefix for one. See asseturl.go.
+	// asset resolves one of cairn's own files to the stamped name it is served
+	// under, base path included, so a template never writes /static/ by hand and
+	// never has to remember .Prefix for one. See asseturl.go.
 	"asset": AssetURL,
 }).ParseFS(Embedded, "templates/*.tmpl"))
 
@@ -35,32 +35,30 @@ type Page struct {
 }
 
 // Model is the immutable unit swapped atomically on config reload or status
-// change. Pages is keyed by URL path without slashes: "fr" for a home,
-// "fr/pdf" for a detail. Statuses is service-id -> what Gatus said about it.
+// change. Pages is keyed by URL path without surrounding slashes ("fr" for a
+// home, "fr/pdf" for a detail), Statuses by service id.
 type Model struct {
 	Cfg      *config.Config
 	Pages    map[string]Page
 	Statuses map[string]status.State
 	CSP      string
-	// Ready is false only while the getting-started page stands in for a
-	// config that never loaded. /readyz reports it; /healthz does not, so a
-	// liveness probe cannot restart-loop a container that is serving fine.
+	// Ready is false only while the getting-started page stands in for a config
+	// that never loaded. /readyz reports it, /healthz does not, so a liveness
+	// probe cannot restart-loop a container that is serving fine.
 	Ready bool
 }
 
-// prePaintScript must stay byte-identical to the inline script in
-// layout.tmpl: its hash is what the CSP allows. A test guards the match.
-// The about cookie stores a hash of the note's content (the data-about
-// attribute), so an edited note reappears even for visitors who dismissed
-// the previous one.
-// data-js is stamped here rather than from a deferred script because CSS keys
-// off it before first paint: with JavaScript off, the mobile category trail
-// must stay as chips instead of folding into a select only nav.js can drive.
+// prePaintScript must stay byte-identical to the inline script in layout.tmpl:
+// its hash is what the CSP allows, and a test guards the match. The about cookie
+// holds a hash of the note's content (the data-about attribute), so an edited
+// note reappears even for visitors who dismissed the previous one. data-js is
+// stamped here rather than from a deferred script because CSS keys off it before
+// first paint: with JavaScript off, the mobile category trail must stay as chips
+// instead of folding into a select only nav.js can drive.
 const prePaintScript = `document.documentElement.setAttribute('data-js','');var a=document.cookie.match(/(?:^|; )about=([^;]*)/);if(a&&a[1]===document.documentElement.getAttribute('data-about'))document.documentElement.setAttribute('data-noabout','');try{var t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t)}catch(e){}`
 
-// aboutHash fingerprints the welcome note across all locales; eight hex
-// chars are plenty for a cookie value that only needs to change when the
-// note does.
+// aboutHash fingerprints the welcome note across all locales. Eight hex chars
+// are enough for a cookie value that only has to change when the note does.
 func aboutHash(about config.LString) string {
 	if len(about) == 0 {
 		return ""
@@ -77,25 +75,23 @@ func aboutHash(about config.LString) string {
 	return hex.EncodeToString(h.Sum(nil))[:8]
 }
 
-// themeStyle is the inline <style> every page carries. It sets the accent on
-// :root -- the stylesheet's own value is a placeholder, this is the real one --
-// overrides the body font when theme.font.family names one, and declares the
-// self-hosted @font-face when theme.font.file does. Its hash is what the CSP
-// allows, so this string and the <style> layout.tmpl renders have to stay
-// identical; csp_test.go guards the match.
+// themeStyle is the inline <style> every page carries: the accent on :root (the
+// stylesheet's own value is a placeholder), the body font when
+// theme.font.family names one, and the self-hosted @font-face when
+// theme.font.file does. Its hash is what the CSP allows, so this string and the
+// <style> layout.tmpl renders have to stay identical; csp_test.go guards the
+// match.
 func themeStyle(cfg *config.Config) string {
 	var b strings.Builder
 	if f := cfg.Site.Theme.Font.File; f != "" {
 		if rel, ok := config.FontRef(f); ok {
-			// No font-weight descriptor, deliberately. cairn's own Fraunces
-			// declares 100 900 because Fraunces is variable; a file someone
-			// drops in fonts/ is usually one static weight, and a face that
-			// claims to cover 100 to 900 is matched at every weight, so the
-			// browser stops synthesizing bold. The page sets 470 through 650
-			// on names, headings and the current entry of a table of contents,
-			// and all of it would come out flat. A variable font measures the
-			// same with the descriptor and without, on Chromium and WebKit
-			// alike, so leaving it out costs that case nothing.
+			// No font-weight descriptor. A file dropped in fonts/ is usually one
+			// static weight, and a face claiming to cover 100 to 900 is matched
+			// at every weight, so the browser stops synthesizing bold: the 470
+			// through 650 the page sets on names, headings and the current entry
+			// of a table of contents would all come out flat. A variable font
+			// measures the same with the descriptor and without, on Chromium and
+			// WebKit alike.
 			fmt.Fprintf(&b, "@font-face{font-family:%s;src:url(%q) format(%q);font-style:normal;font-display:swap}",
 				config.FontFaceName(cfg.Site.Theme.Font.Family),
 				AppURL("/fonts/"+rel),
@@ -109,8 +105,8 @@ func themeStyle(cfg *config.Config) string {
 		b.WriteString(fam)
 	}
 	b.WriteString("}")
-	// Last, so a site that themes no artwork produces the exact string it
-	// produced before this existed, hash included.
+	// Last: a site that themes no artwork has to produce the same string, and so
+	// the same CSP hash, as one built before this existed.
 	var logoDark string
 	if l := cfg.Site.Logo; l.Themed() {
 		logoDark = AppURL(l.Dark)
@@ -124,45 +120,41 @@ func cspHash(s string) string {
 	return "'sha256-" + base64.StdEncoding.EncodeToString(sum[:]) + "'"
 }
 
+// A site with no monitor ships no status.js, no pills and no slots for one.
+func hasMonitor(cfg *config.Config) bool { return cfg.Site.StatusAddress() != "" }
+
 // BuildCSP allows exactly what the pages use: self assets, the inline style
-// (accent, and the @font-face and body font when theme.font is set), the
-// known inline script by hash, and images from anywhere https (icon slugs).
+// (accent, and the @font-face and body font when theme.font is set), the known
+// inline script by hash, and images from anywhere https (icon slugs).
 func BuildCSP(cfg *config.Config) string {
 	csp := "default-src 'none'; img-src 'self' https: data:; " +
 		"style-src 'self' " + cspHash(themeStyle(cfg)) + "; " +
 		"script-src 'self' " + cspHash(prePaintScript) + "; " +
 		"font-src 'self'; manifest-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'"
 	// The one request a cairn page ever makes from the browser: status.js
-	// refetching the page it is on. Sites with no Gatus do not ship the script
-	// and do not get the permission.
-	if cfg.Site.StatusAddress() != "" {
+	// refetching the page it is on.
+	if hasMonitor(cfg) {
 		csp += "; connect-src 'self'"
 	}
 	return csp
 }
 
-// locText is one translated string together with the language it turned out
-// to be written in.
+// locText is one translated string together with the language it turned out to
+// be written in.
 //
-// A field with no translation for the page's locale still renders, in
-// whichever language the config does have, and the page used to claim through
-// <html lang> that the sentence was in its own: a screen reader then reads it
-// in the wrong voice, and an Arabic fallback inside a left-to-right page is
-// laid out the wrong way round, punctuation and all. Attrs is the ` lang="…"
-// dir="…"` that says otherwise, and a template opts into it element by
-// element.
+// A field with no translation for the page's locale still renders, in whichever
+// language the config does have, while <html lang> claims it is in the page's
+// own: a screen reader then reads it in the wrong voice, and an Arabic fallback
+// inside a left-to-right page is laid out the wrong way round, punctuation and
+// all. Attrs is the ` lang="…" dir="…"` that says otherwise, and a template opts
+// into it element by element.
 //
-// Printing is unchanged. String makes {{.Field}} render the wording and
-// nothing else, so every template that only prints keeps printing what it did.
-// Testing is not: this is a struct, and {{if .Field}} on a struct is always
-// true, so a template that shows an element only when the text exists has to
-// ask for {{if .Field.Text}}. TestEmptyFieldsStillRenderNothing is what
-// catches the slip, since the symptom is an empty element nobody looks at.
-//
-// Both Lang and Dir are empty in the overwhelmingly common case, a site whose
-// fields are translated for the locales it lists. A mark on every field would
-// be worse than none: it would say "foreign language" so often that the times
-// it is true would stop meaning anything.
+// String makes {{.Field}} render the wording and nothing else, so a template
+// that only prints keeps printing what it did. Testing differs: this is a
+// struct, and {{if .Field}} on a struct is always true, so a template that shows
+// an element only when the text exists has to ask for {{if .Field.Text}}.
+// TestEmptyFieldsStillRenderNothing catches the slip, since the symptom is an
+// empty element nobody looks at.
 type locText struct {
 	Text string
 	Lang string // the text's own locale, empty when it is the page's language
@@ -173,8 +165,8 @@ func (t locText) String() string { return t.Text }
 
 func (t locText) Attrs() template.HTMLAttr { return langAttrs(t.Lang, t.Dir) }
 
-// prose is the same thing for a markdown field: the blocks it rendered to,
-// and the language they are written in when it is not the page's.
+// prose is locText for a markdown field: the blocks it rendered to, and the
+// language they are written in when it is not the page's.
 type prose struct {
 	Blocks    []template.HTML
 	Lang, Dir string
@@ -185,19 +177,15 @@ func (p prose) Attrs() template.HTMLAttr { return langAttrs(p.Lang, p.Dir) }
 // langAttrs builds the attribute pair a marked run of text carries.
 //
 // template.HTMLAttr is an escape hatch: html/template copies it into the tag
-// verbatim, so a forgeable value here would be an injection. Nothing reaching
-// it is forgeable. lang is a locale tag, and IsLocale is checked here rather
-// than assumed from load, so the guarantee holds even if some later field
-// arrives by another road: localeRe is ^[a-zA-Z][a-zA-Z0-9-]*$, which admits
-// letters, digits and dashes and therefore no quote, space, angle bracket or
-// equals sign. dir is compared against the only two values it may ever hold.
-// Anything failing either check is dropped rather than escaped: a page with no
-// mark is merely as wrong as it was before this existed, while a page with a
-// forged attribute is a different kind of wrong.
+// verbatim, so a forgeable value here would be an injection. IsLocale is checked
+// here rather than assumed from load, so the guarantee holds even for a field
+// that arrives by some later road: localeRe is ^[a-zA-Z][a-zA-Z0-9-]*$, which
+// admits letters, digits and dashes and therefore no quote, space, angle bracket
+// or equals sign. dir is compared against the only two values it may ever hold.
+// Anything failing either check is dropped rather than escaped.
 //
-// dir is left out when it matches the page's own direction. English text on a
-// French page reads left to right either way, and dir="ltr" on every such
-// field would be noise restating what the browser already inherited.
+// dir is left out when it matches the page's own direction, which the browser
+// has already inherited.
 func langAttrs(lang, dir string) template.HTMLAttr {
 	if !config.IsLocale(lang) {
 		return ""
@@ -209,8 +197,6 @@ func langAttrs(lang, dir string) template.HTMLAttr {
 	return template.HTMLAttr(attrs)
 }
 
-// tr resolves one translated field for the page being built: loc is the
-// page's locale, def the site default that the lookup falls back through.
 func tr(ls config.LString, loc, def string) locText {
 	text, from := ls.GetLocale(loc, def)
 	t := locText{Text: text}
@@ -224,17 +210,14 @@ func tr(ls config.LString, loc, def string) locText {
 	return t
 }
 
-// proseOf renders a translated markdown field, keeping the language mark with
-// the blocks it produced.
 func proseOf(t locText, ctx mdCtx) prose {
 	return prose{Blocks: mdBlocks(t.Text, ctx), Lang: t.Lang, Dir: t.Dir}
 }
 
-// catName is CategoryName with the marking, and only where there is something
-// to mark. The name an operator wrote is a translation and falls back like any
-// other; the two cairn derives instead (the localized "Other" bucket, and a
-// category id title-cased into a heading) are in the page's language or in no
-// language at all, so neither carries a mark.
+// catName marks only a name an operator wrote, which falls back like any other
+// translation. The two cairn derives instead, the localized "Other" bucket and a
+// category id title-cased into a heading, are in the page's language or in no
+// language at all.
 func catName(cfg *config.Config, c config.Category, loc string) locText {
 	if len(c.Name) > 0 {
 		if t := tr(c.Name, loc, cfg.DefaultLocale()); t.Text != "" {
@@ -246,94 +229,80 @@ func catName(cfg *config.Config, c config.Category, loc string) locText {
 
 type uiStrings struct {
 	Skip, Languages, SearchLabel, SearchPlaceholder, SearchEmpty, SearchOne, SearchMany, Open, Back, More, Link, Toc, LinksLabel, Dismiss, Theme, Powered, Menu, Top string
-	// The six the leave dialog needs, empty on a site that does not ask for
-	// it. LeaveCopied is the label the copy button swaps to, so it is written
-	// into a data attribute rather than the button: the script needs both.
+	// The six the leave dialog needs, empty on a site that does not ask for it.
+	// LeaveCopied is the label the copy button swaps to, so it goes into a data
+	// attribute rather than the button: the script needs both.
 	LeaveTitle, LeaveBody, LeaveCopy, LeaveCopied, LeaveGo, LeaveStay string
 }
 
 type pageView struct {
 	Locale, Logo, Favicon, TouchIcon, OGImage, SwitchPath, Base, Version, AboutHash string
-	// FaviconDark is the tab icon for a dark system, empty without one. It is
-	// the one themed surface the stylesheet cannot reach, so it goes out as a
-	// second <link> and follows the system rather than the theme button.
+	// FaviconDark is the tab icon for a dark system, empty without one. It is the
+	// one themed surface the stylesheet cannot reach, so it goes out as a second
+	// <link> and follows the system rather than the theme button.
 	FaviconDark string
-	// PageTitle and MetaDesc are the <title> and the meta/og description. Both
-	// are text inside markup rather than markup, so neither can carry a lang
-	// attribute, and neither can be split into a marked part and an unmarked
-	// one: a title is one string. A fallback shows there unannounced, and the
-	// only honest thing to do about it is not pretend otherwise. Same for the
-	// og:title and the aria-label statusMeta builds.
+	// PageTitle and MetaDesc are the <title> and the meta/og description: text
+	// inside markup rather than markup, with no element to hang lang and dir on
+	// and no way to split into a marked part and an unmarked one. A fallback
+	// shows there unannounced. Same for og:title and the aria-label statusMeta
+	// builds.
 	PageTitle, MetaDesc string
-	// Style is the inline <style> of every page, pre-built so its CSP hash
-	// can be computed over the same string the template renders. template.CSS
-	// is what tells html/template this block needs no CSS-escaping: it is
-	// trusted markup, the accent validated to a hex color and the font family
-	// to the characters a CSS font stack is made of.
+	// Style is the inline <style> of every page, pre-built so its CSP hash covers
+	// the same string the template renders. template.CSS tells html/template this
+	// block needs no CSS-escaping: the accent is validated to a hex color and the
+	// font family to the characters a CSS font stack is made of.
 	Style                                       template.CSS
 	SiteTitle                                   locText
 	Prefix                                      string // "" or "/cairn", see BasePath
 	Dir                                         string // "ltr" or "rtl", from the locale
 	CustomCSS, Search, Credit, Noindex, ShowVer bool
-	// StatusPoll is how often, in seconds, status.js refetches the page to
-	// swap the pills. Zero on a site with no Gatus, where the script does not
-	// ship at all.
+	// StatusPoll is how often, in seconds, status.js refetches the page to swap
+	// the pills. Zero on a site with no monitor, where the script never ships.
 	StatusPoll        int
 	VerLabel, VerHref string
 	Locales           []string
 	Links             []linkView
 	Footer            []linkView
 	S                 uiStrings
-	// Leave ships the dialog and its script, and it is set per page rather
-	// than per site: a page with nothing to guard gets neither, so a detail
-	// page for a service the operator runs stays exactly the page it was.
-	// LeaveBlank makes the dialog's own continue link agree with new_tab.
+	// Leave ships the dialog and its script, per page rather than per site: a
+	// page with nothing to guard gets neither. LeaveBlank makes the dialog's own
+	// continue link agree with new_tab.
 	Leave, LeaveBlank bool
 }
 
 type cardView struct {
 	URL, Icon, Tags, MoreHref, Status, StatusLabel, StatusHref string
-	// IconClass carries the dark variant of a themed icon, empty otherwise.
-	// The class names the pair rather than the service, so cards sharing an
-	// icon share the one rule in the page's stylesheet.
+	// IconClass carries the dark variant of a themed icon, empty otherwise. The
+	// class names the pair rather than the service, so cards sharing an icon
+	// share the one rule in the page's stylesheet.
 	IconClass string
 	// MoreA11y names the detail link for a screen reader. The link is a glyph,
-	// which says nothing on its own, and a page of identical "Learn more"
-	// links is a link list nobody can navigate: it names the service too.
+	// which says nothing on its own, and a page of identical "Learn more" links
+	// is a link list nobody can navigate: it names the service too.
 	MoreA11y            string
 	Name, Desc          locText
 	StatusA11y          string // set only when the pill is a link
-	StatusID            string // names the pill's slot, empty without a Gatus
+	StatusID            string // names the pill's slot, empty without a monitor
 	HostKind, HostLabel string // "self"/"external"/"" and its localized label
-	// State is the declared word, `soon` and friends, used as a class; the
-	// label is that word in the page's language. Beware the name: `state` is
-	// already this file's local for a status level, which is the other thing
-	// entirely. See statusMeta.
+	// State is the declared word, `soon` and friends, used as a class, and
+	// StateLabel is that word in the page's language. Neither has anything to do
+	// with a status level.
 	State, StateLabel string
-	// Off is the two disabling states, hoisted onto the view so the template
-	// asks one question instead of comparing strings in three places.
+	// Off is the two disabling states, hoisted onto the view so the template asks
+	// one question instead of comparing strings in three places.
 	Off bool
-	// HostHref is where the flag leads, empty when it leads nowhere and the
-	// flag stays the plain text it has always been. HostBlank is set for a
-	// target that is not this site.
+	// HostHref is where the flag leads, empty when it leads nowhere and the flag
+	// stays plain text. HostBlank is set for a target that is not this site.
 	HostHref  string
 	HostBlank bool
-	// Blank and Leave describe the link on the service's own name. Both are
-	// set from service_links and both only ever apply to a url that leaves
-	// the site, which is why they live on the card rather than on the config:
-	// a service whose url is a page cairn serves gets neither.
+	// Blank and Leave describe the link on the service's own name. Both come from
+	// service_links and both only apply to a url that leaves the site, so a
+	// service whose url is a page cairn serves gets neither.
 	Blank, Leave bool
 }
 
-// serviceLink decides how one service url behaves. hostKind is the card's own
-// flag, which is what lets a site warn about other people's services without
-// warning about its own.
-//
-// Everything here is gated on leaving the site. A url that is a path cairn
-// serves is not a departure, and treating it as one would put a "you are
-// leaving" dialog in front of the operator's own page.
-// hostKindOf is the card's flag, read off the service rather than off the
-// built card, so the detail page can reach the same verdict without one.
+// hostKindOf reads the card's flag off the service rather than off the built
+// card, so the detail page can reach the same verdict without one.
 func hostKindOf(s config.Service) string {
 	if s.Selfhosted == nil {
 		return ""
@@ -344,6 +313,11 @@ func hostKindOf(s config.Service) string {
 	return "external"
 }
 
+// serviceLink decides how one service url behaves, gated throughout on leaving
+// the site: a url that is a path cairn serves is not a departure, and a "you are
+// leaving" dialog in front of the operator's own page is not a warning. hostKind
+// is the card's own flag, which is what lets a site warn about other people's
+// services without warning about its own.
 func serviceLink(cfg *config.Config, url, hostKind string) (blank, leave bool) {
 	if config.IsLocalPath(url) {
 		return false, false
@@ -415,9 +389,9 @@ type sectionView struct {
 }
 
 // hostTarget resolves where a hosting flag leads, and whether that is off this
-// site. A page id becomes the path to that page in the language being read,
-// which is why the key takes an id rather than a path: writing /en/hosting/
-// would pin one language for every visitor. Anything else is used as written.
+// site. The key is a page id rather than a path because the path is built in the
+// language being read: writing /en/hosting/ would pin one language for every
+// visitor. Anything else is used as written.
 func hostTarget(cfg *config.Config, loc, ref string) (href string, blank bool) {
 	if ref == "" {
 		return "", false
@@ -432,10 +406,9 @@ func hostTarget(cfg *config.Config, loc, ref string) (href string, blank bool) {
 
 // statusBase is the page a pill points into, without a trailing slash.
 //
-// The link is for the visitor's browser, so status.page wins: the address
-// cairn polls may be internal and poll-only, and only the operator knows.
-// Failing that, Kuma's published status page is derivable, since /status/{slug}
-// is the URL Kuma itself serves it at, and landing on a status page beats
+// The link is for the visitor's browser, so status.page wins: the address cairn
+// polls may be internal and poll-only, and only the operator knows. Failing
+// that, Kuma serves its published page at /status/{slug}, which at least beats
 // landing on an API root that redirects to a login.
 func statusBase(cfg *config.Config) string {
 	if p := cfg.Site.Status.Page; p != "" {
@@ -450,13 +423,13 @@ func statusBase(cfg *config.Config) string {
 
 // statusMeta fills a pill: its label, where it links, and the label a screen
 // reader reads instead. An empty href makes it display-only, which is what
-// status.linked: false asks for and the only shape the templates need to
-// tell the two apart.
-func statusMeta(cfg *config.Config, loc, state string, s config.Service, key string) (label, href, a11y string) {
-	if state == "" {
+// status.linked: false asks for and the only shape the templates need to tell
+// the two apart.
+func statusMeta(cfg *config.Config, loc, level string, s config.Service, key string) (label, href, a11y string) {
+	if level == "" {
 		return "", "", ""
 	}
-	label = cfg.Str(loc, "status."+state)
+	label = cfg.Str(loc, "status."+level)
 	if !cfg.StatusLinked() {
 		return label, "", ""
 	}
@@ -465,39 +438,33 @@ func statusMeta(cfg *config.Config, loc, state string, s config.Service, key str
 	// page for the whole set, and pointing at a per-service path it does not
 	// serve is the bug v1.13.2 fixed for Gatus, made again from the other end.
 	if cfg.Site.StatusProvider() == "gatus" {
-		// Gatus names its own endpoint pages. Deriving that name from cairn's
-		// categories only ever matched an operator who ran -emit-gatus and kept its
-		// grouping; everyone else got a link to a page their Gatus does not serve.
-		// The derived key stays as the fallback for the pills that render before
-		// Gatus has answered, and for a Gatus too old to report one.
+		// Gatus reports the key of its own endpoint page. Deriving one from
+		// cairn's categories only matched an operator who ran -emit-gatus and kept
+		// its grouping, so it stays as the fallback for the pills that render
+		// before Gatus has answered, and for a Gatus too old to report one.
 		if key == "" {
 			key = status.Key(s.Category, s.ID)
 		}
-		// The key comes off the network, from whatever answers on the poll address.
-		// PathEscape leaves every key Gatus can produce alone and keeps a hostile
-		// one inside the path segment it was written into.
+		// The key comes off the network, from whatever answers on the poll
+		// address. PathEscape leaves every key Gatus can produce alone and keeps a
+		// hostile one inside the path segment it was written into.
 		base += "/endpoints/" + url.PathEscape(key)
 	}
 	href = base
 	// A link has to name its target on its own: read out of the card, "Online"
-	// alone says nothing about which service, nor that it leads anywhere.
-	//
-	// The service name here may be a fallback in another language, and this one
-	// cannot be marked: an aria-label is text inside an attribute, so there is
-	// no element to hang lang and dir on, and the name is glued to two strings
-	// in the page's own language besides. The visible pill next to it carries
-	// the marking the label cannot.
+	// alone says nothing about which service, nor that it leads anywhere. The
+	// service name may be a fallback in another language and cannot be marked
+	// here, an aria-label being text inside an attribute; the visible pill next
+	// to it carries the marking.
 	return label, href, s.Name.Get(loc, cfg.DefaultLocale()) + ", " + label + ", " + cfg.Str(loc, "status.link")
 }
 
 // statusOf returns "", "unknown", "up", "degraded", "maintenance" or "down".
 // While the monitor has not answered yet (boot, outage) every pill is unknown;
-// once it has, services it does not monitor show no pill at all.
-//
-// Only two of them are reachable from Gatus, whose results carry a success
-// bool and nothing else. The other two arrive from monitors that say more.
+// once it has, services it does not monitor show no pill at all. Gatus reaches
+// only up and down, its results carrying a success bool and nothing else.
 func statusOf(cfg *config.Config, statuses map[string]status.State, id string) string {
-	if cfg.Site.StatusAddress() == "" {
+	if !hasMonitor(cfg) {
 		return ""
 	}
 	if len(statuses) == 0 {
@@ -514,29 +481,28 @@ func statusOf(cfg *config.Config, statuses map[string]status.State, id string) s
 	case st.Level == status.LevelUp:
 		return "up"
 	default:
-		// Every other level, including one no version of cairn has heard of,
-		// reads as down. That is the safe direction: a source that grows a word
-		// must not be able to paint a broken service green.
+		// Every other level, one no version of cairn has heard of included, reads
+		// as down: a source that grows a word must not be able to paint a broken
+		// service green.
 		return "down"
 	}
 }
 
-// statusSlot names the pill's slot, which is in the markup on every service of
-// a site that has a Gatus, pill or no pill. status.js swaps what is inside it,
-// and one of the states it has to be able to reach is "nothing": a service the
-// status page stops monitoring loses its pill rather than keeping a stale one.
+// statusSlot names the pill's slot, which is in the markup on every service of a
+// monitored site, pill or no pill. status.js swaps what is inside it, and one of
+// the states it has to reach is nothing at all: a service the status page stops
+// monitoring loses its pill rather than keeping a stale one.
 func statusSlot(cfg *config.Config, id string) string {
-	if cfg.Site.StatusAddress() == "" {
+	if !hasMonitor(cfg) {
 		return ""
 	}
 	return id
 }
 
-// statusPoll is how often status.js refetches the page, in seconds. It is the
-// interval cairn polls Gatus on: asking cairn more often than cairn can learn
-// anything new would only cost requests.
+// statusPoll is the interval cairn polls the monitor on: asking cairn more often
+// than cairn can learn anything new would only cost requests.
 func statusPoll(cfg *config.Config) int {
-	if cfg.Site.StatusAddress() == "" {
+	if !hasMonitor(cfg) {
 		return 0
 	}
 	return int(cfg.StatusInterval().Seconds())
@@ -545,9 +511,9 @@ func statusPoll(cfg *config.Config) int {
 func BuildModel(cfg *config.Config, statuses map[string]status.State) (*Model, error) {
 	def := cfg.DefaultLocale()
 	media := func(src string) (string, int, int) {
-		// MediaDims is keyed by the name under media/. The /media/… spelling
-		// reaches the same file and used to miss the lookup, so the width and
-		// height that exist to stop the page jumping were dropped for it.
+		// MediaDims is keyed by the bare name under media/, so the /media/…
+		// spelling has to be cut back to it or the width and height that stop the
+		// page jumping are dropped.
 		key := src
 		if rel, ok := strings.CutPrefix(src, "/media/"); ok {
 			key = rel
@@ -555,10 +521,9 @@ func BuildModel(cfg *config.Config, statuses map[string]status.State) (*Model, e
 		d := cfg.MediaDims[key]
 		return AppURL(mediaURL(src)), d[0], d[1]
 	}
-	// Built once here rather than per locale: the set is a property of the
-	// config, not of the language. themeStyle builds its own from the same
-	// function to write the rules, which is why that function has to stay
-	// deterministic.
+	// Built once rather than per locale: the set is a property of the config, not
+	// of the language. themeStyle calls themedFor too and its output lands inside
+	// the CSP hash, so the function has to stay deterministic.
 	themed := themedFor(cfg)
 	pages := map[string]Page{}
 	for _, loc := range cfg.Site.Locales {
@@ -581,9 +546,9 @@ func BuildModel(cfg *config.Config, statuses map[string]status.State) (*Model, e
 				return ""
 			}(),
 			TouchIcon: AppURL(TouchIcon(cfg)),
-			// AppURL has already added BasePath to a local logo, so the base
-			// passed here must not carry it again: it used to, and every
-			// og:image under -base-path pointed at /cairn/cairn/… and 404ed.
+			// AppURL has already added BasePath to a local logo, so the base passed
+			// here is the bare site url: carrying it twice points every og:image
+			// under -base-path at /cairn/cairn/… and 404s.
 			OGImage:   ogImage(cfg.Site.URL, AppURL(cfg.Site.Logo.Light)),
 			Noindex:   cfg.Noindex(),
 			AboutHash: aboutHash(cfg.Site.About),
@@ -656,9 +621,8 @@ func BuildModel(cfg *config.Config, statuses map[string]status.State) (*Model, e
 					card.State = string(s.State)
 					card.StateLabel = cfg.Str(loc, "state."+string(s.State))
 				}
-				// A disabling state means nothing is monitored, so there is no
-				// slot for a pill to be swapped into. The other three are live
-				// and keep theirs.
+				// A disabling state means nothing is monitored, so there is no slot
+				// for a pill to be swapped into.
 				if !card.Off {
 					card.Status = statusOf(cfg, statuses, s.ID)
 					card.StatusID = statusSlot(cfg, s.ID)
@@ -677,8 +641,8 @@ func BuildModel(cfg *config.Config, statuses map[string]status.State) (*Model, e
 						card.HostHref, card.HostBlank = hostTarget(cfg, loc, cfg.Site.HostingFlag.External)
 					}
 				}
-				// After the flag, since the scope reads it. A disabling state
-				// has no link at all, so neither key can mean anything.
+				// After the flag: the confirm scope reads HostKind. A disabling
+				// state has no link at all, so neither key can mean anything.
 				if !card.Off {
 					card.Blank, card.Leave = serviceLink(cfg, s.URL, card.HostKind)
 					hv.Leave = hv.Leave || card.Leave
@@ -719,9 +683,9 @@ func BuildModel(cfg *config.Config, statuses map[string]status.State) (*Model, e
 				}
 				if !dv.Off {
 					dv.StatusLabel, dv.StatusHref, dv.StatusA11y = statusMeta(cfg, loc, dv.Status, s, statuses[s.ID].Key)
-					// The detail page has to reach the same verdict as the card
-					// for the same service, or a visitor meets the dialog on one
-					// route and not the other.
+					// The detail page has to reach the same verdict as the card for
+					// the same service, or a visitor meets the dialog on one route
+					// and not the other.
 					dv.Blank, dv.Leave = serviceLink(cfg, s.URL, hostKindOf(s))
 					dv.pageView.Leave = dv.Leave
 				}
@@ -784,12 +748,11 @@ func paragraphs(s string) []string {
 	return out
 }
 
-// defaultTouchIcon is cairn's own, the one shipped in assets/.
 const defaultTouchIcon = "/static/touch-icon.png"
 
-// widestSize reads the largest width out of a manifest `sizes` value, which
-// may list several ("48x48 96x96") or be "any". Anything unreadable is 0, so
-// it loses to any real number without needing a separate case.
+// widestSize reads the largest width out of a manifest `sizes` value, which may
+// list several ("48x48 96x96") or be "any". Anything unreadable is 0, so it
+// loses to any real number without needing a separate case.
 func widestSize(sizes string) int {
 	best := 0
 	for _, token := range strings.Fields(sizes) {
@@ -806,12 +769,11 @@ func widestSize(sizes string) int {
 
 // TouchIcon picks the add-to-home-screen icon.
 //
-// iOS never reads the manifest for this: it reads the apple-touch-icon link
-// and nothing else. So an operator who listed their own icons has to be
-// honoured here too, or their list would take effect on Android while an
-// iPhone home screen showed cairn's mark, which is the one thing supplying
-// your own icons is meant to prevent. The largest is picked, since iOS
-// downsamples and only a too-small icon shows.
+// iOS never reads the manifest for this: it reads the apple-touch-icon link and
+// nothing else. An operator who listed their own icons has to be honoured here
+// too, or their list would take effect on Android while an iPhone home screen
+// showed cairn's mark. The largest is picked, since iOS downsamples and only a
+// too-small icon shows.
 func TouchIcon(cfg *config.Config) string {
 	if own := cfg.Site.Icons; len(own) > 0 {
 		best, bestPx := own[0].Src, widestSize(own[0].Sizes)
@@ -828,8 +790,8 @@ func TouchIcon(cfg *config.Config) string {
 	return defaultTouchIcon
 }
 
-// AppIcon is one entry of the web app manifest's icon list. Everything but
-// the source is omitted when unknown, rather than filled with a guess.
+// AppIcon is one entry of the web app manifest's icon list. Everything but the
+// source is omitted when unknown, rather than filled with a guess.
 type AppIcon struct {
 	Src     string `json:"src"`
 	Sizes   string `json:"sizes,omitempty"`
@@ -837,9 +799,8 @@ type AppIcon struct {
 	Purpose string `json:"purpose,omitempty"`
 }
 
-// iconType maps a file reference to the mime type the manifest wants. An empty
-// result means we do not recognise it, and the entry then omits the field
-// rather than asserting a format.
+// iconType is empty for a reference cairn does not recognise, and the manifest
+// entry then omits the field rather than asserting a format.
 func iconType(ref string) string {
 	i := strings.LastIndex(ref, ".")
 	if i < 0 {
@@ -864,26 +825,23 @@ func iconType(ref string) string {
 
 // AppIcons lists what a phone should use once the site is on a home screen.
 //
-// The rule throughout is that every field is either true or absent. Sizes are
-// never invented: an entry whose size we cannot establish simply carries no
-// `sizes`, which the manifest spec allows, and the browser decides. The old
-// behaviour was to stamp "180x180" on whatever the operator supplied, which
-// was a guess published as a fact.
+// Every field is either true or absent. Sizes are never invented: an entry whose
+// size cairn cannot establish carries no `sizes`, which the manifest spec
+// allows, and the browser decides.
 //
 // Three cases, in order:
 //
-//   - The operator listed `icons` themselves. That wins outright, sizes and
-//     all, because they are the only one who can know them.
-//   - They set a `favicon`. An svg is scalable, so it is declared "any" and
-//     serves every size the way cairn's own does; a raster in the mounted
-//     assets dir is measured at load and declared truthfully; a raster behind
-//     a URL is offered with no size, since measuring it means an outbound
-//     request and cairn makes none.
+//   - The operator listed `icons` themselves. That wins outright, sizes and all,
+//     since they are the only one who can know them.
+//   - They set a `favicon`. An svg is scalable, so it is declared "any"; a raster
+//     in the mounted assets dir is measured at load; a raster behind a URL is
+//     offered with no size, since measuring it means an outbound request and
+//     cairn makes none.
 //   - Neither. cairn's own set, which ships the 192 and the 512 that Chromium
 //     insists on before it will offer to install a site, both declared
-//     "any maskable": the usual reason for a separate padded maskable file is
-//     that a full-bleed icon loses its edges to Android's crop, and this mark
-//     is a narrow stack that clears that circle with room to spare.
+//     "any maskable": a separate padded maskable file exists for full-bleed
+//     icons that lose their edges to Android's crop, and this mark is a narrow
+//     stack that clears that circle with room to spare.
 func AppIcons(cfg *config.Config) []AppIcon {
 	if own := cfg.Site.Icons; len(own) > 0 {
 		out := make([]AppIcon, 0, len(own))
@@ -913,13 +871,10 @@ func AppIcons(cfg *config.Config) []AppIcon {
 	}
 }
 
-// ogImage derives a social preview image from the logo: only when the site
-// has a public URL to make it absolute, and only raster formats, which is
-// what the preview crawlers accept.
-// IsRaster reports a format a link previewer can actually display. svg is
-// deliberately out: og:image with a vector is ignored by most platforms, which
-// is why a vector logo quietly means no preview picture at all. -check says so
-// rather than leaving it to be discovered on a shared link.
+// IsRaster reports a format a link previewer can display. svg is out: og:image
+// with a vector is ignored by most platforms, so a vector logo means no preview
+// picture at all, and -check says so rather than leaving it to be discovered on
+// a shared link.
 func IsRaster(path string) bool {
 	l := strings.ToLower(path)
 	for _, ext := range []string{".png", ".jpg", ".jpeg", ".webp", ".gif"} {
@@ -930,11 +885,10 @@ func IsRaster(path string) bool {
 	return false
 }
 
-// absBase is the public origin every self-referencing link is built from, and
-// it is empty unless the operator gave one. Adding BasePath to an empty url
-// left a bare "/cairn", which is truthy in the template and made cairn emit
-// relative canonical, og:url and hreflang links: worse than emitting none,
-// which is what the absence of a url is supposed to mean.
+// absBase is the public origin every self-referencing link is built from. It
+// stays empty without a site url: BasePath alone is a truthy "/cairn" in the
+// template, and canonical, og:url and hreflang would go out relative instead of
+// not at all.
 func absBase(cfg *config.Config) string {
 	if cfg.Site.URL == "" {
 		return ""
@@ -955,9 +909,9 @@ func ogImage(base, logo string) string {
 	return logo
 }
 
-// mediaURL resolves a bare image name against the /media/ route, which
-// serves the config dir's media/ folder; URLs and absolute paths pass
-// through, same convention as icons.
+// mediaURL resolves a bare image name against the /media/ route, which serves
+// the config dir's media/ folder. URLs and absolute paths pass through, same
+// convention as icons.
 func mediaURL(src string) string {
 	if config.IsURLOrAbs(src) {
 		return src
@@ -965,8 +919,8 @@ func mediaURL(src string) string {
 	return "/media/" + src
 }
 
-// Version is what the footer shows when show_version is on. Package main
-// carries the -ldflags stamp and assigns it here at startup.
+// Version is what the footer shows when show_version is on. Package main carries
+// the -ldflags stamp and assigns it here at startup.
 var Version = "dev"
 
 // The repository the credit and the version stamp point at.
@@ -977,11 +931,10 @@ var (
 	commitRe = regexp.MustCompile(`^[0-9a-f]{7,40}$`)
 )
 
-// versionInfo turns the build stamp into what the footer shows and where it
-// points, which depends on where the binary came from: a tagged release links
-// to its release notes, a build off main links to the commit it was cut from,
-// and anything else (a local `go build`, which stamps nothing) is named but
-// not linked, since there is no public page for it.
+// versionInfo turns the build stamp into a footer label and a link: a tagged
+// release points at its release notes, a build off main at the commit it was cut
+// from, and anything else (a local `go build`, which stamps nothing) is named
+// but not linked, there being no public page for it.
 func versionInfo(v string) (label, href string) {
 	switch {
 	case semverRe.MatchString(v):

--- a/src/internal/render/themed.go
+++ b/src/internal/render/themed.go
@@ -7,37 +7,23 @@ import (
 	"github.com/MorganKryze/cairn/src/internal/config"
 )
 
-// Themed artwork: the second image a monochrome logo or icon needs, and how it
-// reaches the page.
+// The second image a monochrome logo or icon needs. The markup carries the
+// light one and a rule overrides it with content: url(), which follows
+// data-theme and leaves the <img> its alt, its dimensions and its lazy
+// loading. The two alternatives were measured on Chromium and WebKit and both
+// fail here: two <img> with one display:none fetches both in every theme, and
+// <picture> with a prefers-color-scheme media answers to the system alone, so
+// the theme button would leave the wrong artwork on screen.
 //
-// The markup carries the light one and the page's stylesheet overrides it with
-// `content: url(…)`, which is the only one of the three obvious techniques
-// that is both cheap and correct here. Measured on Chromium and WebKit:
+// The cost, also measured: a visitor on a dark system fetches both files,
+// since src starts loading before any rule applies. One extra file per themed
+// image for half of visitors. Serving dark from src moves that onto the others.
 //
-//   - two <img>, one hidden with display:none: BOTH are fetched, always, in
-//     every theme. The page pays for artwork nobody can see.
-//   - <picture> with media="(prefers-color-scheme: dark)": one fetch, but it
-//     answers to the operating system and nothing else. cairn has a theme
-//     button, so a visitor who switches by hand keeps the wrong artwork on
-//     screen, which is worse than not offering the feature at all.
-//   - content: url() in a rule: it follows data-theme, because it is CSS, and
-//     the <img> keeps its alt, its width and height and its lazy loading.
-//
-// What that last one costs, measured rather than assumed: a visitor whose
-// system is light fetches the light file alone, and the dark one only if they
-// press the button. A visitor whose system is dark fetches both, because the
-// src attribute starts loading before any rule applies and the rule then asks
-// for the second. It is one extra file per themed image, for the half of
-// visitors on a dark system, and it buys lazy loading and markup that still
-// means something with no stylesheet. Serving the dark one from src instead
-// would only move the cost onto the other half.
-//
-// The rules live in the inline <style> because they are per-site values, and a
-// style attribute is not an option: the CSP allows the inline block by hash,
-// and a hash never covers an attribute.
+// The rules live in the inline <style> because they are per-site values, and
+// the CSP allows that block by hash. A hash never covers a style attribute.
 type themedSet struct {
-	// class per resolved dark URL rather than per service: a site whose twenty
-	// cards share one icon carries one rule.
+	// keyed by resolved dark URL, not by service: twenty cards sharing one
+	// icon carry one rule
 	class map[string]string
 	order []string
 }
@@ -55,15 +41,12 @@ func (s *themedSet) add(darkURL string) string {
 	return c
 }
 
-// rules writes the dark overrides, twice over: once for the visitors whose
-// system asks for dark and who have expressed no preference here, once for the
-// ones who pressed the button. That is the pair style.css already uses for the
-// theme toggle's own glyphs, and it is what makes the button work at all.
+// rules writes the dark overrides twice: once for a dark system with no
+// preference expressed here, once for the button. style.css uses the same pair
+// for the toggle's own glyphs, and without both the button does nothing.
 func (s *themedSet) rules(logoDark string) string {
-	// No capacity hint: the list is one entry per distinct dark image on the
-	// whole site, and len()+1 inside an allocation is what CodeQL reads as a
-	// possible overflow. It is right that the shape is worth avoiding, and the
-	// hint was buying nothing here.
+	// no capacity hint: len()+1 inside an allocation is what CodeQL reads as a
+	// possible overflow, and one entry per distinct dark image is a short list
 	var sel []string
 	if logoDark != "" {
 		sel = append(sel, fmt.Sprintf(".brand img{content:url(%q)}", logoDark))
@@ -88,9 +71,8 @@ func (s *themedSet) rules(logoDark string) string {
 	return b.String()
 }
 
-// classFor is the class a card wears, empty for an icon that is one image. It
-// reads the set rather than adding to it, so a card can never carry a class no
-// rule paints.
+// classFor is the class a card wears, empty for a single-image icon. It reads
+// the set rather than adding to it, so a card cannot carry an unpainted class.
 func (s *themedSet) classFor(cfg *config.Config, ref config.ThemedRef) string {
 	if !ref.Themed() {
 		return ""
@@ -98,14 +80,10 @@ func (s *themedSet) classFor(cfg *config.Config, ref config.ThemedRef) string {
 	return s.class[AppURL(config.IconURL(cfg, ref.Dark))]
 }
 
-// themedFor hands back the set of dark images a config asks for.
-//
-// It is called twice, once to name the classes the cards wear and once to
-// write the rules that paint them, and the two have to agree or a card wears
-// a class nothing paints. They do, because this walks slices in config order
-// and nothing here reads a map: one function, one input, one answer. Keep it
-// that way; iterating a map to build the set would make the classes disagree
-// on some runs and not others, which is the worst shape a bug can take.
+// themedFor is called twice, once to name the classes and once to write the
+// rules, and the two must agree. They do because it walks slices in config
+// order and reads no map. Building the set from a map would make the classes
+// disagree on some runs and not others.
 func themedFor(cfg *config.Config) *themedSet {
 	s := newThemedSet()
 	for _, c := range cfg.Categories {

--- a/src/internal/render/url.go
+++ b/src/internal/render/url.go
@@ -6,15 +6,13 @@ import (
 	"github.com/MorganKryze/cairn/src/internal/config"
 )
 
-// BasePath mirrors the -base-path flag: "" at the domain root, "/cairn" when
-// the site is mounted under a sub-path. Every URL cairn generates carries it,
-// and the router strips it back off, so the proxy in front needs no rewriting.
-// It is fixed for the life of the process on purpose: pages are pre-rendered
-// once per config, so the prefix cannot be a per-request header.
+// BasePath mirrors the -base-path flag: "" at the domain root, "/cairn" when the
+// site is mounted under a sub-path. Every URL cairn generates carries it and the
+// router strips it back off, so the proxy in front needs no rewriting. Pages are
+// pre-rendered once per config, so it is fixed for the life of the process and
+// cannot become a per-request header.
 var BasePath = ""
 
-// NormalizeBase turns what an operator may type ("cairn", "/cairn/", "/")
-// into the one shape the rest of the code expects: "" or "/cairn".
 func NormalizeBase(p string) string {
 	p = strings.Trim(strings.TrimSpace(p), "/")
 	if p == "" {
@@ -23,17 +21,13 @@ func NormalizeBase(p string) string {
 	return "/" + p
 }
 
-// AppURL prefixes a root-absolute local path with the base path. Empty values
-// and anything already pointing elsewhere pass through untouched, including
-// the protocol-relative "//cdn.example.org/x": it starts with a slash but it
-// is another origin, and prefixing it produced a path resolving nowhere.
+// AppURL prefixes a root-absolute local path with the base path. Anything
+// pointing elsewhere passes through untouched, the protocol-relative
+// "//cdn.example.org/x" included: it starts with a slash but names another
+// origin, and prefixing it produces a path that resolves nowhere.
 func AppURL(p string) string {
 	if !config.IsLocalPath(p) {
 		return p
 	}
-	// One of cairn's own assets goes out under its stamped name, wherever it
-	// was built: the touch icon and the manifest's icons come from here and
-	// not from a template, and they were the only surfaces left unstamped.
-	// Anything the operator supplied passes through untouched.
 	return BasePath + stampStatic(p)
 }

--- a/src/internal/server/handlers.go
+++ b/src/internal/server/handlers.go
@@ -74,9 +74,9 @@ func home(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	locale, _, _ := strings.Cut(loc, "/")
-	// The cookie is an explicit choice only: the switcher links carry
-	// ?choose. A negotiated visit leaves no trace, so a visitor whose
-	// browser language changes is followed until they pick one themselves.
+	// The cookie records an explicit choice only: the switcher links carry
+	// ?choose. A negotiated visit leaves no trace, so a visitor whose browser
+	// language changes is followed until they pick one themselves.
 	if r.URL.Query().Has("choose") {
 		http.SetCookie(w, &http.Cookie{Name: "locale", Value: locale, Path: render.BasePath + "/", MaxAge: 365 * 24 * 3600, SameSite: http.SameSiteLaxMode, Secure: secureRequest(r)})
 		w.Header().Set("Cache-Control", "no-store")
@@ -96,11 +96,9 @@ func home(w http.ResponseWriter, r *http.Request) {
 }
 
 // faviconICO answers the well-known path. No browser asks for it, since the
-// head declares the icons; it is here for the feed readers, link previewers
-// and bookmark tools that skip the html and fetch /favicon.ico directly.
-//
-// An operator who set their own favicon gets pointed at it. Serving cairn's
-// stones to a link previewer would put our mark on their site's card.
+// head declares the icons: it is here for the feed readers, link previewers
+// and bookmark tools that skip the html. An operator's own favicon wins, or
+// cairn's stones end up on their site's link card.
 func faviconICO(static fs.FS) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if own := Current().Cfg.Site.Favicon.Light; own != "" {
@@ -111,8 +109,8 @@ func faviconICO(static fs.FS) http.HandlerFunc {
 	}
 }
 
-// manifest makes "add to home screen" give the site its own name and icon;
-// deliberately no service worker and no offline mode.
+// manifest makes "add to home screen" give the site its own name and icon.
+// No service worker, no offline mode.
 func manifest(w http.ResponseWriter, r *http.Request) {
 	cfg := Current().Cfg
 	name := cfg.Site.Title.Get(negotiate(r, cfg.Site.Locales), cfg.DefaultLocale())
@@ -131,15 +129,13 @@ func manifest(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// secureRequest reports whether the visitor reached us over https, directly
-// or behind a proxy. The cookies carry Secure exactly then, so they keep
-// working on the plain-http LAN deployments cairn is also made for.
+// secureRequest reports whether the visitor reached us over https, directly or
+// behind a proxy. The cookies carry Secure exactly then, so they keep working
+// on the plain-http LAN deployments cairn is also made for.
 func secureRequest(r *http.Request) bool {
 	return r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
 }
 
-// siteBase prefers the configured public URL; without one it falls back to
-// what the request headers suggest.
 func siteBase(r *http.Request) string {
 	if u := Current().Cfg.Site.URL; u != "" {
 		return u + render.BasePath
@@ -150,9 +146,9 @@ func siteBase(r *http.Request) string {
 func baseURL(r *http.Request) string {
 	// X-Forwarded-Proto is attacker-controlled until a proxy overwrites it, and
 	// what it builds here is published in robots.txt, the sitemap and
-	// security.txt. Only the two schemes cairn can be reached over are taken;
-	// anything else falls back to what this connection actually is. Host needs
-	// no such guard: net/http rejects a malformed one with 400 before we run.
+	// security.txt. Only the two schemes cairn can be reached over are taken.
+	// Host needs no such guard: net/http rejects a malformed one with 400
+	// before we run.
 	scheme := r.Header.Get("X-Forwarded-Proto")
 	if scheme != "http" && scheme != "https" {
 		if r.TLS != nil {
@@ -175,11 +171,10 @@ func robots(w http.ResponseWriter, r *http.Request) {
 }
 
 // securityTxt answers RFC 9116, and only once an operator has given a contact.
-// Expires is computed per request rather than configured, because a
-// security.txt that has quietly expired is worth less than none at all, and a
-// file regenerated on every read cannot. Canonical and Preferred-Languages are
-// cairn's to fill too: it knows where it is served and which languages it
-// speaks.
+// Expires is computed per request rather than configured: a security.txt that
+// has quietly expired is worth less than none at all, and a file regenerated
+// on every read cannot. cairn fills Canonical and Preferred-Languages from
+// what it already knows.
 func securityTxt(w http.ResponseWriter, r *http.Request) {
 	sec := Current().Cfg.Site.Security
 	if sec.Contact == "" {
@@ -201,7 +196,6 @@ func securityTxt(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Canonical: %s/.well-known/security.txt\n", siteBase(r))
 }
 
-// xmlText escapes a value for an element body.
 func xmlText(s string) string {
 	var b strings.Builder
 	if err := xml.EscapeText(&b, []byte(s)); err != nil {
@@ -224,8 +218,8 @@ func sitemap(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/xml; charset=utf-8")
 	io.WriteString(w, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n")
 	for _, k := range keys {
-		// The host reaches this from the request, so it is text cairn did not
-		// write: escaped, or one odd Host makes the whole document unparseable.
+		// The host comes from the request, so it is text cairn did not write:
+		// escaped, or one odd Host makes the document unparseable.
 		fmt.Fprintf(w, "  <url><loc>%s</loc></url>\n", xmlText(siteBase(r)+"/"+k+"/"))
 	}
 	io.WriteString(w, "</urlset>\n")

--- a/src/internal/server/probe.go
+++ b/src/internal/server/probe.go
@@ -7,15 +7,15 @@ import (
 	"time"
 )
 
-// healthz answers while the process serves, whatever the config says. It is
-// the liveness signal: a broken config is not a reason to kill a container
-// that is happily serving the getting-started page.
+// healthz is the liveness signal: it answers while the process serves,
+// whatever the config says, because a broken config is not a reason to kill a
+// container serving the getting-started page.
 func healthz(w http.ResponseWriter, _ *http.Request) { io.WriteString(w, "ok\n") }
 
-// readyz is the honest one: 503 while no valid config has ever loaded, so a
-// monitor does not sit green on a site that only says "Almost there". A
-// reload that fails later keeps the last good pages, which is degraded but
-// genuinely serving, so it stays ready.
+// readyz answers 503 while no valid config has ever loaded, so a monitor does
+// not sit green on a site that only says "Almost there". A reload that fails
+// later keeps the last good pages, degraded but genuinely serving, so it stays
+// ready.
 func readyz(w http.ResponseWriter, _ *http.Request) {
 	if !Current().Ready {
 		http.Error(w, "no valid config yet\n", http.StatusServiceUnavailable)
@@ -24,19 +24,24 @@ func readyz(w http.ResponseWriter, _ *http.Request) {
 	io.WriteString(w, "ready\n")
 }
 
+// A bind address naming no interface in particular; loopback is the one of
+// them we can reach.
+func everyInterface(host string) bool {
+	return host == "" || host == "0.0.0.0" || host == "::"
+}
+
 // Probe asks the running server whether it is alive, for a container
 // healthcheck that has no shell to do it with. It dials the address cairn was
 // told to listen on, not loopback: keeping only the port meant an instance
 // bound to one interface was probed somewhere else entirely, which either
-// restart-loops a healthy container or, worse, reports green because something
+// restart-loops a healthy container or reports green because something
 // unrelated answers on that port.
 func Probe(addr string) int {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
 		return 1
 	}
-	// An empty host is "every interface"; loopback is the one we can reach.
-	if host == "" || host == "0.0.0.0" || host == "::" {
+	if everyInterface(host) {
 		host = "127.0.0.1"
 	}
 	client := http.Client{Timeout: 3 * time.Second}

--- a/src/internal/server/routing.go
+++ b/src/internal/server/routing.go
@@ -12,9 +12,9 @@ import (
 	"github.com/MorganKryze/cairn/src/internal/render"
 )
 
-// mount puts the whole site under render.BasePath. The two probes stay at the root
-// whatever the prefix: an orchestrator talks to cairn directly, not through
-// the proxy that adds it.
+// mount puts the whole site under render.BasePath. The two probes stay at the
+// root whatever the prefix: an orchestrator talks to cairn directly, not
+// through the proxy that adds it.
 func mount(h http.Handler) http.Handler {
 	if render.BasePath == "" {
 		return h
@@ -22,14 +22,14 @@ func mount(h http.Handler) http.Handler {
 	outer := http.NewServeMux()
 	outer.HandleFunc("GET /healthz", healthz)
 	outer.HandleFunc("GET /readyz", readyz)
-	// registering the subtree also makes ServeMux redirect a bare /cairn to
-	// /cairn/, so the mount point works with or without its trailing slash
+	// Registering the subtree also makes ServeMux redirect a bare /cairn to
+	// /cairn/, so the mount point works with or without its trailing slash.
 	outer.Handle(render.BasePath+"/", http.StripPrefix(render.BasePath, h))
 	return outer
 }
 
-// secureHeaders sets the response headers a security scan would ask for.
-// The CSP whitelists exactly what the pages use; see BuildCSP.
+// secureHeaders sets the hardening headers. The CSP whitelists exactly what
+// the pages use; see BuildCSP.
 func secureHeaders(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		hd := w.Header()
@@ -40,13 +40,11 @@ func secureHeaders(h http.Handler) http.Handler {
 		hd.Set("Content-Security-Policy", Current().CSP)
 		// Severs window.opener on the links that leave for a service, so a page
 		// cairn opened cannot navigate the tab it came from. The template
-		// already carries rel="noopener"; this is the belt that survives a
-		// future edit forgetting it.
+		// already carries rel="noopener"; this survives an edit that drops it.
 		hd.Set("Cross-Origin-Opener-Policy", "same-origin")
 		// same-site rather than same-origin: self-hosters put their services on
-		// sibling subdomains, and one of those pages showing a cairn icon is a
-		// reasonable thing to do. A genuine third party still cannot embed
-		// anything of ours.
+		// sibling subdomains, and one of those pages may show a cairn icon. A
+		// genuine third party still cannot embed anything of ours.
 		hd.Set("Cross-Origin-Resource-Policy", "same-site")
 		// HSTS only once the visit is already https, like the cookies: sending
 		// it over plain http would strand the LAN deployments cairn also serves.
@@ -57,8 +55,17 @@ func secureHeaders(h http.Handler) http.Handler {
 	})
 }
 
-// noListing serves files but never directory indexes, and never anything under
-// a dot-prefixed name.
+// hasDotSegment covers a .. that survived the mux's cleaning as well as the
+// dotfiles: the dot can be anywhere in the path, not only at the front.
+func hasDotSegment(path string) bool {
+	for _, seg := range strings.Split(path, "/") {
+		if strings.HasPrefix(seg, ".") {
+			return true
+		}
+	}
+	return false
+}
+
 func noListing(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// After StripPrefix the folder root is the empty path.
@@ -67,20 +74,15 @@ func noListing(h http.Handler) http.Handler {
 			return
 		}
 		// -assets gets pointed at a working copy often enough that it has to be
-		// safe: with the dot served, /assets/.git/config is a public URL, and it
-		// carries the remote and whatever a credential helper wrote into it.
-		// The whole class goes rather than a blocklist, which would be one .env
-		// or .DS_Store behind for as long as the file exists. Nothing cairn
-		// serves lives under a dot: the icons, logos and previews are ordinary
-		// names, and /.well-known/security.txt is answered by its own handler on
-		// the route table, never out of these trees. Segment by segment because
-		// the dot can be anywhere in the path, and this catches a .. that
-		// somehow survived the mux's cleaning on the way here too.
-		for _, seg := range strings.Split(r.URL.Path, "/") {
-			if strings.HasPrefix(seg, ".") {
-				http.NotFound(w, r)
-				return
-			}
+		// safe: with the dot served, /assets/.git/config is a public URL
+		// carrying the remote and whatever a credential helper wrote into it.
+		// The whole class goes rather than a blocklist, which stays one .env or
+		// .DS_Store behind. Nothing cairn serves lives under a dot:
+		// /.well-known/security.txt has its own handler on the route table,
+		// never out of these trees.
+		if hasDotSegment(r.URL.Path) {
+			http.NotFound(w, r)
+			return
 		}
 		h.ServeHTTP(w, r)
 	})
@@ -88,27 +90,24 @@ func noListing(h http.Handler) http.Handler {
 
 // gzipPool keeps the compressor's window and tables between requests. A fresh
 // gzip.NewWriter costs about 800 KB of heap, held for as long as the client
-// takes to read: measured, 200 slow readers took a process from 16 MB to 171
-// MB, which crosses the 64Mi the chart asks for by default and the 128M the
-// compose file sets. Pooled, that cost is paid once per concurrent response
-// rather than once per response.
+// takes to read: 200 slow readers took a process from 16 MB to 171 MB, past
+// the 64Mi the chart asks for and the 128M the compose file sets. Pooled, that
+// cost is paid once per concurrent response.
 var gzipPool = sync.Pool{New: func() any { return gzip.NewWriter(io.Discard) }}
 
 // gzipMark separates the compressed representation's validator from the
 // identity one's. The handler tags a page by its html alone, so without this
 // one ETag names two different answers; Vary keeps a compliant cache honest,
 // but a cache configured to ignore it then hands gzip bytes to a client that
-// cannot inflate them, and the client has no way to tell.
+// cannot inflate them.
 //
 // The mark goes inside the quotes. An entity-tag is a quoted string and
-// nothing but, so Apache's historical `"…"-gzip`, with the mark hung off the
-// outside, is not a valid one; a strict parser drops the tag and revalidation
-// quietly stops happening at all.
+// nothing but, so Apache's historical `"…"-gzip` is not a valid one: a strict
+// parser drops the tag and revalidation stops happening at all.
 const gzipMark = "-gzip"
 
-// markGzip moves one validator onto the compressed representation. Inserted
-// before the closing quote rather than appended, so a weak `W/"…"` comes back
-// weak instead of turning into something that parses as neither.
+// markGzip inserts the mark before the closing quote rather than appending it,
+// so a weak `W/"…"` comes back weak instead of parsing as neither.
 func markGzip(tag string) string {
 	if !strings.HasSuffix(tag, `"`) {
 		return tag
@@ -116,37 +115,29 @@ func markGzip(tag string) string {
 	return tag[:len(tag)-1] + gzipMark + `"`
 }
 
-// unmarkGzip is the inverse, over a whole If-None-Match list. ReplaceAll needs
-// no parsing and cannot corrupt a tag: a double quote is the one byte an
-// entity-tag's body may not contain, so `-gzip"` in a well-formed list is
-// always a mark of ours meeting its closing quote, never a slice out of the
-// middle of someone's opaque value. A bare `*` and every unmarked tag come
-// through untouched, and a list is handled in one pass without splitting on a
-// comma, which an entity-tag is allowed to contain.
+// unmarkGzip is the inverse, over a whole If-None-Match list. A double quote
+// is the one byte an entity-tag's body may not contain, so `-gzip"` in a
+// well-formed list is always a mark of ours meeting its closing quote, never a
+// slice out of someone's opaque value. One pass, without splitting on a comma
+// an entity-tag is allowed to contain.
 func unmarkGzip(list string) string {
 	return strings.ReplaceAll(list, gzipMark+`"`, `"`)
 }
 
-// gzipWriter decides at WriteHeader time, once the handler has settled its
-// Content-Type. Deciding earlier would mean guessing from the path, which the
-// /assets tree makes unreliable.
 type gzipWriter struct {
 	http.ResponseWriter
 	gz      *gzip.Writer
 	decided bool
-	// marked records that the request arrived carrying a marked validator,
-	// which is the only thing a 304 has left to reconstruct one from.
+	// marked: the request arrived carrying a marked validator, which is the
+	// only thing a 304 has left to reconstruct one from.
 	marked bool
 }
 
-// compressible covers what cairn actually serves as text. Images, fonts and
-// the ico are already compressed; running them through gzip spends CPU to add
-// bytes.
 func compressible(ct string) bool {
 	ct, _, _ = strings.Cut(ct, ";")
 	switch strings.TrimSpace(ct) {
 	// text/javascript rather than application/javascript: that is what Go's
-	// mime table now hands back for a .js, and the older spelling alone let
+	// mime table hands back for a .js, and the older spelling alone let
 	// search.js through uncompressed.
 	case "text/html", "text/plain", "text/css", "text/xml", "text/javascript",
 		"application/javascript", "application/json", "application/xml",
@@ -156,18 +147,17 @@ func compressible(ct string) bool {
 	return false
 }
 
-// WriteHeader is where the decision has to be made, not Write: headers are
-// frozen the moment it runs, and http.ServeContent calls it before copying a
-// file. Deciding one write too late meant static files went out compressed
-// with no Content-Encoding to say so, and a browser ran gzip bytes as
-// JavaScript.
+// WriteHeader is where the decision has to be made, not Write: the handler has
+// settled its Content-Type by now, headers freeze the moment WriteHeader runs,
+// and http.ServeContent calls it before copying a file. One write too late,
+// static files went out compressed with no Content-Encoding to say so, and a
+// browser ran gzip bytes as JavaScript.
 func (w *gzipWriter) WriteHeader(code int) {
 	if !w.decided {
 		w.decided = true
 		// 200 only, not any 2xx. A 206 carries a Content-Range describing the
-		// uncompressed representation, so gzipping it produces a response that
-		// contradicts itself and reassembles into garbage for anything that
-		// fetches in slices.
+		// uncompressed representation, so gzipping it reassembles into garbage
+		// for anything that fetches in slices.
 		if code == http.StatusOK && compressible(w.Header().Get("Content-Type")) {
 			// The length is the uncompressed one, and Go would send it as is.
 			w.Header().Del("Content-Length")
@@ -175,12 +165,11 @@ func (w *gzipWriter) WriteHeader(code int) {
 			w.gz = gzipPool.Get().(*gzip.Writer)
 			w.gz.Reset(w.ResponseWriter)
 		}
-		// A validator names the bytes that go out, and this is the line that
-		// settled which ones those are. A 304 sends none, so the representation
-		// being confirmed is the one the client already holds: the right tag
-		// there is the one it sent, which means the mark goes back on exactly
-		// when it came off. Doing it any other way hands an identity cache a
-		// gzip tag, or the reverse, and the next revalidation is wrong.
+		// A 304 sends no bytes, so the representation being confirmed is the one
+		// the client already holds: the right tag there is the one it sent, so
+		// the mark goes back on exactly when it came off. Any other way hands an
+		// identity cache a gzip tag, or the reverse, and the next revalidation
+		// is wrong.
 		if w.gz != nil || (code == http.StatusNotModified && w.marked) {
 			if tag := w.Header().Get("ETag"); tag != "" {
 				w.Header().Set("ETag", markGzip(tag))
@@ -203,8 +192,8 @@ func (w *gzipWriter) Write(b []byte) (int, error) {
 // ReadFrom has to exist, and has to funnel back through Write. The embedded
 // http.ResponseWriter implements io.ReaderFrom, and embedding promotes it, so
 // the io.Copy inside http.ServeContent would hand a file straight to the
-// socket and skip the compression entirely. That is not hypothetical: the
-// pages came back gzipped while every static file did not.
+// socket and skip compression: the pages came back gzipped while every static
+// file did not.
 func (w *gzipWriter) ReadFrom(r io.Reader) (int64, error) {
 	return io.Copy(struct{ io.Writer }{w}, r)
 }
@@ -214,17 +203,17 @@ func (w *gzipWriter) Close() error {
 		return nil
 	}
 	err := w.gz.Close()
-	// Reset before returning it: a writer put back still holding a reference to
-	// this response's ResponseWriter would keep the whole request alive.
+	// Reset before returning it: a pooled writer still holding this response's
+	// ResponseWriter would keep the whole request alive.
 	w.gz.Reset(io.Discard)
 	gzipPool.Put(w.gz)
 	w.gz = nil
 	return err
 }
 
-// acceptsGzip reads the header rather than searching it for a substring.
-// "gzip;q=0" is how a client that cannot inflate says so, and it used to be
-// taken for a yes; "notgzipatall" is not an offer at all.
+// acceptsGzip parses the header rather than searching it for a substring.
+// "gzip;q=0" is how a client that cannot inflate says so, and a substring
+// search took it for a yes; "notgzipatall" is not an offer at all.
 func acceptsGzip(h string) bool {
 	for _, part := range strings.Split(h, ",") {
 		tok, params, _ := strings.Cut(strings.TrimSpace(part), ";")
@@ -244,9 +233,8 @@ func acceptsGzip(h string) bool {
 // compress gzips the text responses for clients that asked. Vary rides on
 // every response, compressed or not: a cache that stored the plain answer must
 // not hand it to a client that would have got the compressed one, and the
-// header is the only thing telling it so. The validator is marked to say the
-// same thing a second way, for the caches that are told to ignore Vary; see
-// gzipMark.
+// header is the only thing telling it so. The validator says the same thing a
+// second way for caches told to ignore Vary; see gzipMark.
 func compress(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Vary", "Accept-Encoding")
@@ -256,22 +244,20 @@ func compress(h http.Handler) http.Handler {
 		// the uncompressed representation, which is a true one, rather than
 		// advertising the 23 bytes of an empty gzip member.
 		if r.Method == http.MethodHead || !acceptsGzip(r.Header.Get("Accept-Encoding")) {
-			// The mark is deliberately left on the way in here. A client that
-			// cached the compressed page and can no longer inflate one needs
-			// the identity bytes, so its marked tag must fail the handler's
-			// comparison and earn a 200; stripping it unconditionally would
-			// answer 304 and leave it holding gzip it cannot read.
+			// The mark stays on the way in. A client that cached the compressed
+			// page and can no longer inflate one needs the identity bytes, so
+			// its marked tag must fail the handler's comparison and earn a 200;
+			// stripping it would answer 304 and leave it holding gzip it cannot
+			// read.
 			h.ServeHTTP(w, r)
 			return
 		}
 		gw := &gzipWriter{ResponseWriter: w}
-		// The handler does its own If-None-Match comparison, and it does it
-		// before this layer would rewrite anything on the way out, so the mark
-		// has to come off here or every conditional request on a compressed
-		// page comes back as a full 200 and the ETag stops saving a byte.
-		// Copied rather than edited in place: a handler is not supposed to find
-		// its request mutated underneath it, and the copy is only paid for by
-		// the requests that actually carry a mark.
+		// The handler runs its own If-None-Match comparison before this layer
+		// would rewrite anything on the way out, so the mark has to come off
+		// here or every conditional request on a compressed page comes back as
+		// a full 200. Copied rather than edited in place: a handler is not
+		// supposed to find its request mutated underneath it.
 		if inm := r.Header.Get("If-None-Match"); strings.Contains(inm, gzipMark+`"`) {
 			gw.marked = true
 			clone := *r
@@ -296,18 +282,15 @@ func cacheControl(h http.Handler) http.Handler {
 }
 
 // stamped serves cairn's own assets under the digested names the pages point
-// at, and only under a digest cairn itself issued.
+// at, and only under a digest cairn itself issued. A year and immutable is
+// safe for one reason: the name changes whenever the bytes do, so this
+// response can never become the wrong answer. The pages that point here are
+// served no-cache, so an upgrade is picked up on the next visit without a hard
+// refresh.
 //
-// A year and immutable, which is safe for exactly one reason: the name changes
-// whenever the bytes do, so this response can never become the wrong answer.
-// The pages that point here are served no-cache, so an upgrade is picked up on
-// the next visit without anyone reaching for a hard refresh, which is the
-// whole point of the exercise.
-//
-// A plain name falls through to the handler behind this one, on the day-long
-// cache it has always had, so anything that hardcoded /static/style.css goes
-// on working. A name shaped like a digest that cairn never issued falls
-// through too, and meets the 404 it deserves.
+// A plain name falls through to the handler behind this one and its day-long
+// cache, so anything that hardcoded /static/style.css goes on working. A name
+// shaped like a digest cairn never issued falls through too, and 404s.
 func stamped(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if real, ok := render.AssetPath(strings.TrimPrefix(r.URL.Path, "/static/")); ok {

--- a/src/internal/server/server.go
+++ b/src/internal/server/server.go
@@ -13,15 +13,14 @@ import (
 	"github.com/MorganKryze/cairn/src/internal/render"
 )
 
-// current is the whole served site: an immutable model swapped atomically on
-// config reload or status change, so a request never sees a half-built page.
+// current is the whole served site, swapped whole on config reload or status
+// change, so a request never sees a half-built page.
 var current atomic.Pointer[render.Model]
 
-// reloadMu serializes the two writers of current (config watcher and status
-// poller) so neither clobbers the other's half of the model.
+// reloadMu serializes the two writers of current, the config watcher and the
+// status poller, so neither clobbers the other's half of the model.
 var reloadMu sync.Mutex
 
-// Store installs a model, and Current reads the live one.
 func Store(m *render.Model) { current.Store(m) }
 
 // Current returns the model every handler renders from.
@@ -30,8 +29,8 @@ func Current() *render.Model { return current.Load() }
 // Serve builds the routes and blocks. cfgDir and assetsDir are served as
 // static trees on top of the embedded ones.
 func Serve(addr, cfgDir, assetsDir string) error {
-	// ReadHeaderTimeout caps slow-header (Slowloris) clients; WriteTimeout
-	// drops the ones that never read their answer; IdleTimeout reclaims
+	// ReadHeaderTimeout caps slow-header (Slowloris) clients, WriteTimeout
+	// drops the ones that never read their answer, IdleTimeout reclaims
 	// keep-alives. Every response is a small pre-rendered page, so these are
 	// generous.
 	srv := &http.Server{
@@ -51,37 +50,30 @@ func Serve(addr, cfgDir, assetsDir string) error {
 // root, /healthz, /readyz and the 404 for everything outside the prefix, and
 // with the headers inside mount those three came back bare under -base-path:
 // no COOP, no CORP, no HSTS. HSTS is the one that costs, because the bare host
-// is exactly where a first visit lands, and a header that never arrives there
-// cannot pin the scheme before someone gets to downgrade it.
+// is where a first visit lands, and a header that never arrives there cannot
+// pin the scheme before someone downgrades it.
 //
 // compress stays inside secureHeaders and still outside mount, so the two
-// deployments answer alike. Without -base-path the probes were already inside
-// both wrappers and nobody chose that difference; putting mount innermost
-// settles it in the direction the default deployment has been running all
-// along. It costs the probes nothing: healthz and readyz set no Content-Type,
-// compress reads the one on the header before net/http gets to sniff one, and
-// an empty type is not compressible, so "ok\n" goes out as three bytes either
-// way. What the two wrappers actually add there is Vary and the hardening
-// headers, which is the whole point.
+// deployments answer alike. It costs the probes nothing: healthz and readyz
+// set no Content-Type, compress reads the header before net/http gets to sniff
+// one, and an empty type is not compressible, so "ok\n" goes out as three
+// bytes either way. The two wrappers add Vary and the hardening headers there.
 func handler(cfgDir, assetsDir string) http.Handler {
 	return secureHeaders(compress(mount(routes(cfgDir, assetsDir))))
 }
 
-// routes maps every path cairn answers. Nothing here is exported: what the
-// program needs from this package is Serve, the loops and the probe.
 func routes(cfgDir, assetsDir string) *http.ServeMux {
 	mux := http.NewServeMux()
 	static, _ := fs.Sub(render.Embedded, "assets")
-	// stamped inside cacheControl, not around it, and the order is the whole
-	// point: both write Cache-Control, so the last one to run wins. Written
-	// the other way the day-long header overwrote the year on every stamped
-	// asset, silently, and a test now holds it.
+	// stamped inside cacheControl, not around it: both write Cache-Control and
+	// the last to run wins. The other way round, the day-long header silently
+	// overwrote the year on every stamped asset. A test holds the order.
 	mux.Handle("GET /static/", cacheControl(stamped(http.StripPrefix("/static/", http.FileServerFS(static)))))
 	// Mounted unconditionally: a dir that appears after boot just works.
 	mux.Handle("GET /assets/", http.StripPrefix("/assets/", noListing(http.FileServer(http.Dir(assetsDir)))))
 	// Service preview images live next to the yaml, in <config>/media/.
 	mux.Handle("GET /media/", http.StripPrefix("/media/", noListing(http.FileServer(http.Dir(filepath.Join(cfgDir, "media"))))))
-	// And the self-hosted font theme.font.file names, in <config>/fonts/.
+	// theme.font.file names a self-hosted font in <config>/fonts/.
 	mux.Handle("GET /fonts/", http.StripPrefix("/fonts/", noListing(http.FileServer(http.Dir(filepath.Join(cfgDir, "fonts"))))))
 	mux.HandleFunc("GET /healthz", healthz)
 	mux.HandleFunc("GET /readyz", readyz)
@@ -95,8 +87,8 @@ func routes(cfgDir, assetsDir string) *http.ServeMux {
 	mux.HandleFunc("GET /sitemap.xml", sitemap)
 	mux.HandleFunc("GET /.well-known/security.txt", securityTxt)
 	mux.HandleFunc("GET /{$}", root)
-	// Catch-all rather than /{locale}/{$}: a wildcard pattern would conflict
-	// with the /static/ and /assets/ subtrees in the 1.22 mux.
+	// Catch-all rather than /{locale}/{$}: a wildcard pattern conflicts with
+	// the /static/ and /assets/ subtrees in the 1.22 mux.
 	mux.HandleFunc("GET /", home)
 	return mux
 }

--- a/src/internal/server/watch.go
+++ b/src/internal/server/watch.go
@@ -14,9 +14,8 @@ import (
 	"github.com/MorganKryze/cairn/src/internal/status"
 )
 
-// watch polls instead of using inotify: polling survives bind mounts and
-// configmap symlink swaps that file watchers routinely miss. The loop is only
-// the clock; reloadOnce does the work and is what the tests drive.
+// Watch polls instead of using inotify: polling survives the bind mounts and
+// configmap symlink swaps that file watchers routinely miss.
 func Watch(dir string) {
 	last := watchPrint(dir)
 	for range time.Tick(2 * time.Second) {
@@ -24,15 +23,14 @@ func Watch(dir string) {
 	}
 }
 
-// watchPrint fingerprints everything a page is built from: the config dir, and
-// the local icons that live outside it but change the pages too.
+// watchPrint fingerprints everything a page is built from. The local icons
+// live outside the config dir and change the pages too.
 func watchPrint(dir string) string {
 	return fingerprint(dir) + fingerprint(filepath.Join(config.AssetsPath, "icons"))
 }
 
-// reloadOnce runs one iteration of the watcher and returns the fingerprint to
-// compare against next time. An unchanged directory costs one stat sweep; a
-// broken config is logged and the previous pages stay up.
+// reloadOnce returns the fingerprint to compare against next time. A broken
+// config is logged and the previous pages stay up.
 func reloadOnce(dir, last string) string {
 	fp := watchPrint(dir)
 	if fp == last {
@@ -57,8 +55,8 @@ func reloadOnce(dir, last string) string {
 	return fp
 }
 
-// pollStatus feeds the status dots from the Gatus API, server-side only. On
-// any fetch problem the dots disappear rather than go stale.
+// Poll feeds the status dots from the monitor's API, server-side only. On any
+// fetch problem the dots disappear rather than go stale.
 func Poll() {
 	if cfg := Current().Cfg; cfg.Site.StatusAddress() != "" {
 		log.Printf("status: polling %s at %s every %s", cfg.Site.StatusProvider(), cfg.Site.StatusAddress(), cfg.StatusInterval())
@@ -79,14 +77,13 @@ func Poll() {
 	}
 }
 
-// source is the status block as the poller needs it.
 func source(cfg *config.Config) status.Source {
 	return status.Source{
 		URL:      cfg.Site.StatusAddress(),
 		Provider: cfg.Site.StatusProvider(),
 		Slug:     cfg.Site.Status.Slug,
-		// The two mapping types are deliberately separate, since config
-		// imports nothing of cairn's; this is where one becomes the other.
+		// config imports nothing of cairn's, so the two mapping types stay
+		// separate; this is where one becomes the other.
 		TokenFile:   cfg.Site.Status.TokenFile,
 		TokenScheme: cfg.Site.Status.TokenScheme,
 		Map: status.Mapping{
@@ -103,12 +100,10 @@ func source(cfg *config.Config) status.Source {
 	}
 }
 
-// pollLog remembers the last messages printed, so a Gatus that stays down
+// pollLog remembers the last messages printed, so a monitor that stays down
 // says so once instead of every interval.
 type pollLog struct{ err, missing string }
 
-// pollOnce runs one status poll and swaps the pages in when the dots changed.
-// An empty url is a no-op: a site without Gatus shows no pill at all.
 func pollOnce(src status.Source, seen *pollLog) {
 	if src.URL == "" {
 		return
@@ -146,11 +141,10 @@ func pollOnce(src status.Source, seen *pollLog) {
 
 // fingerprint walks the tree rather than listing one level. A directory's own
 // mtime does not move when a file inside it is overwritten, so media/shot.png
-// replaced in place used to stay invisible: the page kept declaring the old
-// image's width and height until something unrelated touched the top level.
-//
-// The walk is bounded by what a config directory holds, a handful of yaml and
-// a media folder, and it runs on the same two-second tick as before.
+// replaced in place stayed invisible: the page kept declaring the old image's
+// width and height until something unrelated touched the top level. The walk
+// is bounded by what a config directory holds, a handful of yaml and a media
+// folder.
 func fingerprint(dir string) string {
 	var b strings.Builder
 	_ = filepath.WalkDir(dir, func(p string, d fs.DirEntry, err error) error {

--- a/src/internal/status/gatus.go
+++ b/src/internal/status/gatus.go
@@ -20,24 +20,22 @@ import (
 )
 
 // hidden is the Gatus ui block that keeps an endpoint's address off its own
-// dashboard. All three keys, because they hide three different things: the
-// URL, the hostname, and the port, which outlives the other two. hide-url also
-// redacts the address inside the error text, which is the leak that gets
-// forgotten because it only appears when a check fails.
+// dashboard. All three keys are needed: they hide the URL, the hostname and the
+// port separately. hide-url also redacts the address inside the error text,
+// which only appears when a check fails.
 type hidden struct {
 	URL      bool `yaml:"hide-url"`
 	Hostname bool `yaml:"hide-hostname"`
 	Port     bool `yaml:"hide-port"`
 }
 
-// Emit derives a Gatus endpoints config from the services. Endpoint
-// names are service ids: that is also what the status poller matches on.
+// Emit derives a Gatus endpoints config from the services. Endpoint names are
+// service ids, which is what the status poller matches on.
 //
-// hide adds the ui block above to every endpoint. It is off by default because
-// what this writes is the service's own public URL, already printed on its
-// card: hiding that would hide from the status page what the directory shows
-// next to it. It earns its keep once the emitted file is edited to probe an
-// address that is not the published one.
+// hide adds the ui block above to every endpoint. It is off by default: what
+// this writes is the service's own public URL, already printed on its card. It
+// earns its keep once the emitted file is edited to probe an address that is
+// not the published one.
 func Emit(cfg *config.Config, hide bool) ([]byte, error) {
 	type endpoint struct {
 		Name       string   `yaml:"name"`
@@ -54,10 +52,7 @@ func Emit(cfg *config.Config, hide bool) ([]byte, error) {
 	var eps []endpoint
 	for _, c := range cfg.Categories {
 		for _, s := range c.Services {
-			// Nothing to monitor for a service that is not there yet or not
-			// there any more, and an endpoint for one is a red dashboard row
-			// its operator can never fix.
-			if !strings.HasPrefix(s.URL, "http") || s.State.Disables() {
+			if !monitorable(s) {
 				continue
 			}
 			eps = append(eps, endpoint{
@@ -73,16 +68,21 @@ func Emit(cfg *config.Config, hide bool) ([]byte, error) {
 	return yaml.Marshal(map[string]any{"endpoints": eps})
 }
 
-// Level is what a source says about one service. Four values, counted from
-// what the sources actually declare rather than chosen: up and down are
-// universal, degraded and maintenance are each drawn by four monitors of the
-// eight surveyed. Anything else a source says reads as down, which is the safe
-// direction: a word added to a vendor's API next year cannot make a broken
-// service look green.
+// An endpoint for a service that is not there yet or not there any more is a
+// red dashboard row its operator can never fix.
+func monitorable(s config.Service) bool {
+	return strings.HasPrefix(s.URL, "http") && !s.State.Disables()
+}
+
+// Level is what a source says about one service. Up and down are universal,
+// degraded and maintenance are each drawn by four monitors of the eight
+// surveyed. Anything else a source says reads as down, the safe direction: a
+// word added to a vendor's API next year cannot make a broken service look
+// green.
 //
 // Gatus reaches only two of them. Its results carry a success bool and nothing
-// else, which is why giving the other sources more states cannot move what a
-// Gatus site renders.
+// else, so giving the other sources more states cannot move what a Gatus site
+// renders.
 const (
 	LevelUp          = "up"
 	LevelDegraded    = "degraded"
@@ -92,8 +92,8 @@ const (
 
 // State is what a source says about one service: the level, and the key of the
 // source's own page for it, empty when it has none. The key is reported rather
-// than derived because only the operator's Gatus config decides how endpoints
-// are grouped, and cairn's categories are not that config.
+// than derived: only the operator's Gatus config decides how endpoints are
+// grouped, and cairn's categories are not that config.
 type State struct {
 	Level string
 	Key   string
@@ -101,8 +101,8 @@ type State struct {
 
 // Key builds the key Gatus uses in its endpoint page URLs
 // (/endpoints/{group}_{name}), mirroring its own sanitization. It is the
-// fallback for a Gatus too old to report one, and for the pills that show
-// before Gatus has answered at all.
+// fallback for a Gatus too old to report one, and for the pills drawn before
+// Gatus has answered at all.
 func Key(group, name string) string {
 	sanitize := func(s string) string {
 		s = strings.ToLower(s)
@@ -111,7 +111,7 @@ func Key(group, name string) string {
 	return sanitize(group) + "_" + sanitize(name)
 }
 
-// Unmonitored names the services Gatus knows nothing about, so an id
+// Unmonitored names the services the monitor knows nothing about, so an id
 // mismatch is one log line instead of a silent missing pill.
 func Unmonitored(cfg *config.Config, statuses map[string]State) string {
 	var ids []string
@@ -134,43 +134,38 @@ func Unmonitored(cfg *config.Config, statuses map[string]State) string {
 	}
 	line := fmt.Sprintf("%d %s the %s at %s says nothing about, %s no pill: %s",
 		len(ids), subject, cfg.Site.StatusProvider(), cfg.Site.StatusAddress(), cards, strings.Join(ids, ", "))
-	// The other half of the answer. Listing what is missing tells an operator
-	// nothing they did not already see on the page; listing the names the
-	// monitor actually offered puts the two side by side, and a mismatch that
-	// case-folding cannot reach, a domain name or a name with a space in it,
-	// is obvious at a glance. It is only the leftovers: names no service
-	// claimed, which is exactly the set worth renaming.
-	//
-	// Nothing is printed when every name was claimed, since a second list that
-	// is always there is a second list nobody reads.
-	var spare []string
+	// Listing what is missing tells an operator nothing they did not already
+	// see on the page. Naming what the monitor offered and no service claimed
+	// puts the two side by side, so a mismatch case-folding cannot reach, a
+	// domain name or a name with a space in it, is obvious at a glance.
+	var unclaimed []string
 	for k := range statuses {
 		if !claimed[k] {
-			spare = append(spare, k)
+			unclaimed = append(unclaimed, k)
 		}
 	}
-	if len(spare) == 0 {
+	if len(unclaimed) == 0 {
 		return line
 	}
-	slices.Sort(spare)
+	slices.Sort(unclaimed)
 	names := "names"
-	if len(spare) == 1 {
+	if len(unclaimed) == 1 {
 		names = "name"
 	}
 	return fmt.Sprintf("%s. It reports %d %s no service id matches: %s",
-		line, len(spare), names, strings.Join(spare, ", "))
+		line, len(unclaimed), names, strings.Join(unclaimed, ", "))
 }
 
 // verifying and skipping are built once and reused. A client per poll would
 // build a fresh connection pool every interval and leave the old one to be
 // collected with its idle sockets still open.
 //
-// The second one exists because an internal Gatus usually answers with a
-// certificate no public authority signed, and mounting a CA bundle is not
-// always the operator's to arrange. It is a real hole and it is theirs to open:
-// with verification off, anything that can answer on that address decides what
-// the pills say, and the day the certificate changes stops being visible.
-// cairn says so at startup and on every -check rather than only here.
+// skipping exists for an internal Gatus answering with a certificate no public
+// authority signed, where mounting a CA bundle is not always the operator's to
+// arrange. It is a real hole and theirs to open: with verification off,
+// anything that can answer on that address decides what the pills say, and the
+// day the certificate changes stops being visible. cairn says so at startup and
+// on every -check rather than only here.
 var (
 	verifying = &http.Client{Timeout: 5 * time.Second}
 	skipping  = &http.Client{
@@ -184,39 +179,35 @@ var (
 	}
 )
 
-// Source is where the pills come from: the monitor cairn polls, and how much
-// it is willing to trust on the way there. It mirrors the status block in
-// site.yaml, and exists so the trust settings travel together with the address
-// they apply to rather than as loose parameters.
+// Source is where the pills come from: the monitor cairn polls, and how much it
+// is willing to trust on the way there. It mirrors the status block in
+// site.yaml, so the trust settings travel with the address they apply to.
 type Source struct {
 	URL      string
 	Provider string // status.provider: empty means gatus, which is what every config written before providers existed says
 	Slug     string // status.slug: kuma only, the published status page to read
 	Insecure bool   // status.insecure: verify nothing
 	CA       string // status.ca: verify against this too, a URL or an /assets path
-	// TokenFile names a file holding a bearer token, never the token itself:
-	// a secret written in site.yaml is a secret in a config repository. Every
+	// TokenFile names a file holding a bearer token, never the token itself: a
+	// secret written in site.yaml is a secret in a config repository. Every
 	// platform that has secrets delivers them as a mounted file.
 	TokenFile   string
 	TokenScheme string  // default Bearer; Statuspage wants OAuth
 	Map         Mapping // json only: how to read somebody else's document
 }
 
-// trusted caches the client built from a bundle, because building one means
-// reading or fetching that bundle and a poll happens every interval.
+// trusted caches the client built from a bundle: building one means reading or
+// fetching that bundle, and a poll happens every interval.
 //
 // Only a success is cached. A bundle served from an address that is not up yet
-// has to be tried again on the next poll: caching the failure would recreate,
-// one layer down, the bug where cairn started before the thing it depends on
-// and never recovered.
+// is tried again on the next poll, so a cairn started before what it depends on
+// still recovers.
 var trusted struct {
 	sync.Mutex
 	ref    string
 	client *http.Client
 }
 
-// clientFor picks the client for a source: the shared verifying one, the shared
-// skipping one, or one carrying the operator's own authority.
 func clientFor(src Source) (*http.Client, error) {
 	if src.Insecure {
 		return skipping, nil
@@ -239,8 +230,8 @@ func clientFor(src Source) (*http.Client, error) {
 
 // trusting builds a client that verifies against the system roots plus the
 // bundle at ref. Plus, not instead: a Gatus whose certificate a public
-// authority did sign keeps working, and an operator who adds a bundle has not
-// silently narrowed what else cairn would accept.
+// authority did sign keeps working, and adding a bundle narrows nothing else
+// cairn would accept.
 func trusting(ref string) (*http.Client, error) {
 	body, err := bundle(ref)
 	if err != nil {
@@ -261,7 +252,10 @@ func trusting(ref string) (*http.Client, error) {
 	}, nil
 }
 
-// bundle reads the PEM, from the mounted assets dir or over the network.
+// maxBundle: a CA bundle is kilobytes, the whole public root store a few
+// hundred. Unbounded, an endless stream would eat the process.
+const maxBundle = 1 << 20
+
 func bundle(ref string) ([]byte, error) {
 	if p := config.AssetFile(ref); p != "" {
 		return os.ReadFile(p)
@@ -274,27 +268,28 @@ func bundle(ref string) ([]byte, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("answered %s", resp.Status)
 	}
-	// A CA bundle is kilobytes; the whole public root store is a few hundred.
-	// The cap is what stops an endless stream from eating the process, the
-	// same reason the statuses body has one.
-	return io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	return io.ReadAll(io.LimitReader(resp.Body, maxBundle))
 }
 
-// fetcher is one way of asking a monitor what it knows. The client is chosen
-// once, by Fetch, so every provider inherits the same timeout and the same
-// answer to status.insecure and status.ca.
+// fetcher is one way of asking a monitor what it knows. Fetch chooses the
+// client once, so every provider inherits the same timeout and the same answer
+// to status.insecure and status.ca.
 type fetcher func(*http.Client, Source) (map[string]State, error)
 
-// providers is the whole list, and the error below reads it, so a provider
-// registered here is one the message already names without being told.
+// maxBody bounds the document a provider reads: the timeout alone would not
+// stop a fast endless stream from eating the process. A few thousand endpoints
+// fit well under it.
+const maxBody = 8 << 20
+
+// The error in Fetch reads this map, so a provider registered here is one that
+// message already names.
 var providers = map[string]fetcher{"gatus": fetchGatus, "json": fetchJSON, "kuma": fetchKuma}
 
 func providerNames() string {
 	return strings.Join(slices.Sorted(maps.Keys(providers)), ", ")
 }
 
-// Fetch asks the source's monitor what it knows and returns service-id ->
-// state.
+// Fetch asks the source's monitor what it knows, keyed by service id.
 func Fetch(src Source) (map[string]State, error) {
 	name := src.Provider
 	if name == "" {
@@ -315,22 +310,15 @@ func Fetch(src Source) (map[string]State, error) {
 	return folded(got), nil
 }
 
-// folded lowercases what a monitor reported, because that is the difference
-// between a pill and no pill for the most ordinary mistake there is.
+// folded lowercases what a monitor reported. A cairn service id can only be
+// lowercase, idRe sees to that, but a monitor name is typed into a form by a
+// person who writes "Immich": issue #33 was a setup otherwise entirely correct,
+// published page, right slug, monitor green, and no pill on the card.
 //
-// A cairn service id can only be lowercase, idRe sees to that. A monitor name
-// is typed into a form by a person, who writes "Immich". Reported on issue
-// #33 by somebody whose setup was otherwise entirely correct: published page,
-// right slug, monitor green, and no pill on the card.
-//
-// Folding can add a match and cannot invent a wrong one, since the thing on
-// the other side is lowercase by construction. It is done here rather than in
-// each provider so a provider added later cannot forget it; Gatus is
-// unaffected either way, since it reports a key it has already normalised.
-//
-// Two monitors whose names differ only in case would collapse into one. That
-// is a directory nobody could read anyway, and the alternative is the silence
-// this exists to end.
+// Folding can add a match and cannot invent a wrong one, the other side being
+// lowercase by construction. It happens here rather than in each provider so a
+// provider added later cannot forget it. Two monitor names differing only in
+// case collapse into one, which is a directory nobody could read anyway.
 func folded(in map[string]State) map[string]State {
 	out := make(map[string]State, len(in))
 	for k, v := range in {
@@ -339,8 +327,7 @@ func folded(in map[string]State) map[string]State {
 	return out
 }
 
-// fetchGatus reads the endpoint statuses of a Gatus instance, keyed by
-// endpoint name, which is the service id.
+// fetchGatus keys the statuses by endpoint name, which is the service id.
 func fetchGatus(client *http.Client, src Source) (map[string]State, error) {
 	resp, err := get(client, src, strings.TrimSuffix(src.URL, "/")+"/api/v1/endpoints/statuses")
 	if err != nil {
@@ -350,9 +337,7 @@ func fetchGatus(client *http.Client, src Source) (map[string]State, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("gatus answered %s", resp.Status)
 	}
-	// Bound the body: the timeout alone would not stop a fast endless stream
-	// from eating the process. A few thousand endpoints fit well under this.
-	body := io.LimitReader(resp.Body, 8<<20)
+	body := io.LimitReader(resp.Body, maxBody)
 	var list []struct {
 		Name    string `json:"name"`
 		Key     string `json:"key"`

--- a/src/internal/status/jsonmap.go
+++ b/src/internal/status/jsonmap.go
@@ -12,13 +12,12 @@ import (
 )
 
 // Mapping reads a flat array of objects out of any JSON document. Six keys and
-// no expression language: a path is a dotted walk and nothing else. Anything
-// cleverer would be a query language, and a query language in YAML is a second
-// product to document, secure and support.
+// no expression language: a path is a dotted walk and nothing else, since a
+// query language in YAML is a second product to document, secure and support.
 //
 // That is enough for every status API the audit found bar two: Atlassian
-// Statuspage, Instatus, Upptime, StatusCake, Better Stack and whatever is
-// written next all answer with a list of objects carrying a name and a state.
+// Statuspage, Instatus, Upptime, StatusCake and Better Stack all answer with a
+// list of objects carrying a name and a state.
 type Mapping struct {
 	List        string   // path to the array, empty when the document is the array
 	Key         string   // per element: the field holding the service name
@@ -26,16 +25,15 @@ type Mapping struct {
 	Up          []string // values that mean up
 	Degraded    []string // values that mean up but not well
 	Maintenance []string // values that mean off on purpose
-	// Unknown are the values that mean nobody is checking: a monitor paused,
-	// or one waiting for its first verdict. Those services get no pill at all
-	// rather than a red one, which is what cairn's neutral state has always
-	// meant and what the kuma provider does with its own pending.
+	// Unknown are the values that mean nobody is checking: a monitor paused, or
+	// one waiting for its first verdict. Those services get no pill at all
+	// rather than a red one, as the kuma provider does with its own pending.
 	Unknown []string
 }
 
-// level reads one state through the three allow-lists, checked maintenance,
-// degraded, up, then down. A value in none of them reads as down, which is the
-// safe direction twice over: a vendor that adds a word next year cannot make a
+// level reads one state through the three allow-lists in order: maintenance,
+// degraded, up, then down. A value in none of them reads as down, the safe
+// direction twice over: a vendor that adds a word next year cannot make a
 // broken service look green, and an operator who forgot to list one sees a red
 // pill rather than a wrong one.
 func (m Mapping) level(state string) string {
@@ -51,7 +49,6 @@ func (m Mapping) level(state string) string {
 	}
 }
 
-// fetchJSON reads any status API shaped like a list of {name, state}.
 func fetchJSON(client *http.Client, src Source) (map[string]State, error) {
 	resp, err := get(client, src, src.URL)
 	if err != nil {
@@ -62,7 +59,7 @@ func fetchJSON(client *http.Client, src Source) (map[string]State, error) {
 		return nil, err
 	}
 	var doc any
-	if err := json.NewDecoder(io.LimitReader(resp.Body, 8<<20)).Decode(&doc); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxBody)).Decode(&doc); err != nil {
 		return nil, fmt.Errorf("status.url %s answered something that is not JSON: %w", src.URL, err)
 	}
 
@@ -77,19 +74,17 @@ func fetchJSON(client *http.Client, src Source) (map[string]State, error) {
 	out := make(map[string]State, len(rows))
 	named, stated := 0, 0
 	for _, row := range rows {
-		// A row the mapping cannot read is skipped rather than fatal. Real
-		// status pages carry group headers and marketing rows, and cairn only
-		// draws a pill for a name matching a service id, so junk is already
-		// harmless: one bad row must not cost the whole poll.
+		// A row the mapping cannot read is skipped rather than fatal: real
+		// status pages carry group headers and marketing rows, and one bad row
+		// must not cost the whole poll.
 		name, ok := walk(row, m.Key).(string)
 		if !ok || name == "" {
 			continue
 		}
 		named++
 		// A row with a name and no state is left out rather than called down,
-		// which is what Gatus does with an endpoint that has no result and
-		// Kuma with a monitor that has no heartbeat. Nothing has been said
-		// about it, and the unknown pill is what says that.
+		// as Gatus does with an endpoint that has no result and Kuma with a
+		// monitor that has no heartbeat. Nothing has been said about it.
 		state, ok := stateOf(walk(row, m.State))
 		if !ok {
 			continue
@@ -104,11 +99,10 @@ func fetchJSON(client *http.Client, src Source) (map[string]State, error) {
 	}
 	// Nothing read at all is a mapping that is wrong rather than a status page
 	// that is empty, and the two possible typos get separate messages: the
-	// operator is reading one log line and has to know which key to open.
-	//
-	// The counters are what was found, not what was drawn: a page whose every
-	// monitor is paused reads fine and simply produces no pill, so it must not
-	// look like a mapping that missed.
+	// operator is reading one log line and has to know which key to open. The
+	// counters are what was found, not what was drawn, so a page whose every
+	// monitor is paused produces no pill without looking like a mapping that
+	// missed.
 	switch {
 	case len(rows) == 0:
 	case named == 0:
@@ -121,14 +115,11 @@ func fetchJSON(client *http.Client, src Source) (map[string]State, error) {
 	return out, nil
 }
 
-// stateOf reads the state field as text. JSON has three scalar types and
-// monitors use all three: Statping answers a bool, Cachet a number, most
-// vendors a word. Formatting the other two rather than refusing them is what
-// makes "any flat status API" true instead of nearly true. A whole number
+// stateOf reads the state field as text. Monitors use all three JSON scalars:
+// Statping answers a bool, Cachet a number, most vendors a word. A whole number
 // keeps no decimal point, so a mapping lists 1 as "1" and not as "1.000000".
-//
 // Anything else, an object or an array where a state was expected, is not a
-// state; that row is skipped like any other the mapping cannot read.
+// state, and that row is skipped like any other the mapping cannot read.
 func stateOf(v any) (string, bool) {
 	switch t := v.(type) {
 	case string:
@@ -142,7 +133,7 @@ func stateOf(v any) (string, bool) {
 	}
 }
 
-// walk descends a dotted path. An empty path is the document itself, which is
+// walk descends a dotted path; an empty one is the document itself, which is
 // what a bare array answers with.
 func walk(v any, path string) any {
 	if path == "" {
@@ -159,8 +150,8 @@ func walk(v any, path string) any {
 }
 
 // keysOf and describe exist so a mapping that read nothing says what was
-// actually there. -check makes no network request, deliberately, so a typo in
-// a mapping first shows up as one line in a log: that line has to be enough.
+// actually there. -check makes no network request, so a typo in a mapping first
+// shows up as one line in a log: that line has to be enough.
 func keysOf(v any) string {
 	obj, ok := v.(map[string]any)
 	if !ok {

--- a/src/internal/status/kuma.go
+++ b/src/internal/status/kuma.go
@@ -13,11 +13,10 @@ import (
 // Uptime Kuma, read through the two endpoints a published status page answers
 // without a login. There is no config file to write and no setup API to call:
 // standing an instance up for the audit took a browser driven by a script, so
-// there is no -emit-kuma and there cannot be one. What an operator does is
-// name each monitor after the cairn service id, by hand.
+// there is no -emit-kuma and there cannot be one. An operator names each
+// monitor after the cairn service id, by hand.
 //
-// Kuma's status constants, from its own source: 0 down, 1 up, 2 pending,
-// 3 maintenance.
+// The values below come from Kuma's own source.
 const (
 	kumaDown        = 0
 	kumaUp          = 1
@@ -26,8 +25,8 @@ const (
 )
 
 // fetchKuma joins two documents on a numeric monitor id: the names live on the
-// status page, the states in the heartbeat feed, and neither carries the
-// other. That join is why this is code rather than a mapping.
+// status page, the states in the heartbeat feed, and neither carries the other.
+// No Mapping can express that join.
 func fetchKuma(client *http.Client, src Source) (map[string]State, error) {
 	if src.Slug == "" {
 		return nil, fmt.Errorf("status.slug is empty: kuma serves its statuses per published status page, so cairn needs the slug of yours (the last part of its URL, as in https://kuma.example.org/status/tools)")
@@ -60,22 +59,22 @@ func fetchKuma(client *http.Client, src Source) (map[string]State, error) {
 	for _, g := range page.PublicGroupList {
 		for _, m := range g.MonitorList {
 			monitors++
-			// The last beat is the current one, the way the last Gatus result
-			// is. A monitor with none is left out rather than called down:
+			// A monitor with no heartbeat is left out rather than called down:
 			// nobody has looked at it yet, which is what the unknown pill says.
-			hb := beats.HeartbeatList[strconv.Itoa(m.ID)]
-			if len(hb) == 0 {
+			history := beats.HeartbeatList[strconv.Itoa(m.ID)]
+			if len(history) == 0 {
 				continue
 			}
-			switch hb[len(hb)-1].Status {
+			current := history[len(history)-1].Status
+			switch current {
 			case kumaUp:
 				out[m.Name] = State{Level: LevelUp}
 			case kumaMaintenance:
 				out[m.Name] = State{Level: LevelMaintenance}
 			case kumaPending:
-				// Pending is a monitor waiting for its first verdict, which is
-				// unknown by another name. Kuma declares no degraded, so
-				// nothing here may invent one either.
+				// A monitor waiting for its first verdict is unknown by another
+				// name. Kuma declares no degraded, so nothing here may invent
+				// one either.
 			default:
 				out[m.Name] = State{Level: LevelDown}
 			}
@@ -88,8 +87,8 @@ func fetchKuma(client *http.Client, src Source) (map[string]State, error) {
 }
 
 // kumaErr says which key to look at. A 404 is the failure an operator will
-// actually hit: a status page exists in the admin but was never published, and
-// the endpoint answers exactly as it would for a misspelled slug.
+// actually hit: a status page that exists in the admin but was never published
+// answers exactly as a misspelled slug does.
 func kumaErr(src Source, err error) error {
 	if strings.Contains(err.Error(), "404") {
 		return fmt.Errorf("status.slug %q: kuma answered %w, so no status page is published there (create it, tick Published, and use the slug from its URL)", src.Slug, err)
@@ -106,7 +105,5 @@ func kumaGet(client *http.Client, src Source, addr string, v any) error {
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("%s", resp.Status)
 	}
-	// Bounded like the Gatus body: a timeout alone would not stop a fast
-	// endless stream from eating the process.
-	return json.NewDecoder(io.LimitReader(resp.Body, 8<<20)).Decode(v)
+	return json.NewDecoder(io.LimitReader(resp.Body, maxBody)).Decode(v)
 }

--- a/src/internal/status/token.go
+++ b/src/internal/status/token.go
@@ -8,11 +8,9 @@ import (
 )
 
 // get is every request a provider makes: the client Fetch chose, plus the
-// credential when the operator named a file holding one.
-//
-// One helper rather than a header set in three places, because the rule that
-// matters (the token is never written in site.yaml and never printed) is
-// easier to keep in one function than to remember in each provider.
+// credential when the operator named a file holding one. One helper rather than
+// a header set in three places, so the rule that matters, the token is never
+// written in site.yaml and never printed, lives in one function.
 func get(client *http.Client, src Source, addr string) (*http.Response, error) {
 	req, err := http.NewRequest(http.MethodGet, addr, nil)
 	if err != nil {
@@ -23,22 +21,21 @@ func get(client *http.Client, src Source, addr string) (*http.Response, error) {
 		if err != nil {
 			return nil, fmt.Errorf("status.token_file %s could not be read: %w (it is a path the platform mounts, as a kubernetes secret, a docker secret or a vault agent file does)", src.TokenFile, err)
 		}
-		// Trimmed because every editor and every kubectl create secret
-		// --from-file leaves a trailing newline, and a header carrying one is
-		// a header the far end rejects for no reason anybody can see.
 		scheme := src.TokenScheme
 		if scheme == "" {
 			scheme = "Bearer"
 		}
+		// Every editor and every kubectl create secret --from-file leaves a
+		// trailing newline, and a header carrying one is a header the far end
+		// rejects for no reason anybody can see.
 		req.Header.Set("Authorization", scheme+" "+strings.TrimSpace(string(token)))
 	}
 	return client.Do(req)
 }
 
 // answered turns a status code into a message an operator can act on. 401 and
-// 403 are the two that name a key rather than an address: the credential is
-// the thing that was refused, and it is the one part of the request that never
-// appears in a log.
+// 403 name a key rather than an address: the credential is what was refused,
+// and it is the one part of the request that never appears in a log.
 func answered(resp *http.Response, src Source) error {
 	if resp.StatusCode == http.StatusOK {
 		return nil


### PR DESCRIPTION
The owner's rule: no comment per function, nothing easily deduced from the code, a good comment turns into code, and never written as an answer to a question.

38 files, **2151 comment lines down to 1716**, and 471 fewer lines overall.

The last of those four rules was the real target. This repository's comments were full of `That is not academic:`, `which is why`, `worth saying`, `on purpose`. Those are now statements of fact. What was measured stays measured: the owner was explicit that nothing which prevents an error should be lost.

## Turned into code, which is the part worth reviewing

| Was a sentence | Is now |
| --- | --- |
| the disc arithmetic on `.about-x`, five lines twice over | `--x-disc` and `--x-glyph`, the calc |
| `z-index: 41` and "the header is sticky at 40" | `--z-header` and `calc(var(--z-header) + 1)` |
| the 28px ring and its 16px glyph, nine lines on subpixels | `--ring` and `--ring-glyph` |
| `!strings.HasPrefix(s.URL, "http") \|\| s.State.Disables()` | `monitorable(s)` |
| `cfg.Site.StatusAddress() == ""` at four sites | `hasMonitor(cfg)` |
| `len(l) == 0 \|\| l[""] != ""` | `coversEveryLocale(l)` |
| the dotfile loop and its "segment by segment" note | `hasDotSegment(path)` |
| a three-part `Transform` with three lead sentences | three named functions |
| `1<<20`, `8<<20`, `2` | `maxBundle`, `maxBody`, `RETINA` |
| `hb`, `spare`, `used`, `dom`, `state` | `history`, `unclaimed`, `usedBy`, `pos`, `level` |

`var wears [2]bool` indexed by table position became `anySelfhosted` and `anyExternal`, which removes a coupling nothing checked.

## Kept, shortened

Everything that stops an error being made twice. A status colour token measures 4.10:1 as a word. No text reaches 4.5:1 under a 45% veil. `position: relative` on `.card-more` throws it out of the card. A badge in the card's flow charges its height to every card in the row. `oklab()` numbers are not sRGB channels, and a `color(srgb ...)` channel can be negative in scientific notation. Two middlewares both write `Cache-Control` and the last to run wins. Four checks that once passed with the feature deleted, each with the reason.

## How it was done and checked

Six agents on disjoint file sets, same instructions, each reporting a table and the list of comments it kept with the error each one prevents. Every lot was then verified by hand against its diff rather than against its report: the De Morgan transformation in `monitorable`, the sign of `hasMonitor` at four sites, the order of the three markdown passes, and that no user-visible string moved anywhere.

One agent reported that it had run prettier on four scripts that were not prettier-clean, turning 22 comment lines into a 165-line diff. Those four were reverted and redone by hand: they are now 22 changed lines for 22 comment lines.

547 Go tests, 64 browser checks, `just lint` clean, the golden net unmoved byte for byte, and zero em dashes.

Based on `fix-dismiss-phone` because both touch style.css; GitHub will retarget this to main when #87 merges.