### PR TITLE
chore(deps): bump codeql-action to 4.37.5 and login-action to 4.6.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,7 +175,7 @@ jobs:
       # A pull request builds the image but never publishes it, so a fork PR
       # needs no registry credentials.
       - if: github.event_name == 'push'
-        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -226,13 +226,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           username: morgankryze
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,10 +64,10 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: stable
-      - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      - uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
-      - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      - uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -43,13 +43,13 @@ jobs:
       contents: read
       packages: read # reads the source index from ghcr
     steps:
-      - uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           username: morgankryze
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
-      - uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -239,7 +239,7 @@ jobs:
 
       # ghcr serves this package publicly, so the read would work without a
       # token. Logging in anyway keeps the copy off the anonymous rate limit.
-      - uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -248,7 +248,7 @@ jobs:
       # No registry key: docker/login-action defaults to Docker Hub. The
       # account name is public, so only the token is a secret. It carries
       # Read & Write and not Delete, which is why nothing here removes a tag.
-      - uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           username: morgankryze
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
The same two SHAs Dependabot proposed in #91, #92 and #93, applied here
because none of those three ever got a check run.

## Why not just merge theirs

Zero workflow runs on all three head branches, against twelve on a branch of
mine off the same commit. Closing and reopening #91 produced nothing, and
neither did `@dependabot recreate`. Eight of the checks are required, so those
pull requests cannot merge and cannot be made to. Actions are enabled, all
actions are allowed, and `build.yml`, `codeql.yml` and `security.yml` all carry
a `pull_request` trigger with no paths filter.

## The SHAs

Both dereferenced from their tag rather than trusted:

| action | version | commit |
| --- | --- | --- |
| `github/codeql-action/{init,analyze}` | v4.37.5 | `d1ba80a`, from annotated tag `85689a1` |
| `docker/login-action` | v4.6.0 | `dbcb813`, tag points at it directly |

## What is in them

Neither is a security fix, which is the reason this is not a release.

codeql-action 4.37.3 to 4.37.5: a network error while streaming the bundle
download now falls back instead of killing the `init` action, `tools` can come
from a repository property, and the bundle moves to 2.26.2. The two published
advisories against codeql-action were fixed in 3.28.3 and in a 2021 bundle,
both far below what is pinned here.

login-action 4.5.2 to 4.6.0: buildx scoped config path handling hardened, plus
the action's own npm dependencies. No advisory, no CVE.

None of the three touches a byte of the binary, the image or the chart. They
are what runs the pipeline, not what the pipeline produces, so 1.19.2 stands.