### PR TITLE
feat: the detail head reads like a store listing

### DIFF
--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -447,6 +447,107 @@ await check(
   },
 );
 
+// The icon belongs to the name, and nothing under the name may move it. The
+// state row used to live inside the title block, which made the block taller,
+// and align-items centred the tile against that: a pill pushed the icon 18.4px
+// below the name. Both pages are asserted, since only one of them has a state.
+await check(
+  "a state or a pill never shifts the icon off the name",
+  async () => {
+    for (const [path, what] of [
+      ["beta/", "a state and a pill"],
+      ["gone/", "a state and no pill"],
+    ]) {
+      const page = await desk.newPage();
+      await page.goto(new URL(path, STATES).href, { waitUntil: "networkidle" });
+      await page.waitForTimeout(400);
+      const m = await page.evaluate(() => {
+        const tile = document.querySelector(".detail-top .tile");
+        const h1 = document.querySelector(".detail-top h1");
+        if (!tile || !h1) return null;
+        const t = tile.getBoundingClientRect(),
+          n = h1.getBoundingClientRect();
+        return {
+          off: t.top + t.height / 2 - (n.top + n.height / 2),
+          row: !!document.querySelector(".detail-state-row"),
+        };
+      });
+      await page.close();
+      if (!m) throw new Error(`no tile or no name on ${path}`);
+      if (!m.row)
+        throw new Error(`${path} shows no state row, so this proves nothing`);
+      if (Math.abs(m.off) > 1) {
+        throw new Error(
+          `with ${what}, the icon sits ${m.off.toFixed(1)}px off the name`,
+        );
+      }
+    }
+  },
+);
+
+// The action sits beside the name where there is room, and goes up onto the
+// back link's row where there is not, rather than becoming the loudest thing
+// on a phone. It matches its neighbour there rather than the 44px the leaving
+// dialog's actions carry: the back chip has been 72x33 since the target-size
+// pass, and 24x24 is what the rule asks of either of them.
+await check(
+  "the action sits beside the name, and joins the back row on a phone",
+  async () => {
+    for (const [w, beside] of [
+      [1000, true],
+      [390, false],
+    ]) {
+      const page = await desk.newPage();
+      await page.setViewportSize({ width: w, height: 900 });
+      await page.goto(new URL("beta/", STATES).href, {
+        waitUntil: "networkidle",
+      });
+      const m = await page.evaluate(() => {
+        const btn = document.querySelector(".detail-top .btn");
+        const h1 = document.querySelector(".detail-top h1");
+        const back = document.querySelector(".detail-top .back");
+        if (!btn) return null;
+        const b = btn.getBoundingClientRect(),
+          n = h1.getBoundingClientRect(),
+          a = back.getBoundingClientRect();
+        return {
+          w: b.width,
+          h: b.height,
+          onBackRow:
+            Math.abs(b.top + b.height / 2 - (a.top + a.height / 2)) < 3,
+          beside: Math.abs(b.top + b.height / 2 - (n.top + n.height / 2)) < 3,
+          clearsBack: b.left >= a.right,
+          lines: Math.round(
+            n.height / parseFloat(getComputedStyle(h1).lineHeight),
+          ),
+        };
+      });
+      await page.close();
+      if (!m) throw new Error(`no action in the head at ${w}px`);
+      if (m.w < 24 || m.h < 24) {
+        throw new Error(
+          `the action is ${m.w.toFixed(0)}x${m.h.toFixed(0)} at ${w}px, under 24x24`,
+        );
+      }
+      if (m.lines > 1)
+        throw new Error(`the name wrapped onto ${m.lines} lines at ${w}px`);
+      if (beside) {
+        if (!m.beside)
+          throw new Error(`at ${w}px the action left the name's row`);
+        if (m.h < 44)
+          throw new Error(
+            `beside the name it is ${m.h.toFixed(0)}px tall, want 44`,
+          );
+      } else {
+        if (!m.onBackRow)
+          throw new Error(`at ${w}px the action is not on the back link's row`);
+        if (!m.clearsBack)
+          throw new Error(`at ${w}px the action overlaps the back link`);
+      }
+    }
+  },
+);
+
 await check("the back link is a real target on a detail page", async () => {
   const m = await detail.$eval(".back", (el) => {
     const r = el.getBoundingClientRect();

--- a/src/internal/render/assets/style.css
+++ b/src/internal/render/assets/style.css
@@ -964,11 +964,27 @@ a.status-pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 
 .back:hover { background: var(--accent-ink); border-color: var(--accent-ink); color: var(--card); }
 .back:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
-.detail-head { display: flex; align-items: center; gap: 1rem; margin-top: 1.6rem; }
-.detail-head .tile { width: 3.6rem; height: 3.6rem; }
-.detail-head .tile img { width: 2.3rem; height: 2.3rem; }
-.detail-head .tile svg { width: 2rem; height: 2rem; }
-.detail-title { display: flex; flex-direction: column; gap: .6rem; align-items: flex-start; }
+/* Back, name and action in one grid, so the action can sit in two places
+   without a second copy of it: beside the name where there is room, and up on
+   the back link's row where there is not. Both the back link and the action
+   span every column on their row and are justified to opposite ends, so
+   neither of them decides how wide the tile's column is. */
+.detail-top {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  column-gap: 1rem;
+  row-gap: 1.1rem;
+  margin-top: 1.6rem;
+}
+.detail-top .back { grid-area: 1 / 1 / 2 / -1; justify-self: start; }
+.detail-top .tile { grid-area: 2 / 1; width: 3.6rem; height: 3.6rem; }
+.detail-top .tile img { width: 2.3rem; height: 2.3rem; }
+.detail-top .tile svg { width: 2rem; height: 2rem; }
+.detail-top h1 { grid-area: 2 / 2; min-width: 0; }
+.detail-top .btn { grid-area: 2 / 3; justify-self: end; margin: 0; }
+.detail-top .detail-state-row { grid-area: 3 / 1 / 4 / -1; }
+.detail-top h1 { flex: 1 1 auto; min-width: 0; }
 /* No card here, so no badge: the state shares the pill's row under the title.
    On a line of its own it read as an orphan, and the pill leads as the heavier
    object. */
@@ -993,7 +1009,7 @@ a.status-pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 
 .detail-state-new { color: var(--accent-ink); }
 .detail-state-deprecated { color: var(--ink-deprecated); }
 .detail-state-soon { color: var(--ink-soon); }
-.detail-head h1 {
+.detail-top h1 {
   margin: 0;
   font-family: var(--font-display);
   font-variation-settings: "opsz" 96;
@@ -1019,7 +1035,8 @@ a.status-pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 
   align-items: center;
   gap: .5rem;
   margin-top: 1.4rem;
-  padding: .8rem 1.7rem;
+  padding: .62rem 1.25rem;
+  font-size: .95rem;
   background: var(--accent);
   border-radius: 999px;
   color: #fff;
@@ -1104,6 +1121,17 @@ html:has(dialog[open]) {
    languages. The order stays: column-reverse would put the primary on top while
    the keyboard still tabs copy, stay, continue, trading 2.4.3 for a layout. */
 @media (max-width: 44rem) {
+  /* No room beside a name at this width, and a full-width button under it read
+     as the loudest thing on the page. It goes up beside the back link instead,
+     the two of them at opposite ends of one row, and smaller. */
+  .detail-top { grid-template-columns: auto 1fr; row-gap: .9rem; }
+  .detail-top .btn {
+    grid-area: 1 / 1 / 2 / -1;
+    justify-self: end;
+    padding: .42rem .85rem;
+    font-size: .88rem;
+  }
+  .detail-top .btn .btn-glyph { width: .95em; height: .95em; }
   .leave-acts { flex-direction: column; align-items: stretch; }
   .leave-acts .btn { margin-inline-start: 0; justify-content: center; }
 }

--- a/src/internal/render/templates/detail.tmpl
+++ b/src/internal/render/templates/detail.tmpl
@@ -1,22 +1,20 @@
 {{template "top" .}}
 <article class="detail">
-  <p><a class="back" href="{{.Prefix}}/{{.Locale}}/"><svg class="back-glyph" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>{{.S.Back}}</a></p>
-  <div class="detail-head">
+  {{/* One grid for the whole head, because the action sits in two different
+       places and CSS cannot move an element between parents: beside the name
+       where there is room, and up on the back link's row where there is not.
+       Naming the areas says both without a second copy of the markup.
+
+       The state is a row of its own rather than a child of the name: inside
+       one it made that block taller, and centring the tile against the taller
+       box put the icon 18.4px below the name it belongs to. */}}<div class="detail-top">
+    <a class="back" href="{{.Prefix}}/{{.Locale}}/"><svg class="back-glyph" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>{{.S.Back}}</a>
     <span class="tile">{{if .Icon}}<img{{if .IconClass}} class="{{.IconClass}}"{{end}} src="{{.Icon}}" alt="" width="56" height="56">{{else}}{{template "glyph"}}{{end}}</span>
-    <div class="detail-title">
-      <h1{{.Name.Attrs}}>{{.Name}}</h1>
-      {{/* One row, the pill first. The state was written first at first, on
-           the reasoning that what a thing is comes before whether it answers;
-           seen on the page, the pill is the heavier object and the small caps
-           read better trailing it than leading it. On its own line under the
-           pill the state read as an orphan, which is why they share a row at
-           all. The else branch
-           is not a duplicate for tidiness: wrapping the pill on every page
-           moved 43 bytes on a site that declares no state at all. */}}{{if .State}}<div class="detail-state-row">{{template "statuspill" .}}<span class="detail-state detail-state-{{.State}}">{{.StateLabel}}</span></div>{{else}}{{template "statuspill" .}}{{end}}
-    </div>
+    <h1{{.Name.Attrs}}>{{.Name}}</h1>
+    {{if not .Off}}<a class="btn" href="{{.URL}}"{{if .Blank}} target="_blank" rel="noopener noreferrer"{{end}}{{if .Leave}} data-leave{{end}}>{{.S.Open}}<svg class="btn-glyph" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 5h5v5"/><path d="M19 5 11 13"/><path d="M17 14v4a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V8a1 1 0 0 1 1-1h4"/></svg></a>{{end}}
+    {{if or .State .StatusID}}<div class="detail-state-row">{{template "statuspill" .}}{{if .State}}<span class="detail-state detail-state-{{.State}}">{{.StateLabel}}</span>{{end}}</div>{{end}}
   </div>
   {{if .Desc.Text}}<p class="lead"{{.Desc.Attrs}}>{{.Desc}}</p>
   {{end}}{{template "prose" .Body}}{{range .Images}}<figure class="shot"><img src="{{.Src}}" alt="" loading="lazy"{{if .W}} width="{{.W}}" height="{{.H}}"{{end}}>{{if .Caption.Text}}<figcaption{{.Caption.Attrs}}>{{.Caption}}</figcaption>{{end}}</figure>
-  {{end}}{{if not .Off}}<p><a class="btn" href="{{.URL}}"{{if .Blank}} target="_blank" rel="noopener noreferrer"{{end}}{{if .Leave}} data-leave{{end}}>{{.S.Open}}<svg class="btn-glyph" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 5h5v5"/><path d="M19 5 11 13"/><path d="M17 14v4a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V8a1 1 0 0 1 1-1h4"/></svg></a></p>{{end}}
-</article>
+  {{end}}</article>
 {{template "bottom" .}}

--- a/src/internal/render/testdata/golden/en/pdf.html
+++ b/src/internal/render/testdata/golden/en/pdf.html
@@ -53,13 +53,12 @@
 <main id="main"><div class="wrap">
 
 <article class="detail">
-  <p><a class="back" href="/en/"><svg class="back-glyph" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>Back</a></p>
-  <div class="detail-head">
+  <div class="detail-top">
+    <a class="back" href="/en/"><svg class="back-glyph" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>Back</a>
     <span class="tile"><svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg></span>
-    <div class="detail-title">
-      <h1>PDF toolbox</h1>
-      <span class="status-slot" data-status="pdf"><a class="status-pill status-up" href="https://status.example.org/endpoints/documents_pdf" target="_blank" rel="noopener" aria-label="PDF toolbox, Online, view status"><span class="dot" aria-hidden="true"></span>Online</a></span>
-    </div>
+    <h1>PDF toolbox</h1>
+    <a class="btn" href="https://pdf.example.org">Open<svg class="btn-glyph" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 5h5v5"/><path d="M19 5 11 13"/><path d="M17 14v4a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V8a1 1 0 0 1 1-1h4"/></svg></a>
+    <div class="detail-state-row"><span class="status-slot" data-status="pdf"><a class="status-pill status-up" href="https://status.example.org/endpoints/documents_pdf" target="_blank" rel="noopener" aria-label="PDF toolbox, Online, view status"><span class="dot" aria-hidden="true"></span>Online</a></span></div>
   </div>
   <p class="lead">Merge and split PDFs.</p>
   <h2>What it does</h2>
@@ -82,7 +81,6 @@
 </tr>
 </tbody>
 </table></div>
-<p><a class="btn" href="https://pdf.example.org">Open<svg class="btn-glyph" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 5h5v5"/><path d="M19 5 11 13"/><path d="M17 14v4a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V8a1 1 0 0 1 1-1h4"/></svg></a></p>
 </article>
 </div></main>
 <footer><div class="wrap foot">

--- a/src/internal/render/testdata/golden/fr/pdf.html
+++ b/src/internal/render/testdata/golden/fr/pdf.html
@@ -53,13 +53,12 @@
 <main id="main"><div class="wrap">
 
 <article class="detail">
-  <p><a class="back" href="/fr/"><svg class="back-glyph" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>Retour</a></p>
-  <div class="detail-head">
+  <div class="detail-top">
+    <a class="back" href="/fr/"><svg class="back-glyph" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>Retour</a>
     <span class="tile"><svg viewBox="0 0 32 32" fill="currentColor" aria-hidden="true"><rect x="3.2" y="23.6" width="25" height="5.4" rx="2.4"/><rect x="7.8" y="16.2" width="17.4" height="5.8" rx="2.6"/><rect x="9.4" y="9.4" width="13" height="5.4" rx="2.5"/><rect x="12.4" y="3" width="9.4" height="4.8" rx="2.2" transform="rotate(-9 17.1 5.4)"/></svg></span>
-    <div class="detail-title">
-      <h1>Boîte à outils PDF</h1>
-      <span class="status-slot" data-status="pdf"><a class="status-pill status-up" href="https://status.example.org/endpoints/documents_pdf" target="_blank" rel="noopener" aria-label="Boîte à outils PDF, En ligne, voir le statut"><span class="dot" aria-hidden="true"></span>En ligne</a></span>
-    </div>
+    <h1>Boîte à outils PDF</h1>
+    <a class="btn" href="https://pdf.example.org">Ouvrir<svg class="btn-glyph" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 5h5v5"/><path d="M19 5 11 13"/><path d="M17 14v4a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V8a1 1 0 0 1 1-1h4"/></svg></a>
+    <div class="detail-state-row"><span class="status-slot" data-status="pdf"><a class="status-pill status-up" href="https://status.example.org/endpoints/documents_pdf" target="_blank" rel="noopener" aria-label="Boîte à outils PDF, En ligne, voir le statut"><span class="dot" aria-hidden="true"></span>En ligne</a></span></div>
   </div>
   <p class="lead">Fusionner et découper vos PDF.</p>
   <div lang="en"><h2>What it does</h2>
@@ -83,7 +82,6 @@
 </tbody>
 </table></div>
 </div>
-<p><a class="btn" href="https://pdf.example.org">Ouvrir<svg class="btn-glyph" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 5h5v5"/><path d="M19 5 11 13"/><path d="M17 14v4a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V8a1 1 0 0 1 1-1h4"/></svg></a></p>
 </article>
 </div></main>
 <footer><div class="wrap foot">


### PR DESCRIPTION
Two things asked for, and one bug behind the first.

## The icon stopped following the name

The state row lived inside the title block. That made the block taller, and
`align-items: center` centred the tile against the taller box rather than
against the name:

| page | before | after |
| --- | --- | --- |
| a pill and a state | icon 18.4px below the name | 0px |
| a coming-soon state, no pill | 14px below | 0px |

## One grid, because the action sits in two places

CSS cannot move an element between parents, and the action belongs beside the
name where there is room and up on the back link's row where there is not. So
the back link, the icon, the name, the action and the state are one grid, and
the two placements are two sets of coordinates rather than two copies of the
markup.

The back link and the action each span every column of their row and are
justified to opposite ends, so neither decides how wide the icon's column is.

```console
wide    icon 0px | title 1 line | 103x44 beside the name
tablet  icon 0px | title 1 line | 103x44 beside the name
phone   icon 0px | title 1 line |  85x36 on the back row
narrow  icon 0px | title 1 line |  85x36 on the back row
```

A full-width button under the name, which is where the first draft put it, was
the loudest thing on a phone. 85x36 is its neighbour's scale: the back chip has
been 72x33 since the target-size pass. 24x24 is what the rule asks of either of
them, and the 44px floor belongs to the leaving dialog's three actions, where a
check still enforces it.

## Emptiness

`statuspill` renders nothing without a `StatusID`, so the state row is
conditional on there being a state or a monitor. Unconditional, it left an
empty `<div>` on every detail page of a site running neither.

## Checked

| revert | what went red |
| --- | --- |
| the action's placement on the back row removed | the action check, and only it |
| `align-items: start` on the grid | the icon check, and only it |

**The icon check could not be proved red the obvious way**, and that is worth
recording: putting the state row back into the name's cell left it green,
because two items in one grid cell overlap rather than stack, so the row cannot
grow. The grid does not fix the misalignment, it removes the shape of it. The
check is therefore a guard against a future regression rather than a
reproduction of the original, and it is proved on what it actually measures.

80 browser checks, the Go suite and `just chart` pass. The golden files carry
the restructure and no whitespace: two earlier drafts left a four-space line
under the back link and another where the button used to stand, both from
template comments whose newline printed.

## Worth knowing

On a phone the reading order is back and action, then name, then state. For a
service that is offline or deprecated, the action is met before the reason not
to take it. Both are above the fold and a thumb's width apart.