### PR TITLE
build: raise the Go pin to 1.26.6 and the buildkit pin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,7 @@ jobs:
           # (dependabot-core#5541), so a pin here would rot in silence.
           # The buildkit-pin job in security.yml is what stops that: it
           # runs weekly and says when buildx-stable-1 has moved past it.
-          driver-opts: image=mirror.gcr.io/moby/buildkit@sha256:2f5adac4ecd194d9f8c10b7b5d7bceb5186853db1b26e5abd3a657af0b7e26ec # buildx-stable-1
+          driver-opts: image=mirror.gcr.io/moby/buildkit@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8 # buildx-stable-1
 
       # A pull request builds the image but never publishes it, so a fork PR
       # needs no registry credentials.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
           # (dependabot-core#5541), so a pin here would rot in silence.
           # The buildkit-pin job in security.yml is what stops that: it
           # runs weekly and says when buildx-stable-1 has moved past it.
-          driver-opts: image=mirror.gcr.io/moby/buildkit@sha256:2f5adac4ecd194d9f8c10b7b5d7bceb5186853db1b26e5abd3a657af0b7e26ec # buildx-stable-1
+          driver-opts: image=mirror.gcr.io/moby/buildkit@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8 # buildx-stable-1
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,18 @@
 # Pinned by digest, like every action in the workflows: the tag alone lets the
 # compiler that produces a released binary change under us between two builds
-# of the same commit. Dependabot watches /docker and moves it, and it can still
-# read the tag list through the mirror: 1513 tags, 1.26-alpine among them.
+# of the same commit.
+#
+# Nothing moves this pin automatically. Dependabot compares tags, and its log
+# reads "Latest version is 1.26-alpine" every week: the tag is already the
+# newest, so a digest sliding from one patch release to the next underneath it
+# is invisible to it. Left alone the pin holds the Go it was written with, and
+# on 2026-08-17 that was 1.26.5 against a released 1.26.6, eight HIGH stdlib
+# CVEs in the shipped binary.
+#
+# What catches it is the weekly Trivy scan, which reads the binary rather than
+# this line, and fires once the Go left behind carries a published CVE. That is
+# late by design: raising the pin on every golang rebuild would be a weekly red
+# build for nothing.
 #
 # Read through mirror.gcr.io rather than straight from Docker Hub, for the same
 # reason demo/compose.yaml is: an anonymous Hub pull shares one rate limit with
@@ -10,10 +21,10 @@
 # main after 1.13.2 shipped.
 #
 # The digest is the same object either way, verified rather than assumed: both
-# registries answer sha256:0178a641… for this reference. A digest is what the
+# registries answer sha256:3889b425… for this reference. A digest is what the
 # content hashes to, so the mirror cannot serve a different image under it; the
 # registry in front is only the road taken to reach it.
-FROM --platform=$BUILDPLATFORM mirror.gcr.io/library/golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS build
+FROM --platform=$BUILDPLATFORM mirror.gcr.io/library/golang:1.26-alpine@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83 AS build
 # The scratch image ships no CA bundle, so cairn cannot verify TLS on its own:
 # polling a public https Gatus fails with x509: unknown authority. Copy the
 # bundle in (below); install it here so the build never depends on the base


### PR DESCRIPTION
The weekly `security` run failed on 17 August, on both of the jobs whose whole
purpose is to fail when a pin goes stale. `govulncheck` passed, which is itself
part of the story.

## Trivy: eight HIGH, one base image

All eight are `stdlib`, installed version `v1.26.5`, and every one is fixed in
`1.26.6`. They are not eight problems, they are one: the pinned
`golang:1.26-alpine` digest held go1.26.5.

| CVE | package |
| --- | --- |
| CVE-2026-56858 | `html/template`, cross-site scripting via pathological input |
| CVE-2026-56853 | `net/http`, DoS on unencrypted HTTP/2 |
| CVE-2026-56862 | `crypto/tls`, DoS via indefinite KeyUpdate |
| CVE-2026-56860 | `net/url`, quadratic complexity in path handling |
| CVE-2026-56859 | `encoding/xml`, recursion depth |
| CVE-2026-33818 | `encoding/asn1`, recursion in Unmarshal |
| CVE-2026-46600 | `x/net/dns/dnsmessage`, invalid record parsing |
| CVE-2026-39821 | `x/net/idna`, punycode label processing |

The first is the one worth naming: cairn renders every page through
`html/template`, and that template package is the escaping that stands between
a config file and the browser. The rest are denial of service in code paths
cairn either does not run or does not expose.

The digest moves to `sha256:3889b425…`, which is `go1.26.6`, checked by running
the image rather than by reading a tag:

```console
$ docker run --rm mirror.gcr.io/library/golang:1.26-alpine@sha256:0178a641… go version
go version go1.26.5 linux/arm64
$ docker run --rm mirror.gcr.io/library/golang:1.26-alpine@sha256:3889b425… go version
go version go1.26.6 linux/arm64
```

Both registries answer the same digest for the tag, so the comment's claim
about the mirror still holds and its example digest is updated with the pin.

## Proved both ways

Rebuilt locally and scanned with the same Trivy and the same flags CI uses,
then the published image scanned as the control, so the clean result is a
result and not a scanner that found nothing:

```console
$ trivy image --severity HIGH,CRITICAL --ignore-unfixed  cairn:scan-new
│ cairn  │ gobinary │        0        │
$ trivy image --severity HIGH,CRITICAL --ignore-unfixed  ghcr.io/morgankryze/cairn:1.19.2
│ cairn  │ gobinary │        8        │
```

The Dockerfile runs `go vet ./... && go test ./...` during the build, so the
suite passing under 1.26.6 is a precondition of that image existing.

## Why nothing caught it earlier

The Dockerfile said Dependabot watches this pin. It does not. Its log says the
same thing every week:

```console
Checking if library/golang 1.26-alpine needs updating
Latest version is 1.26-alpine
```

It compares tags. `1.26-alpine` is already the newest tag, so a digest sliding
from one patch release to the next underneath it is invisible to it, and it has
never opened a pull request for this file in the repository's history.

No new watcher is added for it. Raising the pin on every golang rebuild would
mean a weekly red build for nothing, which is the reasoning `buildkit-pin`
already carries in its own comment. Trivy is the right watcher precisely
because it is late: it fires when the Go left behind starts carrying a
published CVE, which is the moment it matters. The comment now says that
instead of the thing that was not true.

`govulncheck` stayed green throughout, and that is not a contradiction: it
analyses the source with the runner's own `stable` toolchain, which was already
patched. It answers "is this source vulnerable", Trivy answers "is this
artifact vulnerable". Only the second question is about what people pull.

## buildkit

`buildx-stable-1` moved to `sha256:28a89871…`. The pin follows in `build.yml`
and `release.yml`, which the job checks are the same value.

## What this does not do

It does not fix anything for anyone yet. The published `1.19.2` image, and
every floating tag pointing at it, still carries the eight. Only a release
rebuilds them.