### PR TITLE
feat: one category trail, a row that scrolls instead of two controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ account or a manual, and boring for you to operate.
   themes, a skip link, named landmarks, search results announced through a
   live region, a theme toggle that says which way it is set, and
   right-to-left languages laid out the right way round. The controls a
-  visitor can operate, the search box and the phone's jump-to select, carry a
+  visitor can operate, the search box and the leaving dialog's buttons, carry a
   boundary that clears 3:1, remeasured in a real browser on every pull
   request. Tested with a browser, never audited as a whole, and not yet with a
   real screen reader: if you use one,

--- a/docs/configuration/theming.md
+++ b/docs/configuration/theming.md
@@ -98,8 +98,8 @@ The stylesheet is built on custom properties; override those first:
 Two border colors, because they answer to different rules. `--border` draws
 decoration: the outline of a card, a rule, the trail's spine, all things the
 page would still be legible without. `--ui-border` draws the edge of something
-a visitor operates, the search box on the home page and the jump-to select a
-phone gets, where nothing else says where to type or tap. That edge is held at
+a visitor operates, the search box on the home page and the two buttons in the
+leaving dialog, where nothing else says where to type or tap. That edge is held at
 3:1 against the page and against its own fill, which is the floor
 [WCAG asks for a control's boundary](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html);
 if you override it, keep it there.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -19,11 +19,11 @@ numbers, count there.
 
 **Does it need JavaScript?**
 No. Pages are fully server-rendered; small scripts add the search box, the
-theme toggle, the welcome note's dismiss button and the highlight that follows
-you down the category trail. Without them the directory is all still there,
-every category, every card, every link, in the system's theme. On a phone the
-trail stays a row of chips instead of folding into the compact jump-to select,
-which is a control only a script can drive.
+theme toggle, the welcome note's dismiss button and the mark that follows you
+down the category trail in the margin. Without them the directory is all still
+there, every category, every card, every link, in the system's theme. The
+category trail is a row of links at every width below that margin, so a phone
+keeps it in full with scripting off.
 
 **Can I put it behind authentication?**
 You can (any proxy auth works: Authelia, Tinyauth, basic auth), but cairn is
@@ -48,6 +48,21 @@ Headings derive from the `category` id unless you name them in
 One image: 4.3 MB to pull, about 10 MB unpacked, nearly all of that the static
 binary. One process, a few MB of RAM. `FROM scratch`, non-root, no shell
 inside.
+
+**Why does my browser console show CSP errors on cairn's pages?**
+Your extensions, and the policy doing what it is for. cairn serves exactly one
+inline script and one inline style per page, and the two hashes in the
+`Content-Security-Policy` header are theirs; everything else is an external
+file under `/static/`. Read the file each message names. If it is
+`autoconsent.js`, `content.js`, `utils.js` or a filename that is just a UUID,
+something outside the page tried to inject code into it and was refused.
+Firefox's own cookie-banner blocker is one of those, and it has nothing to
+block here. Letting them through would mean opening the policy to any script,
+which is the thing it exists to prevent. Nothing of cairn's is ever blocked, and it
+shows: that inline script is the one that applies a saved theme before the
+first paint and hides an already-dismissed welcome note. Refused, a visitor who
+picked the theme opposite their system would see the wrong one until the page
+finished loading, and a dismissed note would flash back.
 
 **Can visitors switch language permanently?**
 Yes: the header switcher sets a one-year cookie and `/` honors it from

--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -684,37 +684,74 @@ await check(
   },
 );
 
