### PR TITLE
chore(deps): bump codeql-action to 4.37.6, both steps at once

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,14 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # CodeQL refuses a workflow whose codeql-action steps sit on different
+    # versions, and init and analyze are two steps of the same action.
+    # Ungrouped, Dependabot opens one pull request per step, and neither can
+    # pass its own checks: #91 and #93 both failed with "configuration error".
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
   - package-ecosystem: docker
     directory: /docker
     schedule:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,10 +64,10 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: stable
-      - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      - uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
-      - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      - uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Closes out #91 and #93, which cannot pass on their own.

## Why they failed

Dependabot split one bump into two pull requests, #91 for `analyze` and #93
for `init`. Each leaves `codeql.yml` with its two `github/codeql-action` steps
on different versions, and CodeQL refuses that:

```console
##[warning]1 issue was detected with this workflow: Not all workflow steps that
use `github/codeql-action` actions use the same version.
CodeQL job status was configuration error.
```

Three failed checks each, `Analyze (actions)`, `Analyze (go)` and
`Analyze (javascript-typescript)`. They are only valid together, so the two
steps move together here.

`github/codeql-action` is the only action this repository uses at more than one
sub-path, so the Dependabot group is written for it alone rather than for every
action.

## Version

v4.37.6, not the v4.37.5 those two proposed. It was published 4 August, two
days before they were opened, so merging 4.37.5 would earn two more split pull
requests next week. Commit `5595ccaf`, dereferenced from the annotated tag
rather than taken on trust.

Between 4.37.3 and 4.37.6: a network error while streaming the bundle download
now falls back instead of killing `init`, `tools` can come from a repository
property, the bundle moves to 2.26.2, and the remote config file address
defaults to `.github/codeql-config.yml`. cairn names no remote config, so that
last one reaches nothing here.

Not a security fix. The two published advisories against codeql-action were
patched in 3.28.3 and in a 2021 bundle, both far below what was pinned.

## Note on the three original pull requests

None of them ever got a check run when they were opened on 6 August: GitHub
Actions was in a major outage from 15:22 UTC that day. Reopening them once
Actions recovered gave all three their runs, which is how the split was found.
#92, `docker/login-action` 4.6.0, came back green on twelve checks and is
already merged.