### PR TITLE
style: the back chip fills on hover, like every other outlined control

### DIFF
--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -370,6 +370,42 @@ await check(
 );
 
 // The way back out of a detail page: the same two duties as the card glyph.
+// Every outlined control here moves its fill on hover, since 1.16.1 measured
+// that tinting a border alone reads as nothing: the pointer is already a hand
+// over any link. The back chip was the one left doing only that.
+await check(
+  "the back chip fills on hover, like the other outlined ones",
+  async () => {
+    for (const scheme of ["light", "dark"]) {
+      const page = await desk.newPage();
+      await page.emulateMedia({ colorScheme: scheme });
+      await page.goto(new URL("pdf/", SITE).href, { waitUntil: "networkidle" });
+      const fill = () =>
+        page.evaluate(
+          () =>
+            getComputedStyle(document.querySelector(".back")).backgroundColor,
+        );
+      const rest = await fill();
+      await page.locator(".back").hover();
+      await page.waitForTimeout(300);
+      const hovered = await fill();
+      const pageBg = await page.evaluate(
+        () => getComputedStyle(document.body).backgroundColor,
+      );
+      await page.close();
+      if (rest === hovered) {
+        throw new Error(`in ${scheme} the fill stays ${rest} on hover`);
+      }
+      // and it has to leave the page behind rather than melt into it
+      if (hovered === pageBg) {
+        throw new Error(
+          `in ${scheme} the hovered chip is the page colour, ${pageBg}`,
+        );
+      }
+    }
+  },
+);
+
 await check("the back link is a real target on a detail page", async () => {
   const m = await detail.$eval(".back", (el) => {
     const r = el.getBoundingClientRect();

--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -370,38 +370,79 @@ await check(
 );
 
 // The way back out of a detail page: the same two duties as the card glyph.
-// Every outlined control here moves its fill on hover, since 1.16.1 measured
-// that tinting a border alone reads as nothing: the pointer is already a hand
-// over any link. The back chip was the one left doing only that.
+// One hover rule, and the point is that it is one: an outlined control fills
+// with --accent-ink wherever it sits. The status pill used to do this inside a
+// card foot and only tint its border outside one, so the same pill behaved
+// differently between the home page and a detail page.
 await check(
-  "the back chip fills on hover, like the other outlined ones",
+  "every outlined control fills with the same ink on hover",
   async () => {
-    for (const scheme of ["light", "dark"]) {
+    const resolve = (css) => {
+      const cv = document.createElement("canvas");
+      cv.width = cv.height = 1;
+      const x = cv.getContext("2d");
+      x.fillStyle = css;
+      x.fillRect(0, 0, 1, 1);
+      return [...x.getImageData(0, 0, 1, 1).data].slice(0, 3).join(",");
+    };
+    const seen = [];
+    const targets = [
+      [new URL("pdf/", SITE).href, ".back", null],
+      [SITE, ".card-more", null],
+      [STATUS, "a.status-pill", null],
+      [LEAVE, ".leave-stay", "open"],
+      [LEAVE, ".leave-copy", "open"],
+    ];
+    for (const [url, sel, setup] of targets) {
       const page = await desk.newPage();
-      await page.emulateMedia({ colorScheme: scheme });
-      await page.goto(new URL("pdf/", SITE).href, { waitUntil: "networkidle" });
-      const fill = () =>
-        page.evaluate(
-          () =>
-            getComputedStyle(document.querySelector(".back")).backgroundColor,
+      await page.goto(url, { waitUntil: "networkidle" });
+      if (setup === "open") {
+        await page.evaluate(() =>
+          document.querySelector("a[data-leave]").click(),
         );
-      const rest = await fill();
-      await page.locator(".back").hover();
+        await page.waitForTimeout(350);
+      }
+      const el = await page.$(sel);
+      if (!el) {
+        await page.close();
+        throw new Error(`${sel} is not on ${url}`);
+      }
+      await el.hover();
       await page.waitForTimeout(300);
-      const hovered = await fill();
-      const pageBg = await page.evaluate(
-        () => getComputedStyle(document.body).backgroundColor,
+      const fill = await page.evaluate(
+        ([s, r]) =>
+          eval(`(${r})`)(
+            getComputedStyle(document.querySelector(s)).backgroundColor,
+          ),
+        [sel, resolve.toString()],
       );
       await page.close();
-      if (rest === hovered) {
-        throw new Error(`in ${scheme} the fill stays ${rest} on hover`);
-      }
-      // and it has to leave the page behind rather than melt into it
-      if (hovered === pageBg) {
-        throw new Error(
-          `in ${scheme} the hovered chip is the page colour, ${pageBg}`,
-        );
-      }
+      seen.push([sel, fill]);
+    }
+    const first = seen[0][1];
+    const odd = seen.filter(([, f]) => f !== first);
+    if (odd.length) {
+      throw new Error(
+        `these do not share the hover fill rgb(${first}):\n        ` +
+          odd.map(([s, f]) => `${s} is rgb(${f})`).join("\n        "),
+      );
+    }
+    // and it has to be a real fill rather than every one of them staying put
+    const rest = await (async () => {
+      const page = await desk.newPage();
+      await page.goto(new URL("pdf/", SITE).href, { waitUntil: "networkidle" });
+      const c = await page.evaluate(
+        ([r]) =>
+          eval(`(${r})`)(
+            getComputedStyle(document.querySelector(".back")).backgroundColor,
+          ),
+        [resolve.toString()],
+      );
+      await page.close();
+      return c;
+    })();
+    if (rest === first) {
+      throw new Error(`the hover fill rgb(${first}) is the resting colour too`);
     }
   },
 );

--- a/src/internal/render/assets/style.css
+++ b/src/internal/render/assets/style.css
@@ -869,6 +869,15 @@ a.flag { min-height: 1.5rem; }
    theme to read against the card, so the fill measures 6.82:1 in light and
    5.47:1 in dark, and the card-coloured mark on it the same, whatever accent
    the operator chose. */
+/* THE HOVER RULE for outlined controls, and it holds everywhere rather than
+   per place: an outlined control fills with --accent-ink and takes --card for
+   its text. 1.16.1 established the fill, since tinting a border alone reads as
+   nothing when the pointer is already a hand; what was missing until now was
+   that the same control did it inside a card and not outside, so the status
+   pill changed behaviour between the home page and a detail page.
+
+   The primary button is --accent rather than --accent-ink and is filled at
+   rest, so it stays the loudest thing on any page it appears on. */
 .card-more:hover { background: var(--accent-ink); border-color: var(--accent-ink); color: var(--card); }
 .card-more:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .more-glyph { width: var(--ring-glyph); height: var(--ring-glyph); }
@@ -894,8 +903,12 @@ a.flag { min-height: 1.5rem; }
 }
 /* Only a pill that leads somewhere answers to a pointer: a display-only one
    (status.linked: false) is not a control. */
-.card-foot a.status-pill:hover { background: var(--accent-ink); border-color: var(--accent-ink); color: var(--card); }
-a.status-pill:hover { color: var(--fg); border-color: color-mix(in oklab, var(--accent) 40%, var(--border)); }
+a.status-pill:hover { background: var(--accent-ink); border-color: var(--accent-ink); color: var(--card); }
+/* The dot goes with the text rather than keeping its state colour: green on
+   the filled accent measures 1.30:1 in light and 1.12:1 in dark, which is a
+   smudge and not a dot. Nothing is lost, since the label beside it says
+   Online or Offline in words. */
+a.status-pill:hover .dot { background: var(--card); }
 a.status-pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .card .status-pill { flex: none; }
 /* Raised above the card's stretched link so a click reaches the status page. A
@@ -948,11 +961,7 @@ a.status-pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 
    the pointer is a hand over any link, so only a fill says this one is a
    button. --faint darkens it against the page in light and lightens it in
    dark, one step either way. */
-.back:hover {
-  color: var(--fg);
-  background: var(--faint);
-  border-color: color-mix(in oklab, var(--accent) 40%, var(--border));
-}
+.back:hover { background: var(--accent-ink); border-color: var(--accent-ink); color: var(--card); }
 .back:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
 .detail-head { display: flex; align-items: center; gap: 1rem; margin-top: 1.6rem; }
@@ -1081,7 +1090,7 @@ html:has(dialog[open]) {
   color: var(--fg);
   cursor: pointer;
 }
-.leave-copy:hover, .leave-stay:hover { background: var(--bg); }
+.leave-copy:hover, .leave-stay:hover { background: var(--accent-ink); border-color: var(--accent-ink); color: var(--card); }
 .leave-copy:focus-visible, .leave-stay:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 /* The continue link borrows .btn, which carries a 1.4rem top margin for the
    detail page; in a row of buttons that margin is a step. */
@@ -1386,7 +1395,7 @@ footer {
 }
 .totop.show { opacity: 1; visibility: visible; pointer-events: auto; }
 .totop svg { width: 1.15rem; height: 1.15rem; }
-.totop:hover { border-color: color-mix(in oklab, var(--accent) 45%, var(--border)); }
+.totop:hover { background: var(--accent-ink); border-color: var(--accent-ink); color: var(--card); }
 .totop:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
 @media (prefers-reduced-motion: no-preference) {

--- a/src/internal/render/assets/style.css
+++ b/src/internal/render/assets/style.css
@@ -940,10 +940,19 @@ a.status-pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 
   font-weight: 500;
   color: var(--muted);
   text-decoration: none;
-  transition: color .16s, border-color .16s;
+  transition: color .16s, border-color .16s, background .16s;
 }
 .back-glyph { width: .85rem; height: .85rem; flex: none; }
-.back:hover { color: var(--fg); border-color: color-mix(in oklab, var(--accent) 40%, var(--border)); }
+/* The fill moves, like every other outlined control here. Tinting the text and
+   the border alone was what 1.16.1 already found invisible on a card control:
+   the pointer is a hand over any link, so only a fill says this one is a
+   button. --faint darkens it against the page in light and lightens it in
+   dark, one step either way. */
+.back:hover {
+  color: var(--fg);
+  background: var(--faint);
+  border-color: color-mix(in oklab, var(--accent) 40%, var(--border));
+}
 .back:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
 .detail-head { display: flex; align-items: center; gap: 1rem; margin-top: 1.6rem; }


### PR DESCRIPTION
The detail page's back chip was the one outlined control that did not change
its fill on hover.

| control | on hover |
| --- | --- |
| `.leave-copy`, `.leave-stay` | the fill moves |
| `.card-more` | the fill goes to the accent |
| `.back` | text and border only |

1.16.1 already measured that shape and rejected it: tinting a border from 2.04
to 2.82 read as nothing, because the pointer is a hand over any link and only a
fill says a thing is a button.

## Why `--faint` and not `--bg`

`.leave-stay` hovers to `--bg`, but it sits on the dialog's `--card` and is
darkening toward the page. The back chip sits **on** the page with a `--card`
fill, so `--bg` would put it at exactly the page colour and it would melt into
the background. `--faint` moves away from both.

```console
light   .back        rgb(251,251,249) -> rgb(232,231,223)   1.197:1
        .leave-stay  rgb(251,251,249) -> rgb(238,240,234)   1.108:1
dark    .back        rgb(27,33,35)    -> rgb(33,40,41)      1.087:1
        .leave-stay  rgb(27,33,35)    -> rgb(20,24,26)      1.096:1
```

Both start from the same resting colour and travel a comparable distance, which
is the consistency being asked for. Those numbers needed the painted colour
rather than the computed one: `.leave-stay` rests on `transparent`, which a
naive reading scores as black and reported an 18:1 hover.

## Checked

The check asserts both halves, that the fill moves and that it does not land on
the page colour, in both themes.

Proving the second red took two attempts. The first revert replaced the wrong
rule, since `background: var(--faint)` appears ten times in the stylesheet and
the pattern took the first, so the chip was never touched and the check stayed
green. Anchored on the rule's own next line it fails as it should. Nothing was
wrong with the check; the proof was.

78 browser checks pass, and the Go suite with them.