### PR TITLE
ci: hold new versions a week, then let Dependabot merge itself

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,27 @@
 version: 2
+
+# cooldown holds a new version back for a week before it is ever proposed,
+# which is the window a compromised release is usually pulled in. It applies
+# to version updates only and never to a security update, so a real fix still
+# arrives the day it is published. That delay is what makes automerge.yml
+# defensible: nothing lands the day it is cut.
+#
+# github-actions and docker take default-days only; the per-semver variants
+# are gomod's.
 updates:
   - package-ecosystem: gomod
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
+
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     # CodeQL refuses a workflow whose codeql-action steps sit on different
     # versions, and init and analyze are two steps of the same action.
     # Ungrouped, Dependabot opens one pull request per step, and neither can
@@ -16,7 +30,10 @@ updates:
       codeql-action:
         patterns:
           - "github/codeql-action*"
+
   - package-ecosystem: docker
     directory: /docker
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,42 @@
+name: automerge
+
+# Arms GitHub's own auto-merge on Dependabot's pull requests. It merges
+# nothing by itself: the required checks still gate the merge, and a red one
+# leaves the pull request open exactly as it does today.
+#
+# No update-type filter and no third-party action, deliberately. How large a
+# version bump is says nothing about whether it is safe, so gating on
+# semver-patch would buy nothing and would add `dependabot/fetch-metadata` to
+# the supply chain of the workflow meant to keep that chain short. The window
+# where a compromised release is still up is covered by `cooldown` in
+# dependabot.yml instead, which holds a version back for a week and never
+# applies to a security update.
+#
+# goldmark is the only dependency here that reaches a reader rather than the
+# build, and golden_test.go pins four rendered pages byte for byte: a change
+# in what it emits is a red check, not a merge.
+#
+# Needs "Allow auto-merge" on in the repository settings. Without it the step
+# below exits non-zero on every Dependabot pull request and says so, rather
+# than quietly leaving them all open.
+
+on: pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  arm:
+    runs-on: ubuntu-latest
+    # The pull request's author, which is GitHub's own condition for this, and
+    # a repository check so a fork inherits an inert workflow rather than one
+    # that merges on its behalf.
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'MorganKryze/cairn'
+    permissions:
+      contents: write # merges the pull request once the checks pass
+      pull-requests: write
+    steps:
+      - run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Six Dependabot pull requests landed in two weeks, every one of them a pinned
SHA moving to another pinned SHA, every one read by hand.

## What arms the merge

`automerge.yml` runs `gh pr merge --auto --squash` on pull requests whose
author is `dependabot[bot]`. It merges nothing itself: the eight required
checks still gate it, and a red one leaves the pull request open exactly as it
does today. GitHub's documented pattern, `on: pull_request` rather than
`pull_request_target`, and nothing is checked out.

Two things left out on purpose:

- **No update-type filter.** How large a version bump is says nothing about
  whether it is safe, so gating on `semver-patch` would buy nothing real.
- **No `dependabot/fetch-metadata`.** It exists only to power that filter, and
  adding a third-party action to the workflow meant to keep the supply chain
  short is the wrong direction. This workflow uses no action at all.

## What makes it defensible

`cooldown: default-days: 7` on all three ecosystems. A version is not proposed
until it has been published for a week, which is the window in which a
compromised release is normally yanked, and per the option reference it
**applies to version updates only and never to a security update**, so a real
fix still arrives the day it is published.

`github-actions` and `docker` accept `default-days` only; the per-semver
variants exist for `gomod`.

The honest reason this needs saying: every action here is pinned by SHA so a
moved tag cannot change what runs, and "CI is green" is not evidence an action
is safe, because CI is what runs it. The `image` job holds `packages: write`
and the release workflow holds `id-token: write`. The delay, not the checks, is
what covers that.

`goldmark` is the only dependency that reaches a reader rather than the build,
and `golden_test.go` pins four rendered pages byte for byte, so a change in
what it emits is a red check and not a merge.

## One thing to switch on

`allow_auto_merge` is `false` on the repository and I could not flip it from
here. Until it is on, the step exits non-zero on every Dependabot pull request,
loudly, which is better than leaving them all silently open. Either the
checkbox in Settings → General, or:

```sh
gh api -X PATCH repos/MorganKryze/cairn -f allow_auto_merge=true
```

The ruleset needs no change: it already requires zero approving reviews, so the
eight status checks are the only gate.

## Checked

Both files are Prettier-clean, matching the workflows already in the tree.