### PR TITLE
style: waypoints that line up, headings that answer, a language that is a label

### DIFF
--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -1362,6 +1362,181 @@ await check(
   await st.close();
 }
 
+// ---- A12: the trail, the headings that answer it, and where a jump lands ----
+
+{
+  const wp = await browser.newContext();
+
+  // The centre a small mark should sit on beside a word is the middle of its
+  // x-height, not the middle of its line box: a line box carries descender
+  // space that no lowercase letter reaches. Half a pixel is the tolerance, an
+  // order below what the eye caught at 1.5px and 2.86px.
+  const offXCentre = (page, markSel, nameSel) =>
+    page.evaluate(
+      ([m, n]) => {
+        const mark = document.querySelector(m),
+          name = document.querySelector(n);
+        if (!mark || !name || !mark.getClientRects().length) return null;
+        const mr = mark.getBoundingClientRect(),
+          nr = name.getBoundingClientRect();
+        const cs = getComputedStyle(name);
+        const cv = document.createElement("canvas").getContext("2d");
+        cv.font = `${cs.fontWeight} ${cs.fontSize} ${cs.fontFamily}`;
+        const fm = cv.measureText("x");
+        const lead =
+          (nr.height - (fm.fontBoundingBoxAscent + fm.fontBoundingBoxDescent)) /
+          2;
+        const baseline = nr.top + lead + fm.fontBoundingBoxAscent;
+        const xCentre = baseline - fm.actualBoundingBoxAscent / 2;
+        return mr.top + mr.height / 2 - xCentre;
+      },
+      [markSel, nameSel],
+    );
+
+  await check(
+    "a waypoint diamond sits on the x-height of its label",
+    async () => {
+      const wide = await wp.newPage();
+      await wide.setViewportSize({ width: 1440, height: 900 });
+      await wide.goto(MANY);
+      const rail = await offXCentre(wide, ".toc-mark", ".toc-name");
+      const heading = await offXCentre(wide, ".way-mark", ".way-name");
+      await wide.close();
+      if (rail === null) throw new Error("the rail is not painted at 1440px");
+      if (heading === null) throw new Error("no diamond beside a heading");
+      for (const [what, off] of [
+        ["the rail's", rail],
+        ["a heading's", heading],
+      ]) {
+        if (Math.abs(off) > 0.5) {
+          throw new Error(
+            `${what} diamond is ${off.toFixed(2)}px off the x-height centre`,
+          );
+        }
+      }
+    },
+  );
+
+  await check("a category heading is a link to its own anchor", async () => {
+    const page = await wp.newPage();
+    await page.goto(MANY);
+    const pairs = await page.$$eval(".way-name", (hs) =>
+      hs.map((h) => ({
+        id: h.id,
+        href: h.querySelector("a")?.getAttribute("href"),
+      })),
+    );
+    await page.close();
+    if (!pairs.length) throw new Error("no category heading on the page");
+    for (const { id, href } of pairs) {
+      if (href !== `#${id}`) {
+        throw new Error(`heading ${id} links to ${href} rather than to itself`);
+      }
+    }
+  });
+
+  // The gap above a heading is 2.6rem, so a margin past it pulls the previous
+  // section's last card back into view. Both edges are asserted: a margin of
+  // zero would satisfy the second on its own.
+  for (const [label, size] of [
+    ["a wide screen", { width: 1440, height: 900 }],
+    ["a phone", PHONE],
+  ]) {
+    await check(
+      `clicking a heading lands it clear of the top on ${label}`,
+      async () => {
+        const page = await wp.newPage();
+        await page.setViewportSize(size);
+        await page.emulateMedia({ reducedMotion: "reduce" });
+        await page.goto(MANY);
+        const m = await page.evaluate(async () => {
+          const cats = [...document.querySelectorAll(".cat")];
+          const target = cats[2];
+          scrollTo(0, 0);
+          await new Promise((r) => setTimeout(r, 250));
+          target.querySelector(".way-name a").click();
+          await new Promise((r) => setTimeout(r, 700));
+          const prev = [...cats[1].querySelectorAll(".card")].pop();
+          return {
+            hash: location.hash,
+            top: target.querySelector(".way-name").getBoundingClientRect().top,
+            prevBottom: prev.getBoundingClientRect().bottom,
+          };
+        });
+        await page.close();
+        if (m.hash !== "#cat-charlie") {
+          throw new Error(`the click set ${m.hash || "no hash at all"}`);
+        }
+        if (m.top < 24) {
+          throw new Error(
+            `the heading lands ${m.top.toFixed(1)}px from the top, too tight`,
+          );
+        }
+        if (m.prevBottom > 0) {
+          throw new Error(
+            `${m.prevBottom.toFixed(1)}px of the previous section's last card is in view`,
+          );
+        }
+      },
+    );
+  }
+
+  // Reading a language is not an action. The link led back to the page it was
+  // on, and on a site with one language it was the only thing there to click.
+  for (const [label, url] of [
+    ["among several", SITE],
+    ["when it is the only one", MANY],
+  ]) {
+    await check(
+      `the language you are reading is not a control, ${label}`,
+      async () => {
+        const page = await wp.newPage();
+        await page.goto(url);
+        const m = await page.evaluate(() => {
+          const el = document.querySelector(".langs [aria-current]");
+          if (!el) return null;
+          el.focus?.();
+          return {
+            tag: el.tagName.toLowerCase(),
+            href: el.getAttribute("href"),
+            tookFocus: document.activeElement === el,
+            others: document.querySelectorAll(".langs a[href]").length,
+          };
+        });
+        await page.close();
+        if (!m) throw new Error("nothing in the switcher is marked as current");
+        if (m.tag === "a" || m.href !== null) {
+          throw new Error(
+            `the current language is still a <${m.tag} href=${m.href}>`,
+          );
+        }
+        if (m.tookFocus)
+          throw new Error("the current language still takes focus");
+      },
+    );
+  }
+
+  await check("every other language is still one click away", async () => {
+    const page = await wp.newPage();
+    await page.goto(SITE);
+    const hrefs = await page.$$eval(".langs a[href]", (as) =>
+      as.map((a) => a.getAttribute("href")),
+    );
+    await page.close();
+    // example/ carries fr and en, so exactly one link is left beside the label
+    if (hrefs.length !== 1) {
+      throw new Error(
+        `expected one switchable language, found ${hrefs.length}`,
+      );
+    }
+    if (!hrefs[0].includes("?choose")) {
+      throw new Error(`${hrefs[0]} does not carry ?choose, so it cannot pin`);
+    }
+  });
+
+  await wp.close();
+}
+
 await browser.close();
 console.log(failures ? `\n${failures} failed` : "\nall passed");
 process.exit(failures ? 1 : 0);