-// A row that scrolls hides entries, so the one it marks has to be brought
-// back. Asserted where the row genuinely overflows, since otherwise every
-// entry is in view and the check would pass with the scrolling deleted.
-await check("the marked entry is brought into the row", async () => {
-  await sm.setViewportSize({ width: 320, height: 780 });
-  const r = await sm.evaluate(async () => {
-    const ul = document.querySelector(".toc ul");
-    if (ul.scrollWidth <= ul.clientWidth + 1) return { overflows: false };
+// A chip row is a set of buttons, so none of them is ever the selected one.
+// The rail above 88rem is what tracks the reader; a chip lighting up under a
+// thumb reported a place the reader had not chosen to be.
+await check("no chip is ever painted as the current one", async () => {
+  for (const w of [320, 390, 970]) {
+    await sm.setViewportSize({ width: w, height: 780 });
+    const r = await sm.evaluate(async () => {
+      const cats = [...document.querySelectorAll(".cat")];
+      scrollTo(0, cats[2].getBoundingClientRect().top + scrollY - 80);
+      await new Promise((r) => setTimeout(r, 600));
+      const marked = document.querySelector(".toc a[aria-current]");
+      if (!marked) return { marked: null };
+      const plain = [...document.querySelectorAll(".toc a")].find(
+        (a) => !a.hasAttribute("aria-current"),
+      );
+      const look = (el) => {
+        const c = getComputedStyle(el);
+        return `${c.color}|${c.backgroundColor}|${c.borderColor}|${c.fontWeight}`;
+      };
+      return {
+        marked: marked.textContent.trim(),
+        same: look(marked) === look(plain),
+        a: look(marked),
+        b: look(plain),
+      };
+    });
+    if (r.marked === null) continue; // nothing marked at all is also fine
+    if (!r.same) {
+      throw new Error(
+        `at ${w}px the chip "${r.marked}" is painted differently:\n        ${r.a}\n        against ${r.b}`,
+      );
+    }
+  }
+  await sm.setViewportSize(PHONE);
+});
+
+// The rail is the other half of that rule: it does track the reader, since it
+// is a trail down the margin rather than a row of buttons.
+await check("the rail above 88rem still says where the reader is", async () => {
+  const wide = await stillPhone.newPage();
+  await wide.setViewportSize({ width: 1500, height: 900 });
+  await wide.goto(MANY);
+  const r = await wide.evaluate(async () => {
     const cats = [...document.querySelectorAll(".cat")];
-    const last = cats[cats.length - 1];
-    scrollTo(0, last.getBoundingClientRect().top + scrollY - 100);
-    await new Promise((r) => setTimeout(r, 700));
+    scrollTo(0, cats[2].getBoundingClientRect().top + scrollY - 80);
+    await new Promise((r) => setTimeout(r, 600));
     const a = document.querySelector(".toc a[aria-current]");
-    if (!a) return { overflows: true, marked: null };
-    const e = a.getBoundingClientRect(),
-      u = ul.getBoundingClientRect();
+    if (!a) return null;
+    const mark = a.querySelector(".toc-mark");
     return {
-      overflows: true,
-      marked: a.textContent.trim(),
-      inView: e.left >= u.left - 1 && e.right <= u.right + 1,
+      text: a.textContent.trim(),
+      weight: getComputedStyle(a).fontWeight,
+      dot: getComputedStyle(mark).backgroundColor,
+      plainDot: getComputedStyle(
+        [...document.querySelectorAll(".toc a")]
+          .find((x) => !x.hasAttribute("aria-current"))
+          .querySelector(".toc-mark"),
+      ).backgroundColor,
     };
   });
-  await sm.setViewportSize(PHONE);
-  if (!r.overflows)
+  await wide.close();
+  if (!r)
+    throw new Error("the rail marks nothing after scrolling into a section");
+  if (r.dot === r.plainDot) {
     throw new Error(
-      "the row does not overflow at 320px, so this proves nothing",
+      `the rail's current diamond is the same colour as the rest: ${r.dot}`,
     );
-  if (!r.marked)
-    throw new Error("scrolling to the last category marked nothing");
-  if (!r.inView)
-    throw new Error(`the marked entry "${r.marked}" sits outside the row`);
+  }
 });
 
 // The trail is plain markup now, so scripting off costs the chips nothing.

--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -1082,6 +1082,56 @@ await check(
     eq(await dialog.evaluate((d) => d.open), false, "dialog.open after stay");
   });
 
+  // A modal dialog takes the interaction but not the scroll. The control run
+  // with it shut is the point of this one: overflow:hidden stops a wheel and
+  // not scrollTo, so a test that scrolls by script measures nothing, and a
+  // page with no room to scroll passes it with the rule deleted.
+  await check("the page does not travel behind the open dialog", async () => {
+    await l.goto(LEAVE, { waitUntil: "networkidle" });
+    await l.setViewportSize({ width: 1000, height: 400 });
+    const room = await l.evaluate(
+      () => document.documentElement.scrollHeight - innerHeight,
+    );
+    if (room < 40)
+      throw new Error(`only ${room}px of scroll room, this proves nothing`);
+
+    await l.mouse.move(500, 200);
+    await l.mouse.wheel(0, 200);
+    await l.waitForTimeout(250);
+    const control = await l.evaluate(() => scrollY);
+    if (control === 0)
+      throw new Error("the wheel moved nothing with the dialog shut");
+
+    await l.evaluate(() => {
+      scrollTo(0, 0);
+      document.querySelector("a[data-leave]").click();
+    });
+    await l.waitForTimeout(350);
+    eq(
+      await l.locator("#leave").evaluate((d) => d.open),
+      true,
+      "the dialog opened",
+    );
+    await l.mouse.wheel(0, 200);
+    await l.waitForTimeout(250);
+    const whileOpen = await l.evaluate(() => scrollY);
+    if (whileOpen !== 0) {
+      throw new Error(
+        `the page travelled ${whileOpen}px behind the open dialog`,
+      );
+    }
+
+    await l.evaluate(() => document.querySelector("#leave").close());
+    await l.waitForTimeout(300);
+    await l.mouse.wheel(0, 200);
+    await l.waitForTimeout(250);
+    if ((await l.evaluate(() => scrollY)) === 0) {
+      throw new Error("closing the dialog left the page stuck");
+    }
+    await l.setViewportSize(PHONE);
+    await l.goto(LEAVE, { waitUntil: "networkidle" });
+  });
+
   await check("the detail page carries the same guard", async () => {
     await l.goto(new URL("mail/", LEAVE).href, { waitUntil: "networkidle" });
     await l.locator("a.btn[data-leave]").click();

--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -618,6 +618,43 @@ const stillPhone = await browser.newContext({
 const sm = await stillPhone.newPage();
 await sm.goto(MANY);
 
+// The chip block has to come after the rules it overrides. Placed before them
+// it lost padding-inline to the rail's `padding: .28rem 0` at equal
+// specificity, and every short category came out a 34px circle with the word
+// against its edges. Nothing else noticed: the row was still one line and
+// still scrolled, which is all the other checks were looking at.
+await check("a chip is a chip and not a squeezed circle", async () => {
+  for (const w of [320, 390, 970]) {
+    await sm.setViewportSize({ width: w, height: 780 });
+    const r = await sm.evaluate(() =>
+      [...document.querySelectorAll(".toc a")]
+        .filter((a) => a.getClientRects().length)
+        .map((a) => {
+          const cs = getComputedStyle(a);
+          const b = a.getBoundingClientRect();
+          return {
+            t: a.textContent.trim(),
+            pad: parseFloat(cs.paddingInlineStart),
+            w: b.width,
+            h: b.height,
+          };
+        }),
+    );
+    if (!r.length) throw new Error(`no chip painted at ${w}px`);
+    for (const c of r) {
+      if (c.pad < 10) {
+        throw new Error(`"${c.t}" has ${c.pad}px of side padding at ${w}px`);
+      }
+      if (c.w < c.h) {
+        throw new Error(
+          `"${c.t}" is ${Math.round(c.w)}x${Math.round(c.h)} at ${w}px, taller than it is wide`,
+        );
+      }
+    }
+  }
+  await sm.setViewportSize(PHONE);
+});
+
 await check(
   "the trail is one row that scrolls, never a wrapped block",
   async () => {

--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -608,29 +608,79 @@ for (const width of [390, 320]) {
   });
 }
 
-// The jump-to select is painted only at phone width.
+// One control below the rail, at every width and every category count. It
+// used to split at seven into a wrapping chip row and a jump-to select, with
+// the swap gated on data-js because nav.js was the select's whole behaviour.
 const stillPhone = await browser.newContext({
   viewport: PHONE,
   reducedMotion: "reduce",
 });
 const sm = await stillPhone.newPage();
 await sm.goto(MANY);
-await check("the mobile jump-to select clears 3:1 too", async () => {
-  atLeast3(await boundary(sm, ".toc-select"), "the jump-to select");
-});
 
 await check(
-  "a phone with JavaScript shows the jump-to select, not the chips",
+  "the trail is one row that scrolls, never a wrapped block",
   async () => {
-    eq((await painted(m, ".toc-select")).length, 1, "painted jump selects");
-    eq((await painted(m, ".toc.many a")).length, 0, "painted trail chips");
+    for (const w of [320, 390, 768, 1024]) {
+      await sm.setViewportSize({ width: w, height: 780 });
+      const r = await sm.evaluate(() => {
+        const toc = document.querySelector(".toc");
+        if (!toc || !toc.getClientRects().length) return null;
+        const ul = toc.querySelector("ul");
+        const links = [...ul.querySelectorAll("a")];
+        return {
+          rows: new Set(
+            links.map((a) => Math.round(a.getBoundingClientRect().top)),
+          ).size,
+          links: links.length,
+          selects: document.querySelectorAll(".toc-select, .toc-jump").length,
+        };
+      });
+      if (!r) throw new Error(`no category navigation painted at ${w}px`);
+      if (r.rows !== 1)
+        throw new Error(`the trail wraps onto ${r.rows} rows at ${w}px`);
+      if (r.selects) throw new Error(`a jump-to select came back at ${w}px`);
+      if (r.links < 9)
+        throw new Error(`${r.links} categories listed at ${w}px, want all 9`);
+    }
+    await sm.setViewportSize(PHONE);
   },
 );
 
-// The swap to a select is gated on JavaScript because nav.js is the select's
-// entire behaviour. Ungated, a phone with scripting off got no category
-// navigation at all, on the viewport where a nine-category list is least
-// scrollable.
+// A row that scrolls hides entries, so the one it marks has to be brought
+// back. Asserted where the row genuinely overflows, since otherwise every
+// entry is in view and the check would pass with the scrolling deleted.
+await check("the marked entry is brought into the row", async () => {
+  await sm.setViewportSize({ width: 320, height: 780 });
+  const r = await sm.evaluate(async () => {
+    const ul = document.querySelector(".toc ul");
+    if (ul.scrollWidth <= ul.clientWidth + 1) return { overflows: false };
+    const cats = [...document.querySelectorAll(".cat")];
+    const last = cats[cats.length - 1];
+    scrollTo(0, last.getBoundingClientRect().top + scrollY - 100);
+    await new Promise((r) => setTimeout(r, 700));
+    const a = document.querySelector(".toc a[aria-current]");
+    if (!a) return { overflows: true, marked: null };
+    const e = a.getBoundingClientRect(),
+      u = ul.getBoundingClientRect();
+    return {
+      overflows: true,
+      marked: a.textContent.trim(),
+      inView: e.left >= u.left - 1 && e.right <= u.right + 1,
+    };
+  });
+  await sm.setViewportSize(PHONE);
+  if (!r.overflows)
+    throw new Error(
+      "the row does not overflow at 320px, so this proves nothing",
+    );
+  if (!r.marked)
+    throw new Error("scrolling to the last category marked nothing");
+  if (!r.inView)
+    throw new Error(`the marked entry "${r.marked}" sits outside the row`);
+});
+
+// The trail is plain markup now, so scripting off costs the chips nothing.
 const dumb = await browser.newContext({
   viewport: PHONE,
   javaScriptEnabled: false,
@@ -641,12 +691,9 @@ await nojs.goto(MANY);
 await check(
   "a phone without JavaScript still paints category navigation",
   async () => {
-    const chips = await painted(nojs, ".toc.many a");
+    const chips = await painted(nojs, ".toc a");
     if (chips.length === 0) {
-      const inert = (await painted(nojs, ".toc-select")).length;
-      throw new Error(
-        `no category link is painted, and ${inert} jump select(s) are, which nothing can drive`,
-      );
+      throw new Error("no category link is painted with scripting off");
     }
   },
 );

--- a/src/internal/render/assets/nav.js
+++ b/src/internal/render/assets/nav.js
@@ -39,13 +39,5 @@
     requestAnimationFrame(() => { update(); ticking = false; });
   }, { passive: true });
 
-  const sel = document.querySelector('.toc-select');
-  if (sel) {
-    sel.addEventListener('change', () => {
-      if (sel.value) location.hash = sel.value;
-      sel.selectedIndex = 0;
-    });
-  }
-
   update();
 })();

--- a/src/internal/render/assets/style.css
+++ b/src/internal/render/assets/style.css
@@ -496,51 +496,6 @@ header { padding-block: 1.4rem; }
 /* A fixed rail beside the content: one diamond per category on a vertical line.
    Shown only where the margin can hold it. */
 .toc { display: none; }
-/* Below the rail the trail is a row of chips that scrolls sideways rather than
-   wrapping: one line at any category count, on a 320px phone as on a laptop
-   window. It replaces two controls that used to split at seven categories, a
-   wrapping row and a jump-to select, and it closes the band between 44rem and
-   88rem where a reader had no category navigation at all.
-
-   toc.js keeps the current chip in view. Without it the row is still a list
-   you can swipe, which the select it replaces was not: that one did nothing
-   without JavaScript, which is why it had to be swapped in behind data-js. */
-@media (max-width: 87.99rem) {
-  .toc {
-    display: block;
-    margin: 1.5rem 0 .3rem;
-  }
-  .toc ul {
-    display: flex;
-    flex-wrap: nowrap;
-    gap: .5rem;
-    overflow-x: auto;
-    /* the row is the scroller, so its own focus ring must not be clipped */
-    padding-block-end: 2px;
-    scrollbar-width: none;
-    scroll-snap-type: x proximity;
-  }
-  .toc ul::-webkit-scrollbar { display: none; }
-  .toc ul::before { display: none; }
-  .toc li { flex: none; scroll-snap-align: center; }
-  .toc a {
-    min-height: 2.5rem;
-    padding: 0 .85rem;
-    border: 1px solid var(--border);
-    border-radius: 999px;
-    background: var(--card);
-    font-size: .85rem;
-    white-space: nowrap;
-  }
-  .toc-mark { display: none; }
-  .toc a[aria-current] {
-    color: var(--fg);
-    font-weight: 500;
-    border-color: color-mix(in oklab, var(--accent) 45%, var(--border));
-    background: color-mix(in oklab, var(--accent) 8%, var(--card));
-  }
-}
-
 @media (min-width: 88rem) {
   .toc {
     display: block;
@@ -600,6 +555,51 @@ header { padding-block: 1.4rem; }
 .toc a[aria-current] { color: inherit; font-weight: 600; }
 .toc a[aria-current] .toc-mark { background: var(--accent); }
 .toc a:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 3px; }
+
+/* Below the rail the trail is a row of chips that scrolls sideways rather than
+   wrapping: one line at any category count, on a 320px phone as on a laptop
+   window. It replaces two controls that used to split at seven categories, a
+   wrapping row and a jump-to select, and it closes the band between 44rem and
+   88rem where a reader had no category navigation at all.
+
+   toc.js keeps the current chip in view. Without it the row is still a list
+   you can swipe, which the select it replaces was not: that one did nothing
+   without JavaScript, which is why it had to be swapped in behind data-js. */
+@media (max-width: 87.99rem) {
+  .toc {
+    display: block;
+    margin: 1.5rem 0 .3rem;
+  }
+  .toc ul {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: .5rem;
+    overflow-x: auto;
+    /* the row is the scroller, so its own focus ring must not be clipped */
+    padding-block-end: 2px;
+    scrollbar-width: none;
+    scroll-snap-type: x proximity;
+  }
+  .toc ul::-webkit-scrollbar { display: none; }
+  .toc ul::before { display: none; }
+  .toc li { flex: none; scroll-snap-align: center; }
+  .toc a {
+    min-height: 2.5rem;
+    padding: 0 .85rem;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--card);
+    font-size: .85rem;
+    white-space: nowrap;
+  }
+  .toc-mark { display: none; }
+  .toc a[aria-current] {
+    color: var(--fg);
+    font-weight: 500;
+    border-color: color-mix(in oklab, var(--accent) 45%, var(--border));
+    background: color-mix(in oklab, var(--accent) 8%, var(--card));
+  }
+}
 
 /* On the heading and not on .cat: every #cat- link, the rail's and the jump
    select's and now the heading's own, targets the h2, so the section's margin

--- a/src/internal/render/assets/style.css
+++ b/src/internal/render/assets/style.css
@@ -496,7 +496,51 @@ header { padding-block: 1.4rem; }
 /* A fixed rail beside the content: one diamond per category on a vertical line.
    Shown only where the margin can hold it. */
 .toc { display: none; }
-.toc-jump { display: none; } /* shown in the mobile block */
+/* Below the rail the trail is a row of chips that scrolls sideways rather than
+   wrapping: one line at any category count, on a 320px phone as on a laptop
+   window. It replaces two controls that used to split at seven categories, a
+   wrapping row and a jump-to select, and it closes the band between 44rem and
+   88rem where a reader had no category navigation at all.
+
+   toc.js keeps the current chip in view. Without it the row is still a list
+   you can swipe, which the select it replaces was not: that one did nothing
+   without JavaScript, which is why it had to be swapped in behind data-js. */
+@media (max-width: 87.99rem) {
+  .toc {
+    display: block;
+    margin: 1.5rem 0 .3rem;
+  }
+  .toc ul {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: .5rem;
+    overflow-x: auto;
+    /* the row is the scroller, so its own focus ring must not be clipped */
+    padding-block-end: 2px;
+    scrollbar-width: none;
+    scroll-snap-type: x proximity;
+  }
+  .toc ul::-webkit-scrollbar { display: none; }
+  .toc ul::before { display: none; }
+  .toc li { flex: none; scroll-snap-align: center; }
+  .toc a {
+    min-height: 2.5rem;
+    padding: 0 .85rem;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--card);
+    font-size: .85rem;
+    white-space: nowrap;
+  }
+  .toc-mark { display: none; }
+  .toc a[aria-current] {
+    color: var(--fg);
+    font-weight: 500;
+    border-color: color-mix(in oklab, var(--accent) 45%, var(--border));
+    background: color-mix(in oklab, var(--accent) 8%, var(--card));
+  }
+}
+
 @media (min-width: 88rem) {
   .toc {
     display: block;
@@ -1409,46 +1453,6 @@ footer {
   }
 
   /* the category trail becomes a wrapping chip row under the intro */
-  .toc { display: block; margin: 1.5rem 0 .3rem; }
-  .toc ul { display: flex; flex-wrap: wrap; gap: .5rem; }
-  .toc ul::before { display: none; }
-  .toc a {
-    min-height: 2.5rem;
-    padding: 0 .85rem;
-    border: 1px solid var(--border);
-    border-radius: 999px;
-    background: var(--card);
-    font-size: .85rem;
-  }
-  .toc-mark { display: none; }
-  .toc a[aria-current] {
-    color: var(--fg);
-    font-weight: 500;
-    border-color: color-mix(in oklab, var(--accent) 45%, var(--border));
-    background: color-mix(in oklab, var(--accent) 8%, var(--card));
-  }
-
-  /* Above ~7 categories the chips give way to a compact jump-to select, but
-     only where something can drive it: the select's behaviour lives entirely in
-     nav.js, so with JavaScript off this swap left a phone with no category
-     navigation at all. The pre-paint script in <head> stamps data-js before
-     first render, so gating on it costs no flash of the wrong one, and the
-     fallback needs no markup: .toc.many stays a chip row. */
-  [data-js] .toc.many { display: none; }
-  [data-js] .toc-jump { display: block; margin: 1.5rem 0 .3rem; }
-  .toc-select {
-    width: 100%;
-    max-width: 22rem;
-    min-height: 2.75rem;
-    padding: .3rem .9rem;
-    /* a form control, so --ui-border and its 3:1, like the search box */
-    border: 1px solid var(--ui-border);
-    border-radius: .7rem;
-    background: var(--card);
-    color: var(--fg);
-    font: inherit;
-    font-size: .9rem;
-  }
 
   .totop { display: grid; }
 

--- a/src/internal/render/assets/style.css
+++ b/src/internal/render/assets/style.css
@@ -593,11 +593,16 @@ header { padding-block: 1.4rem; }
     white-space: nowrap;
   }
   .toc-mark { display: none; }
+  /* No current one. A chip row is a set of buttons that take you somewhere,
+     not a report of where you are: the rail above 88rem is the thing that
+     tracks the reader, and it has the room to say so without a chip having to
+     light up under their thumb. aria-current is still set, since it costs
+     nothing and a screen reader can use it. */
   .toc a[aria-current] {
-    color: var(--fg);
-    font-weight: 500;
-    border-color: color-mix(in oklab, var(--accent) 45%, var(--border));
-    background: color-mix(in oklab, var(--accent) 8%, var(--card));
+    color: var(--muted);
+    font-weight: inherit;
+    border-color: var(--border);
+    background: var(--card);
   }
 }
 

--- a/src/internal/render/assets/style.css
+++ b/src/internal/render/assets/style.css
@@ -1031,6 +1031,16 @@ a.status-pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 
   max-width: min(34rem, calc(100vw - 2rem));
   box-shadow: var(--shadow-lift);
 }
+/* A modal dialog takes the interaction but not the scroll: under a wheel or a
+   thumb the page still travels behind it. Keyed on the dialog's own open state
+   rather than on a class leave.js would have to add and remove, so Escape, the
+   backdrop and the stay button all undo it without anyone remembering to.
+   scrollbar-gutter holds the width the scrollbar had, or the page jumps
+   sideways by it as the bar goes. */
+html:has(dialog[open]) {
+  overflow: hidden;
+  scrollbar-gutter: stable;
+}
 .leave::backdrop { background: light-dark(rgba(20, 30, 28, .38), rgba(0, 0, 0, .62)); }
 .leave h2 { font-family: var(--font-display); font-size: 1.25rem; margin: 0 0 .6rem; }
 .leave-body { margin: 0 0 1rem; color: var(--muted); }

--- a/src/internal/render/assets/toc.js
+++ b/src/internal/render/assets/toc.js
@@ -8,19 +8,6 @@
   const sections = Array.from(document.querySelectorAll('.cat'));
   let current;
 
-  const rail = toc.querySelector('ul');
-  const smooth = !matchMedia('(prefers-reduced-motion: reduce)').matches;
-
-  // Below the rail the trail is a row that scrolls sideways, so the entry it
-  // marks can sit outside it. Centring by the difference between the two
-  // rectangles rather than by offsetLeft, which is measured from whichever
-  // ancestor happens to be positioned.
-  const keepInView = el => {
-    if (rail.scrollWidth <= rail.clientWidth + 1) return;
-    const e = el.getBoundingClientRect(), r = rail.getBoundingClientRect();
-    rail.scrollBy({ left: (e.left + e.width / 2) - (r.left + r.width / 2), behavior: smooth ? 'smooth' : 'auto' });
-  };
-
   const spy = () => {
     const visible = sections.filter(s => !s.hidden);
     // Nothing until a section has actually crossed: at the top of the page the
@@ -36,10 +23,7 @@
     const next = active && links.get(active.getAttribute('aria-labelledby'));
     if (next === current) return;
     if (current) current.removeAttribute('aria-current');
-    if (next) {
-      next.setAttribute('aria-current', 'true');
-      keepInView(next.parentElement);
-    }
+    if (next) next.setAttribute('aria-current', 'true');
     current = next;
   };
 

--- a/src/internal/render/assets/toc.js
+++ b/src/internal/render/assets/toc.js
@@ -8,10 +8,25 @@
   const sections = Array.from(document.querySelectorAll('.cat'));
   let current;
 
+  const rail = toc.querySelector('ul');
+  const smooth = !matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  // Below the rail the trail is a row that scrolls sideways, so the entry it
+  // marks can sit outside it. Centring by the difference between the two
+  // rectangles rather than by offsetLeft, which is measured from whichever
+  // ancestor happens to be positioned.
+  const keepInView = el => {
+    if (rail.scrollWidth <= rail.clientWidth + 1) return;
+    const e = el.getBoundingClientRect(), r = rail.getBoundingClientRect();
+    rail.scrollBy({ left: (e.left + e.width / 2) - (r.left + r.width / 2), behavior: smooth ? 'smooth' : 'auto' });
+  };
+
   const spy = () => {
     const visible = sections.filter(s => !s.hidden);
-    // the last section whose top has crossed, or the final one at page bottom
-    let active = visible[0];
+    // Nothing until a section has actually crossed: at the top of the page the
+    // reader is in the tagline and the note, not in the first category, and
+    // marking it there says they are somewhere they are not.
+    let active = null;
     for (const s of visible) {
       if (s.getBoundingClientRect().top <= innerHeight * 0.4) active = s;
     }
@@ -21,7 +36,10 @@
     const next = active && links.get(active.getAttribute('aria-labelledby'));
     if (next === current) return;
     if (current) current.removeAttribute('aria-current');
-    if (next) next.setAttribute('aria-current', 'true');
+    if (next) {
+      next.setAttribute('aria-current', 'true');
+      keepInView(next.parentElement);
+    }
     current = next;
   };
 

--- a/src/internal/render/nav_test.go
+++ b/src/internal/render/nav_test.go
@@ -26,18 +26,30 @@ func TestCategoryNavScales(t *testing.T) {
 		return string(m.Pages["en"].HTML)
 	}
 
-	// A handful of categories: the chip trail, no jump-to select.
-	if h := build(4); strings.Contains(h, "toc-select") {
-		t.Error("few categories should stay chips, not a select")
+	// One control at every count. The trail used to split at seven into a
+	// wrapping chip row and a jump-to select; the select drove nothing without
+	// JavaScript, so it had to be swapped in behind data-js, and it never said
+	// which category the reader was in. The row scrolls sideways instead.
+	for _, n := range []int{2, 4, 8, 20} {
+		h := build(n)
+		if strings.Contains(h, "toc-select") || strings.Contains(h, "toc-jump") {
+			t.Errorf("%d categories brought back the jump-to select", n)
+		}
+		if strings.Contains(h, "toc many") {
+			t.Errorf("%d categories still carry the .many modifier", n)
+		}
+		if got := strings.Count(h, `<nav class="toc"`); got != 1 {
+			t.Errorf("%d categories rendered %d trails, want exactly 1", n, got)
+		}
+		// every category reachable, since a row that scrolls hides some of them
+		// off screen and a missing entry would look like one scrolled away
+		if got := strings.Count(h, `<li><a href="#cat-`); got != n {
+			t.Errorf("%d categories listed %d entries in the trail", n, got)
+		}
 	}
 
-	// Above the threshold the compact jump-to select takes over on mobile, and
-	// the trail keeps its sidebar role tagged with the .many modifier.
-	h := build(8)
-	if !strings.Contains(h, `class="toc-select"`) {
-		t.Error("8 categories should render the jump-to select")
-	}
-	if !strings.Contains(h, `class="toc many"`) {
-		t.Error("8 categories should tag the trail as many")
+	// Nothing to navigate between with a single category.
+	if h := build(1); strings.Contains(h, `class="toc"`) {
+		t.Error("one category should render no trail at all")
 	}
 }

--- a/src/internal/render/templates/home.tmpl
+++ b/src/internal/render/templates/home.tmpl
@@ -7,17 +7,12 @@
        it here would have claimed the button reads in another language too. */}}
   <button class="about-x" id="about-x" hidden><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12"/></svg><span>{{.S.Dismiss}}</span></button>
   {{template "prose" .About}}</section>
-{{end}}{{if gt (len .Cats) 1}}<nav class="toc{{if gt (len .Cats) 7}} many{{end}}" aria-label="{{.S.Toc}}">
+{{end}}{{if gt (len .Cats) 1}}<nav class="toc" aria-label="{{.S.Toc}}">
   <ul>
     {{range .Cats}}<li><a href="#cat-{{.ID}}"><span class="toc-mark" aria-hidden="true"></span><span class="toc-name"{{.Name.Attrs}}>{{.Name}}</span></a></li>
     {{end}}
   </ul>
 </nav>
-{{if gt (len .Cats) 7}}<label class="toc-jump"><span class="visually-hidden">{{.S.Toc}}</span><select class="toc-select">
-  <option value="">{{.S.Toc}}</option>
-  {{range .Cats}}<option value="#cat-{{.ID}}"{{.Name.Attrs}}>{{.Name}}</option>
-  {{end}}</select></label>
-{{end}}
 {{end}}{{range .Cats}}<section class="cat" aria-labelledby="cat-{{.ID}}">
   <div class="way">
     <span class="way-mark" aria-hidden="true"></span>

--- a/src/internal/render/testdata/golden/en.html
+++ b/src/internal/render/testdata/golden/en.html
@@ -68,7 +68,6 @@
     
   </ul>
 </nav>
-
 <section class="cat" aria-labelledby="cat-documents">
   <div class="way">
     <span class="way-mark" aria-hidden="true"></span>

--- a/src/internal/render/testdata/golden/fr.html
+++ b/src/internal/render/testdata/golden/fr.html
@@ -69,7 +69,6 @@
     
   </ul>
 </nav>
-
 <section class="cat" aria-labelledby="cat-documents">
   <div class="way">
     <span class="way-mark" aria-hidden="true"></span>


### PR DESCRIPTION
A responsive audit, what it found, and what testing it on a screen found after.

## What the audit found sound

No horizontal overflow on any page at any width from 320px to 1440px, landscape
included. The 320px floor, which is what the reflow rule asks for at 400% zoom,
holds. Detail pages and 404s are clean at every width.

Two interactive targets measure under 24×24, and both are exceptions the rule
names rather than defects: "cairn" inside "powered by cairn" is a link in a
sentence, and the header links are 22.5px tall with 24px of spacing.

## The category trail

| defect | measured |
| --- | --- |
| no navigation between 44rem and 88rem | chips stopped at the first, the rail started at the second |
| the first entry marked from the top | `toc.js` started at `visible[0]` |
| the select never said where you were | `nav.js` reset `selectedIndex` after each jump |
| the chips wrapped | 2 rows, 88px, at 320 and 360px |
| two controls, split at seven | and the swap gated on `data-js`, since the select did nothing without it |

One row now, scrolling sideways, from 320px up to the rail, 40px tall at any
count. The select is gone, and with it the threshold and the `data-js` gate:
what is left is a list, which a phone can swipe with scripting off.

**No chip is the selected one.** A chip row takes the reader somewhere; it does
not report where they are. The first category lit up at rest on any window wide
enough for it to cross the line, announcing a place the reader had not chosen
to be, and the row scrolled itself to follow them. The rail above 88rem keeps
that job, since it is a trail down the margin with the room to say so.
`aria-current` is still set on both, since a screen reader can use it.

## Two things a screenshot found that the audit did not

**The chip block sat before the rules it overrides.** At equal specificity it
lost `padding-inline` to the rail's `padding: .28rem 0`, so every short
category rendered as a 34px circle with the word against its edges. "Tools"
measured 34x40. The checks written alongside it did not notice: the row was
still one line and still scrolled, which is all they were looking at.

**The page travelled behind the leaving dialog.** `showModal` takes the
interaction and not the scroll: 138px at 1000x400, 200px on a phone. Keyed on
the dialog's own `[open]` rather than on a class `leave.js` would have to add
and remove, so Escape, the backdrop and the stay button all undo it.

## Docs

Three pages still described the removed select: the FAQ's JavaScript answer,
theming's account of `--ui-border`, and the README's list of controls held at
3:1. `--ui-border` draws the search box and the leaving dialog's two buttons.

A new FAQ entry answers a console full of CSP errors. Every message named its
own source and none is a file cairn serves: `autoconsent.js` is Firefox's
cookie-banner blocker, the rest are extension content scripts and one filename
that is only a UUID. cairn emits exactly one inline script and one inline
style, and the two hashes in the header are theirs.

## Checked

77 browser checks, ten added here, each proved red against what it guards:

| revert | what went red |
| --- | --- |
| `flex-wrap: wrap` | the one-row check |
| the chip block moved back before the base rules | the chip-shape check alone, the other two staying green |
| the selected look given back to a chip | the no-selected-chip check |
| the rail's current diamond greyed | the rail check, and only it |
| the scroll lock removed | the dialog check |

`TestCategoryNavScales` pinned the old split at seven. It now pins the new
invariant at 2, 4, 8 and 20: exactly one trail, no select, every category
listed, since a row that scrolls hides some and a missing entry would read as
one that scrolled away.

The dialog check runs the wheel three times, shut, open, shut. The first makes
the second mean anything: `overflow: hidden` stops a wheel and not `scrollTo`,
and the fixture's page is exactly one viewport tall, which had a first attempt
passing against a page with nowhere to go.

## Not decided

The chips carry a `--border` outline at about 1.84:1. If that outline is what
identifies them as controls, 1.4.11 asks 3:1; if the text and the fill are, it
does not apply. It predates this branch.

The scroll lock is measured in Chromium. On iOS Safari `overflow: hidden` on
the root has not historically been enough on its own, and that is untested
here.