--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -1466,7 +1466,9 @@ await check(
         };
       });
       await page.close();
-      if (after.opacity < 1) {
+      // Visible, not opaque: it is deliberately held back, so this is a floor
+      // for "you can see it" and not the value the rule happens to carry.
+      if (after.opacity < 0.5) {
         throw new Error(`hovering left the glyph at opacity ${after.opacity}`);
       }
       if (Math.abs(after.name - before.name) > 0.5) {

--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -1427,6 +1427,88 @@ await check(
     },
   );
 
+  // The glyph hangs in the margin rather than in the row, so the two things
+  // worth pinning are that it appears and that nothing else moves when it
+  // does. It is also off below the breakpoint, where the margin cannot hold it.
+  await check(
+    "the link glyph appears in the margin, moving nothing",
+    async () => {
+      const page = await wp.newPage();
+      await page.setViewportSize({ width: 1280, height: 900 });
+      await page.goto(MANY);
+      const before = await page.evaluate(() => {
+        const way = [...document.querySelectorAll(".way")][1];
+        const g = way.querySelector(".way-link");
+        const n = way.querySelector(".way-name");
+        return {
+          opacity: +getComputedStyle(g).opacity,
+          name: n.getBoundingClientRect().left,
+          rowLeft: way.getBoundingClientRect().left,
+        };
+      });
+      if (before.opacity !== 0) {
+        throw new Error(
+          `the glyph shows at rest, at opacity ${before.opacity}`,
+        );
+      }
+      await (await page.$$(".way-name a"))[1].hover();
+      await page.waitForTimeout(300);
+      const after = await page.evaluate(() => {
+        const way = [...document.querySelectorAll(".way")][1];
+        const g = way.querySelector(".way-link");
+        const gr = g.getBoundingClientRect();
+        return {
+          opacity: +getComputedStyle(g).opacity,
+          name: way.querySelector(".way-name").getBoundingClientRect().left,
+          glyphRight: gr.right,
+          glyphLeft: gr.left,
+          rowLeft: way.getBoundingClientRect().left,
+        };
+      });
+      await page.close();
+      if (after.opacity < 1) {
+        throw new Error(`hovering left the glyph at opacity ${after.opacity}`);
+      }
+      if (Math.abs(after.name - before.name) > 0.5) {
+        throw new Error(
+          `the heading moved ${(after.name - before.name).toFixed(1)}px when the glyph appeared`,
+        );
+      }
+      if (after.glyphRight > before.rowLeft + 0.5) {
+        throw new Error(
+          "the glyph overlaps the row rather than sitting beside it",
+        );
+      }
+      if (after.glyphLeft < 0) {
+        throw new Error(
+          `the glyph is ${after.glyphLeft.toFixed(1)}px off the left edge`,
+        );
+      }
+    },
+  );
+
+  await check("and stays away where the margin cannot hold it", async () => {
+    const page = await wp.newPage();
+    await page.setViewportSize({ width: 1024, height: 900 });
+    await page.goto(MANY);
+    await (await page.$$(".way-name a"))[1].hover();
+    await page.waitForTimeout(300);
+    // The glyph of the heading being hovered, not the first one in the
+    // document: reading that one leaves the check green whatever the rule
+    // does, since nothing is ever hovering it.
+    const o = await page.evaluate(() => {
+      const g = [...document.querySelectorAll(".way")][1].querySelector(
+        ".way-link",
+      );
+      if (!g) throw new Error("no glyph beside the heading at all");
+      return +getComputedStyle(g).opacity;
+    });
+    await page.close();
+    if (o !== 0) {
+      throw new Error(`at 1024px the glyph shows anyway, at opacity ${o}`);
+    }
+  });
+
   await check("the rail's spine runs through its diamonds", async () => {
     const wide = await wp.newPage();
     await wide.setViewportSize({ width: 1440, height: 900 });

--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -1367,40 +1367,50 @@ await check(
 {
   const wp = await browser.newContext();
 
-  // The centre a small mark should sit on beside a word is the middle of its
-  // x-height, not the middle of its line box: a line box carries descender
-  // space that no lowercase letter reaches. Half a pixel is the tolerance, an
-  // order below what the eye caught at 1.5px and 2.86px.
-  const offXCentre = (page, markSel, nameSel) =>
+  // Halfway between the middle of the lowercase and the middle of the
+  // capitals. Centred on the line box a mark reads high, since the box carries
+  // descender space no lowercase letter reaches; dropped onto the lowercase it
+  // reads low, since the capital and the ascenders have nothing under them to
+  // answer. Both references come from the layout and not from the font's own
+  // tables: a zero-height inline-block sits on the baseline and 1ex is the
+  // x-height. Computing the baseline from the font's ascent instead put it
+  // 0.45px out, which is most of what is being corrected here.
+  const offMark = (page, markSel, nameSel) =>
     page.evaluate(
       ([m, n]) => {
         const mark = document.querySelector(m),
           name = document.querySelector(n);
         if (!mark || !name || !mark.getClientRects().length) return null;
-        const mr = mark.getBoundingClientRect(),
-          nr = name.getBoundingClientRect();
+        const ex = document.createElement("span");
+        ex.style.cssText = "display:inline-block;width:0;height:1ex";
+        const base = document.createElement("span");
+        base.style.cssText = "display:inline-block;width:0;height:0";
+        name.appendChild(ex);
+        name.appendChild(base);
+        const xh = ex.getBoundingClientRect().height;
+        const baseline = base.getBoundingClientRect().bottom;
+        ex.remove();
+        base.remove();
         const cs = getComputedStyle(name);
         const cv = document.createElement("canvas").getContext("2d");
         cv.font = `${cs.fontWeight} ${cs.fontSize} ${cs.fontFamily}`;
-        const fm = cv.measureText("x");
-        const lead =
-          (nr.height - (fm.fontBoundingBoxAscent + fm.fontBoundingBoxDescent)) /
-          2;
-        const baseline = nr.top + lead + fm.fontBoundingBoxAscent;
-        const xCentre = baseline - fm.actualBoundingBoxAscent / 2;
-        return mr.top + mr.height / 2 - xCentre;
+        const cap = cv.measureText("H").actualBoundingBoxAscent;
+        const mr = mark.getBoundingClientRect();
+        const lower = baseline - xh / 2;
+        const caps = baseline - cap / 2;
+        return mr.top + mr.height / 2 - (lower + caps) / 2;
       },
       [markSel, nameSel],
     );
 
   await check(
-    "a waypoint diamond sits on the x-height of its label",
+    "a waypoint diamond sits between the lowercase and the capitals",
     async () => {
       const wide = await wp.newPage();
       await wide.setViewportSize({ width: 1440, height: 900 });
       await wide.goto(MANY);
-      const rail = await offXCentre(wide, ".toc-mark", ".toc-name");
-      const heading = await offXCentre(wide, ".way-mark", ".way-name");
+      const rail = await offMark(wide, ".toc-mark", ".toc-name");
+      const heading = await offMark(wide, ".way-mark", ".way-name");
       await wide.close();
       if (rail === null) throw new Error("the rail is not painted at 1440px");
       if (heading === null) throw new Error("no diamond beside a heading");
@@ -1410,7 +1420,7 @@ await check(
       ]) {
         if (Math.abs(off) > 0.5) {
           throw new Error(
-            `${what} diamond is ${off.toFixed(2)}px off the x-height centre`,
+            `${what} diamond is ${off.toFixed(2)}px off that midpoint`,
           );
         }
       }

--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -1427,6 +1427,33 @@ await check(
     },
   );
 
+  await check("the rail's spine runs through its diamonds", async () => {
+    const wide = await wp.newPage();
+    await wide.setViewportSize({ width: 1440, height: 900 });
+    await wide.goto(MANY);
+    const offs = await wide.evaluate(() => {
+      const ul = document.querySelector(".toc ul");
+      if (!ul || !ul.getClientRects().length) return null;
+      const cs = getComputedStyle(ul, "::before");
+      const start = parseFloat(cs.insetInlineStart || cs.left);
+      const centre =
+        ul.getBoundingClientRect().left + start + parseFloat(cs.width) / 2;
+      return [...document.querySelectorAll(".toc-mark")].map((m) => {
+        const r = m.getBoundingClientRect();
+        return r.left + r.width / 2 - centre;
+      });
+    });
+    await wide.close();
+    if (!offs) throw new Error("the rail is not painted at 1440px");
+    if (!offs.length) throw new Error("the rail carries no diamonds");
+    const worst = offs.reduce((a, b) => (Math.abs(b) > Math.abs(a) ? b : a));
+    if (Math.abs(worst) > 0.25) {
+      throw new Error(
+        `a diamond sits ${worst.toFixed(2)}px ${worst < 0 ? "left" : "right"} of the spine`,
+      );
+    }
+  });
+
   await check("a category heading is a link to its own anchor", async () => {
     const page = await wp.newPage();
     await page.goto(MANY);

--- a/src/internal/render/assets/style.css
+++ b/src/internal/render/assets/style.css
@@ -458,26 +458,26 @@ header { padding-block: 1.4rem; }
   margin-inline-end: .55rem;
   top: 50%;
   transform: translateY(-50%);
-  width: .9rem;
-  height: .9rem;
-  /* --border and not --muted: the rule that closes this same row is decoration
-     at that weight, and one row wants one weight. It is also the floor the
-     palette settles on, around 2:1, below which a hairline disappears on a
-     cheap screen in daylight. */
-  color: var(--border);
+  width: 1.05rem;
+  height: 1.05rem;
+  /* --muted held back to .65 rather than --border at full strength. Tried at
+     the rule's weight first, which is tidier on paper since the rule closes
+     the same row, and it read as a smudge at real size: a glyph is line work
+     with gaps in it, not a solid 1px bar, so the same ink does not carry the
+     same distance. */
+  color: var(--muted);
   opacity: 0;
   transition: opacity .14s;
 }
 /* Only where the margin can hold it. Below this the content sits against the
    wrap's own padding and there is nothing to hang it in: measured, 32.5px of
-   margin at 68rem against the 23px the glyph and its gap need, and 24px at
-   64rem, which clears it by less than a pixel and is not something to lean on.
-   And only where there is a pointer, since a tap has no hover to reveal it
-   with. */
+   margin at 68rem against the 26px the glyph and its gap need, and 24px at
+   64rem. And only where there is a pointer, since a tap has no hover to
+   reveal it with. */
 @media (hover: hover) and (min-width: 69rem) {
   .way-name a:hover .way-link,
   .way-name a:focus-visible .way-link {
-    opacity: 1;
+    opacity: .65;
   }
 }
 .way-name a:focus-visible {

--- a/src/internal/render/assets/style.css
+++ b/src/internal/render/assets/style.css
@@ -85,6 +85,9 @@
      why one number serves both. */
   --mark-drop: .0356;
   --way-font: 1.5rem;
+  /* The rail's diamond, named because the spine has to be centred on it and a
+     second literal would drift from the first. */
+  --toc-mark: .42rem;
 }
 
 :root[data-theme="light"] { color-scheme: light; }
@@ -478,7 +481,10 @@ header { padding-block: 1.4rem; }
 .toc ul::before {
   content: "";
   position: absolute;
-  inset-inline-start: .2rem;
+  /* Centred on the diamonds rather than set near them: half the mark, less
+     half the line's own width. Written as .2rem it drew 0.34px to their right,
+     which is invisible until something moves and then is not. */
+  inset-inline-start: calc(var(--toc-mark) / 2 - .5px);
   top: .8rem;
   bottom: .8rem;
   width: 1px;
@@ -495,8 +501,8 @@ header { padding-block: 1.4rem; }
   transition: color .16s;
 }
 .toc-mark {
-  width: .42rem;
-  height: .42rem;
+  width: var(--toc-mark);
+  height: var(--toc-mark);
   flex: none;
   border-radius: 1.5px;
   background: var(--border);

--- a/src/internal/render/assets/style.css
+++ b/src/internal/render/assets/style.css
@@ -419,6 +419,8 @@ header { padding-block: 1.4rem; }
   align-items: center;
   gap: .7rem;
   margin: 2.6rem 0 1.1rem;
+  /* the containing block for the link glyph, which hangs off the start edge */
+  position: relative;
 }
 .way-mark {
   width: .5rem;
@@ -445,6 +447,33 @@ header { padding-block: 1.4rem; }
 .way-name a {
   color: inherit;
   text-decoration: none;
+}
+/* The affordance a markdown renderer puts beside a heading. It sits in the
+   margin rather than in the row, so nothing shifts when it appears, and it is
+   inside the anchor, so clicking it does what it says. aria-hidden because the
+   heading beside it is that same link and would otherwise be announced twice. */
+.way-link {
+  position: absolute;
+  inset-inline-end: 100%;
+  margin-inline-end: .55rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 1.05rem;
+  height: 1.05rem;
+  color: var(--muted);
+  opacity: 0;
+  transition: opacity .14s;
+}
+/* Only where the margin can hold it. Below this the content sits against the
+   wrap's own padding and there is nothing to hang it in: measured, 32.5px of
+   margin at 68rem against the 26px the glyph and its gap need, and 24px at
+   64rem. And only where there is a pointer, since a tap has no hover to
+   reveal it with. */
+@media (hover: hover) and (min-width: 69rem) {
+  .way-name a:hover .way-link,
+  .way-name a:focus-visible .way-link {
+    opacity: 1;
+  }
 }
 .way-name a:focus-visible {
   outline: 2px solid var(--accent);

--- a/src/internal/render/assets/style.css
+++ b/src/internal/render/assets/style.css
@@ -69,13 +69,21 @@
   /* the sticky header on narrow screens; .skip has to paint one above it */
   --z-header: 40;
   /* How far a waypoint diamond drops from the centre of its line box, as a
-     fraction of the label's font size. A line box carries descender space no
-     lowercase letter reaches, so a mark centred in it reads high beside a word
-     that is mostly lowercase. Measured against the x-height centre: 1.5px at
-     the rail's 13px and 2.86px at a heading's 24px. Unitless, because a mark
-     does not inherit the font size of the label it sits beside, so each site
-     multiplies by the size it is aligning to. */
-  --mark-drop: .115;
+     fraction of the label's font size.
+
+     A line box carries descender space no lowercase letter reaches, so a mark
+     centred in it reads high beside a word that is mostly lowercase. Dropping
+     it all the way onto the middle of the lowercase then reads low, because
+     the capital and the ascenders carry mass above that band with nothing
+     under it to answer. This lands halfway between the two centres.
+
+     Measured against a baseline the layout reports, not one computed from the
+     font's own ascent: those differ by about 0.45px here, which is most of
+     what is being corrected. A zero-height inline-block sits on the baseline
+     and 1ex is the x-height, so both come from the browser. Read that way the
+     rail's sans and the heading's Fraunces want the same fraction, which is
+     why one number serves both. */
+  --mark-drop: .0356;
   --way-font: 1.5rem;
 }
 
@@ -495,7 +503,7 @@ header { padding-block: 1.4rem; }
   transform: rotate(45deg);
   transition: background .16s;
   position: relative;
-  /* 1em here: the rail's mark does inherit its label's size. */
+  /* em here: the rail's mark does inherit its label's size. */
   top: calc(1em * var(--mark-drop));
 }
 .toc-name {

--- a/src/internal/render/assets/style.css
+++ b/src/internal/render/assets/style.css
@@ -458,17 +458,22 @@ header { padding-block: 1.4rem; }
   margin-inline-end: .55rem;
   top: 50%;
   transform: translateY(-50%);
-  width: 1.05rem;
-  height: 1.05rem;
-  color: var(--muted);
+  width: .9rem;
+  height: .9rem;
+  /* --border and not --muted: the rule that closes this same row is decoration
+     at that weight, and one row wants one weight. It is also the floor the
+     palette settles on, around 2:1, below which a hairline disappears on a
+     cheap screen in daylight. */
+  color: var(--border);
   opacity: 0;
   transition: opacity .14s;
 }
 /* Only where the margin can hold it. Below this the content sits against the
    wrap's own padding and there is nothing to hang it in: measured, 32.5px of
-   margin at 68rem against the 26px the glyph and its gap need, and 24px at
-   64rem. And only where there is a pointer, since a tap has no hover to
-   reveal it with. */
+   margin at 68rem against the 23px the glyph and its gap need, and 24px at
+   64rem, which clears it by less than a pixel and is not something to lean on.
+   And only where there is a pointer, since a tap has no hover to reveal it
+   with. */
 @media (hover: hover) and (min-width: 69rem) {
   .way-name a:hover .way-link,
   .way-name a:focus-visible .way-link {

--- a/src/internal/render/assets/style.css
+++ b/src/internal/render/assets/style.css
@@ -68,6 +68,15 @@
   --maxw: 66rem;
   /* the sticky header on narrow screens; .skip has to paint one above it */
   --z-header: 40;
+  /* How far a waypoint diamond drops from the centre of its line box, as a
+     fraction of the label's font size. A line box carries descender space no
+     lowercase letter reaches, so a mark centred in it reads high beside a word
+     that is mostly lowercase. Measured against the x-height centre: 1.5px at
+     the rail's 13px and 2.86px at a heading's 24px. Unitless, because a mark
+     does not inherit the font size of the label it sits beside, so each site
+     multiplies by the size it is aligning to. */
+  --mark-drop: .115;
+  --way-font: 1.5rem;
 }
 
 :root[data-theme="light"] { color-scheme: light; }
@@ -189,7 +198,8 @@ header { padding-block: 1.4rem; }
 :root[data-theme="dark"] .theme-toggle .sun { display: block; }
 
 .langs { display: flex; gap: .2rem; }
-.langs a {
+.langs a,
+.langs [aria-current] {
   padding: .3rem .6rem;
   border: 1px solid transparent;
   border-radius: .5rem;
@@ -199,7 +209,7 @@ header { padding-block: 1.4rem; }
   text-decoration: none;
   color: var(--muted);
 }
-.langs a[aria-current] {
+.langs [aria-current] {
   color: var(--fg);
   background: var(--card);
   border-color: var(--border);
@@ -243,7 +253,8 @@ header { padding-block: 1.4rem; }
   box-shadow: var(--shadow-lift);
   z-index: 10;
 }
-.langs-menu nav a {
+.langs-menu nav a,
+.langs-menu nav [aria-current] {
   padding: .35rem .6rem;
   border-radius: .45rem;
   font-size: .8rem;
@@ -252,7 +263,7 @@ header { padding-block: 1.4rem; }
   text-decoration: none;
   color: var(--muted);
 }
-.langs-menu nav a[aria-current] { color: var(--fg); background: var(--faint); }
+.langs-menu nav [aria-current] { color: var(--fg); background: var(--faint); }
 .langs-menu nav a:hover { color: var(--fg); background: var(--faint); }
 .langs-menu nav a:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
@@ -405,14 +416,29 @@ header { padding-block: 1.4rem; }
   border-radius: 2px;
   background: var(--accent);
   transform: rotate(45deg);
+  position: relative;
+  top: calc(var(--way-font) * var(--mark-drop));
 }
 .way-name {
   margin: 0;
   font-family: var(--font-display);
   font-variation-settings: "opsz" 60;
   font-weight: 540;
-  font-size: 1.5rem;
+  font-size: var(--way-font);
   letter-spacing: -.012em;
+}
+/* The whole heading is the anchor, the way its entry in the rail is. It takes
+   neither colour nor underline: a heading that changed weight or colour on
+   hover would read as a different heading. The pointer says it is a target,
+   and the focus ring says so to a keyboard. */
+.way-name a {
+  color: inherit;
+  text-decoration: none;
+}
+.way-name a:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+  border-radius: 3px;
 }
 .way-rule {
   flex: 1;
@@ -469,6 +495,8 @@ header { padding-block: 1.4rem; }
   transform: rotate(45deg);
   transition: background .16s;
   position: relative;
+  /* 1em here: the rail's mark does inherit its label's size. */
+  top: calc(1em * var(--mark-drop));
 }
 .toc-name {
   overflow: hidden;
@@ -481,7 +509,19 @@ header { padding-block: 1.4rem; }
 .toc a[aria-current] .toc-mark { background: var(--accent); }
 .toc a:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 3px; }
 
-.cat { scroll-margin-top: 1.2rem; }
+/* On the heading and not on .cat: every #cat- link, the rail's and the jump
+   select's and now the heading's own, targets the h2, so the section's margin
+   was never the one the browser read. 2.6rem is the gap above a heading, and
+   anything past it brings the previous section's last card into view; this
+   keeps 9px of that gap in hand.
+
+   One value, phones included. The 4.5rem a narrow screen used to carry was
+   meant to clear the sticky header, but it sat on .cat and so never applied,
+   and it cannot do that job anyway: the header is 132px, which is past the gap
+   by a long way. nav.js hides it on the way down, which is the direction a
+   trail link travels, so a jump downward lands clear of it. A jump upward
+   brings the header back over the heading, and that is not new. */
+.way-name { scroll-margin-top: 2rem; }
 @media (prefers-reduced-motion: no-preference) {
   html { scroll-behavior: smooth; }
 }
@@ -1255,7 +1295,6 @@ footer {
     transition: transform .3s ease;
   }
   header.header-hidden { transform: translateY(-100%); }
-  .cat { scroll-margin-top: 4.5rem; }
 
   /* the header links fold behind a burger, the search stays beside it, and the
      desktop divider goes so the row sits centered */
@@ -1309,7 +1348,8 @@ footer {
 
   /* finger-sized controls (44px) */
   .theme-toggle { width: 2.75rem; height: 2.75rem; }
-  .langs a { display: inline-flex; align-items: center; min-height: 2.75rem; }
+  .langs a,
+  .langs [aria-current] { display: inline-flex; align-items: center; min-height: 2.75rem; }
   .search-box input { padding-block: .55rem; }
   /* 44px for the thumb, and still a disc: the fold caps the width, so raising
      the height alone left a 30 by 44 oval with the cross 3px from the clip. */

--- a/src/internal/render/templates/home.tmpl
+++ b/src/internal/render/templates/home.tmpl
@@ -21,7 +21,7 @@
 {{end}}{{range .Cats}}<section class="cat" aria-labelledby="cat-{{.ID}}">
   <div class="way">
     <span class="way-mark" aria-hidden="true"></span>
-    <h2 id="cat-{{.ID}}" class="way-name"{{.Name.Attrs}}>{{.Name}}</h2>
+    <h2 id="cat-{{.ID}}" class="way-name"{{.Name.Attrs}}><a href="#cat-{{.ID}}">{{.Name}}</a></h2>
     <span class="way-rule" aria-hidden="true"></span>
   </div>
   <ul class="cards">

--- a/src/internal/render/templates/home.tmpl
+++ b/src/internal/render/templates/home.tmpl
@@ -21,7 +21,7 @@
 {{end}}{{range .Cats}}<section class="cat" aria-labelledby="cat-{{.ID}}">
   <div class="way">
     <span class="way-mark" aria-hidden="true"></span>
-    <h2 id="cat-{{.ID}}" class="way-name"{{.Name.Attrs}}><a href="#cat-{{.ID}}">{{.Name}}</a></h2>
+    <h2 id="cat-{{.ID}}" class="way-name"{{.Name.Attrs}}><a href="#cat-{{.ID}}"><svg class="way-link" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.07 0l3-3a5 5 0 0 0-7.07-7.07l-1.5 1.5"/><path d="M14 11a5 5 0 0 0-7.07 0l-3 3a5 5 0 0 0 7.07 7.07l1.5-1.5"/></svg>{{.Name}}</a></h2>
     <span class="way-rule" aria-hidden="true"></span>
   </div>
   <ul class="cards">

--- a/src/internal/render/templates/layout.tmpl
+++ b/src/internal/render/templates/layout.tmpl
@@ -49,11 +49,16 @@
     {{$v := .}}{{if gt (len .Locales) 3}}<details class="langs langs-menu">
       <summary aria-label="{{.S.Languages}}">{{upper .Locale}}<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg></summary>
       <nav aria-label="{{.S.Languages}}">{{range .Locales}}
-        <a href="{{$v.Prefix}}/{{.}}/{{$v.SwitchPath}}?choose"{{if eq . $v.Locale}} aria-current="page"{{end}}>{{upper .}}</a>{{end}}
+        {{if eq . $v.Locale}}<span aria-current="page">{{upper .}}</span>{{else}}<a href="{{$v.Prefix}}/{{.}}/{{$v.SwitchPath}}?choose">{{upper .}}</a>{{end}}{{end}}
       </nav>
     </details>
-    {{else}}<nav class="langs" aria-label="{{.S.Languages}}">{{range .Locales}}
-      <a href="{{$v.Prefix}}/{{.}}/{{$v.SwitchPath}}?choose"{{if eq . $v.Locale}} aria-current="page"{{end}}>{{upper .}}</a>{{end}}
+    {{else}}{{/* The language you are reading is a label, not a control: a link
+         there only ever led back to the same page. It keeps aria-current so the
+         switcher still says which one is live, and leaves the tab order.
+         Pinning a language against browser negotiation is what ?choose does,
+         and that is still reachable, on every language you are not reading.
+    */}}<nav class="langs" aria-label="{{.S.Languages}}">{{range .Locales}}
+      {{if eq . $v.Locale}}<span aria-current="page">{{upper .}}</span>{{else}}<a href="{{$v.Prefix}}/{{.}}/{{$v.SwitchPath}}?choose">{{upper .}}</a>{{end}}{{end}}
     </nav>{{end}}
   </div>
 </div>

--- a/src/internal/render/testdata/golden/en.html
+++ b/src/internal/render/testdata/golden/en.html
@@ -36,7 +36,7 @@
       <svg class="sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2m7.07-17.07-1.41 1.41M6.34 17.66l-1.41 1.41M22 12h-2M4 12H2m17.07 7.07-1.41-1.41M6.34 6.34 4.93 4.93"/></svg>
     </button>
     <nav class="langs" aria-label="Language">
-      <a href="/en/?choose" aria-current="page">EN</a>
+      <span aria-current="page">EN</span>
       <a href="/fr/?choose">FR</a>
     </nav>
   </div>
@@ -72,7 +72,7 @@
 <section class="cat" aria-labelledby="cat-documents">
   <div class="way">
     <span class="way-mark" aria-hidden="true"></span>
-    <h2 id="cat-documents" class="way-name">Documents</h2>
+    <h2 id="cat-documents" class="way-name"><a href="#cat-documents">Documents</a></h2>
     <span class="way-rule" aria-hidden="true"></span>
   </div>
   <ul class="cards">
@@ -106,7 +106,7 @@
 <section class="cat" aria-labelledby="cat-other">
   <div class="way">
     <span class="way-mark" aria-hidden="true"></span>
-    <h2 id="cat-other" class="way-name">Other</h2>
+    <h2 id="cat-other" class="way-name"><a href="#cat-other">Other</a></h2>
     <span class="way-rule" aria-hidden="true"></span>
   </div>
   <ul class="cards">

--- a/src/internal/render/testdata/golden/en.html
+++ b/src/internal/render/testdata/golden/en.html
@@ -72,7 +72,7 @@
 <section class="cat" aria-labelledby="cat-documents">
   <div class="way">
     <span class="way-mark" aria-hidden="true"></span>
-    <h2 id="cat-documents" class="way-name"><a href="#cat-documents">Documents</a></h2>
+    <h2 id="cat-documents" class="way-name"><a href="#cat-documents"><svg class="way-link" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.07 0l3-3a5 5 0 0 0-7.07-7.07l-1.5 1.5"/><path d="M14 11a5 5 0 0 0-7.07 0l-3 3a5 5 0 0 0 7.07 7.07l1.5-1.5"/></svg>Documents</a></h2>
     <span class="way-rule" aria-hidden="true"></span>
   </div>
   <ul class="cards">
@@ -106,7 +106,7 @@
 <section class="cat" aria-labelledby="cat-other">
   <div class="way">
     <span class="way-mark" aria-hidden="true"></span>
-    <h2 id="cat-other" class="way-name"><a href="#cat-other">Other</a></h2>
+    <h2 id="cat-other" class="way-name"><a href="#cat-other"><svg class="way-link" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.07 0l3-3a5 5 0 0 0-7.07-7.07l-1.5 1.5"/><path d="M14 11a5 5 0 0 0-7.07 0l-3 3a5 5 0 0 0 7.07 7.07l1.5-1.5"/></svg>Other</a></h2>
     <span class="way-rule" aria-hidden="true"></span>
   </div>
   <ul class="cards">

--- a/src/internal/render/testdata/golden/en/pdf.html
+++ b/src/internal/render/testdata/golden/en/pdf.html
@@ -36,7 +36,7 @@
       <svg class="sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2m7.07-17.07-1.41 1.41M6.34 17.66l-1.41 1.41M22 12h-2M4 12H2m17.07 7.07-1.41-1.41M6.34 6.34 4.93 4.93"/></svg>
     </button>
     <nav class="langs" aria-label="Language">
-      <a href="/en/pdf/?choose" aria-current="page">EN</a>
+      <span aria-current="page">EN</span>
       <a href="/fr/pdf/?choose">FR</a>
     </nav>
   </div>

--- a/src/internal/render/testdata/golden/fr.html
+++ b/src/internal/render/testdata/golden/fr.html
@@ -37,7 +37,7 @@
     </button>
     <nav class="langs" aria-label="Langue">
       <a href="/en/?choose">EN</a>
-      <a href="/fr/?choose" aria-current="page">FR</a>
+      <span aria-current="page">FR</span>
     </nav>
   </div>
 </div>
@@ -73,7 +73,7 @@
 <section class="cat" aria-labelledby="cat-documents">
   <div class="way">
     <span class="way-mark" aria-hidden="true"></span>
-    <h2 id="cat-documents" class="way-name">Documents</h2>
+    <h2 id="cat-documents" class="way-name"><a href="#cat-documents">Documents</a></h2>
     <span class="way-rule" aria-hidden="true"></span>
   </div>
   <ul class="cards">
@@ -107,7 +107,7 @@
 <section class="cat" aria-labelledby="cat-other">
   <div class="way">
     <span class="way-mark" aria-hidden="true"></span>
-    <h2 id="cat-other" class="way-name">Autres</h2>
+    <h2 id="cat-other" class="way-name"><a href="#cat-other">Autres</a></h2>
     <span class="way-rule" aria-hidden="true"></span>
   </div>
   <ul class="cards">

--- a/src/internal/render/testdata/golden/fr.html
+++ b/src/internal/render/testdata/golden/fr.html
@@ -73,7 +73,7 @@
 <section class="cat" aria-labelledby="cat-documents">
   <div class="way">
     <span class="way-mark" aria-hidden="true"></span>
-    <h2 id="cat-documents" class="way-name"><a href="#cat-documents">Documents</a></h2>
+    <h2 id="cat-documents" class="way-name"><a href="#cat-documents"><svg class="way-link" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.07 0l3-3a5 5 0 0 0-7.07-7.07l-1.5 1.5"/><path d="M14 11a5 5 0 0 0-7.07 0l-3 3a5 5 0 0 0 7.07 7.07l1.5-1.5"/></svg>Documents</a></h2>
     <span class="way-rule" aria-hidden="true"></span>
   </div>
   <ul class="cards">
@@ -107,7 +107,7 @@
 <section class="cat" aria-labelledby="cat-other">
   <div class="way">
     <span class="way-mark" aria-hidden="true"></span>
-    <h2 id="cat-other" class="way-name"><a href="#cat-other">Autres</a></h2>
+    <h2 id="cat-other" class="way-name"><a href="#cat-other"><svg class="way-link" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.07 0l3-3a5 5 0 0 0-7.07-7.07l-1.5 1.5"/><path d="M14 11a5 5 0 0 0-7.07 0l-3 3a5 5 0 0 0 7.07 7.07l1.5-1.5"/></svg>Autres</a></h2>
     <span class="way-rule" aria-hidden="true"></span>
   </div>
   <ul class="cards">

--- a/src/internal/render/testdata/golden/fr/pdf.html
+++ b/src/internal/render/testdata/golden/fr/pdf.html
@@ -37,7 +37,7 @@
     </button>
     <nav class="langs" aria-label="Langue">
       <a href="/en/pdf/?choose">EN</a>
-      <a href="/fr/pdf/?choose" aria-current="page">FR</a>
+      <span aria-current="page">FR</span>
     </nav>
   </div>
 </div>

--- a/src/internal/render/testdata/golden/states.html
+++ b/src/internal/render/testdata/golden/states.html
@@ -50,7 +50,7 @@
 <section class="cat" aria-labelledby="cat-other">
   <div class="way">
     <span class="way-mark" aria-hidden="true"></span>
-    <h2 id="cat-other" class="way-name"><a href="#cat-other">Other</a></h2>
+    <h2 id="cat-other" class="way-name"><a href="#cat-other"><svg class="way-link" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.07 0l3-3a5 5 0 0 0-7.07-7.07l-1.5 1.5"/><path d="M14 11a5 5 0 0 0-7.07 0l-3 3a5 5 0 0 0 7.07 7.07l1.5-1.5"/></svg>Other</a></h2>
     <span class="way-rule" aria-hidden="true"></span>
   </div>
   <ul class="cards">

--- a/src/internal/render/testdata/golden/states.html
+++ b/src/internal/render/testdata/golden/states.html
@@ -29,7 +29,7 @@
       <svg class="sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2m7.07-17.07-1.41 1.41M6.34 17.66l-1.41 1.41M22 12h-2M4 12H2m17.07 7.07-1.41-1.41M6.34 6.34 4.93 4.93"/></svg>
     </button>
     <nav class="langs" aria-label="Language">
-      <a href="/en/?choose" aria-current="page">EN</a>
+      <span aria-current="page">EN</span>
     </nav>
   </div>
 </div>
@@ -50,7 +50,7 @@
 <section class="cat" aria-labelledby="cat-other">
   <div class="way">
     <span class="way-mark" aria-hidden="true"></span>
-    <h2 id="cat-other" class="way-name">Other</h2>
+    <h2 id="cat-other" class="way-name"><a href="#cat-other">Other</a></h2>
     <span class="way-rule" aria-hidden="true"></span>
   </div>
   <ul class="cards">


### PR DESCRIPTION
Four reports, and three of them turned out to be somewhere other than where
they looked. Two more things came out of testing it on a screen.

## The diamonds

Both sets were centred on their line box, which carries descender space no
lowercase letter reaches, so they read high beside a mostly lowercase word.
They now sit halfway between the middle of the lowercase and the middle of the
capitals: on the lowercase alone they read low, because the capital and the
ascenders carry mass above that band with nothing under it to answer.

The heading's diamond was the worse of the two and was not in the report.
Fixing only the rail would have left the more visible one wrong.

**The reference was wrong as much as the target was.** The first rounds
computed the baseline from the font's own ascent, which sits about 0.45px from
where the layout actually puts it, so they measured against a line that is not
there. A zero-height inline-block sits on the baseline and `1ex` is the
x-height, both from the browser. Read that way one fraction serves both
typefaces, where the bad baseline had suggested two were needed.

## The rail's spine

The line was placed near the marks rather than on them: `.2rem` against a
centre at `.21rem`, drawing 0.34px to their right. It predates this branch and
sat on `main` unnoticed until the marks moved. The mark's size is a token now
and the spine is half of it less half its own width, so the two cannot drift.

## Where an anchor lands

`.cat { scroll-margin-top }` never did anything. Every `#cat-` link targets the
`h2`, so the section's margin is not the one the browser reads, and the heading
landed 0.5px from the top. It moves onto `.way-name` at `2rem`. The gap above a
heading is 2.6rem, so anything past that pulls the previous section's last card
into view.

```console
desktop        heading at 32.5px | previous card bottom  -9.1px (off screen)
phone          heading at 32.3px | previous card bottom  -9.3px (off screen)
narrow phone   heading at 32.3px | previous card bottom  -9.3px (off screen)
```

One value, phones included. The `4.5rem` a narrow screen carried was meant to
clear the sticky header; it sat on `.cat` and never applied, and could not have
done that job anyway since the header is 132px.

## The headings, and the glyph beside them

Each category heading is a link to its own id, taking neither colour nor
underline: a heading that changed on hover would read as a different heading.

Beside it, on hover, the affordance a markdown renderer puts there. It hangs in
the margin rather than in the row, so nothing moves when it appears, measured
at 0.00px. It is inside the anchor, so clicking it does what it looks like, and
`aria-hidden`, since the heading is that same link.

Only past 69rem, where the margin can hold it, and only where a pointer exists.
`--muted` held back to `.65`: the rule's own weight was tried first, which is
tidier on paper since the rule closes the same row, and it read as a smudge at
real size. A glyph is line work with gaps in it rather than a solid 1px bar, so
the same ink does not carry the same distance.

## The language you are reading

A `<span aria-current="page">` in both switcher shapes, so it is neither
clickable nor in the tab order. On a single-language site it was the only thing
in the switcher there was to click.

**What that costs.** The switcher links carry `?choose`, which pins a language
against browser negotiation, and clicking the one you were reading was a way to
pin it. Thin loss: pinning matters when you want something other than what
negotiation gives you, which means clicking a different language, and that
still works. Nothing ever told anyone the affordance existed.

## Checked

Ten browser checks added, 74 in total, each proved red against exactly what it
guards:

| revert | what went red |
| --- | --- |
| no drop on the marks | the midpoint check |
| the full drop onto the lowercase | the midpoint check, from the other side |
| the spine's old literal | the spine check, at -0.34px |
| heading back to plain text | the link check and both landing checks |
| margin back on `.cat` | both landing checks |
| the glyph out of the template | both glyph checks |
| the glyph's width gate removed | the width check |
| the glyph at opacity .2 | the visibility check |
| current language back to `<a>` | all three switcher checks |

**One of them was vacuous when written** and is the fourth of its kind here: the
width check read the first glyph in the document while hovering the second
heading, so it stayed green with the rule deleted. It reads the hovered one now.

The golden files carry the two markup changes and the svg, nothing else. An
earlier regeneration also carried a stray blank line on every page, from a
template comment whose newline printed; the comment closes against its tag.

`golangci-lint` is not installed on this machine so it did not run locally. No
Go changed.