### PR TITLE
style: a detail head a thumb can use, and a trail that says it scrolls

### DIFF
--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -517,6 +517,7 @@ await check(
             Math.abs(b.top + b.height / 2 - (a.top + a.height / 2)) < 3,
           beside: Math.abs(b.top + b.height / 2 - (n.top + n.height / 2)) < 3,
           clearsBack: b.left >= a.right,
+          backH: a.height,
           lines: Math.round(
             n.height / parseFloat(getComputedStyle(h1).lineHeight),
           ),
@@ -543,6 +544,18 @@ await check(
           throw new Error(`at ${w}px the action is not on the back link's row`);
         if (!m.clearsBack)
           throw new Error(`at ${w}px the action overlaps the back link`);
+        // The same height, not merely both large: 33px against 36px read as a
+        // mistake rather than as a hierarchy.
+        if (Math.abs(m.h - m.backH) > 1) {
+          throw new Error(
+            `the action is ${m.h.toFixed(0)}px and the back link ${m.backH.toFixed(0)}px`,
+          );
+        }
+        if (m.h < 44) {
+          throw new Error(
+            `beside the back link it is ${m.h.toFixed(0)}px, want a thumb's 44`,
+          );
+        }
       }
     }
   },
@@ -801,6 +814,70 @@ await sm.goto(MANY);
 // specificity, and every short category came out a 34px circle with the word
 // against its edges. Nothing else noticed: the row was still one line and
 // still scrolled, which is all the other checks were looking at.
+// A row that scrolls has to say so, or it reads as a complete list: a chip cut
+// exactly at the edge looks like the last one. The side with chips behind it
+// fades, and the side without does not, so the cue follows the reader.
+await check("the trail says which way it still has chips", async () => {
+  await sm.setViewportSize({ width: 390, height: 780 });
+  const r = await sm.evaluate(async () => {
+    const ul = document.querySelector(".toc ul");
+    const max = ul.scrollWidth - ul.clientWidth;
+    if (max < 40) return { overflows: false };
+    const go = async (x) => {
+      ul.scrollTo({ left: x, behavior: "instant" });
+      await new Promise((res) => setTimeout(res, 250));
+      return {
+        more: ul.getAttribute("data-more"),
+        masked: getComputedStyle(ul).maskImage !== "none",
+      };
+    };
+    return {
+      overflows: true,
+      start: await go(0),
+      half: await go(max / 2),
+      end: await go(max),
+    };
+  });
+  await sm.setViewportSize(PHONE);
+  if (!r.overflows)
+    throw new Error(
+      "the row does not overflow at 390px, so this proves nothing",
+    );
+  const want = { start: "right", half: "left right", end: "left" };
+  for (const k of ["start", "half", "end"]) {
+    if (r[k].more !== want[k]) {
+      throw new Error(
+        `at the ${k} the row reports "${r[k].more}", want "${want[k]}"`,
+      );
+    }
+    if (!r[k].masked) throw new Error(`at the ${k} nothing is actually faded`);
+  }
+});
+
+// And a row that fits says nothing, since there is nothing behind either edge.
+await check("a trail that fits advertises no scrolling", async () => {
+  const page = await desk.newPage();
+  await page.setViewportSize({ width: 1000, height: 780 });
+  await page.goto(SITE, { waitUntil: "networkidle" });
+  const r = await page.evaluate(() => {
+    const ul = document.querySelector(".toc ul");
+    if (!ul || !ul.getClientRects().length) return null;
+    return {
+      overflows: ul.scrollWidth > ul.clientWidth + 1,
+      more: ul.getAttribute("data-more"),
+      masked: getComputedStyle(ul).maskImage !== "none",
+    };
+  });
+  await page.close();
+  if (!r) throw new Error("no trail painted at 1000px");
+  if (r.overflows)
+    throw new Error(
+      "the example trail overflows at 1000px, so this proves nothing",
+    );
+  if (r.more) throw new Error(`a row that fits still reports "${r.more}"`);
+  if (r.masked) throw new Error("a row that fits is faded anyway");
+});
+
 await check("a chip is a chip and not a squeezed circle", async () => {
   for (const w of [320, 390, 970]) {
     await sm.setViewportSize({ width: w, height: 780 });

--- a/src/internal/render/assets/style.css
+++ b/src/internal/render/assets/style.css
@@ -581,6 +581,18 @@ header { padding-block: 1.4rem; }
     scroll-snap-type: x proximity;
   }
   .toc ul::-webkit-scrollbar { display: none; }
+  /* The side with chips behind it fades, so the row cannot be mistaken for a
+     complete list. toc.js sets the attribute; without it the row still scrolls,
+     it just does not advertise it. */
+  .toc ul[data-more="right"] {
+    mask-image: linear-gradient(to right, #000 calc(100% - 2.2rem), transparent);
+  }
+  .toc ul[data-more="left"] {
+    mask-image: linear-gradient(to right, transparent, #000 2.2rem);
+  }
+  .toc ul[data-more="left right"] {
+    mask-image: linear-gradient(to right, transparent, #000 2.2rem, #000 calc(100% - 2.2rem), transparent);
+  }
   .toc ul::before { display: none; }
   .toc li { flex: none; scroll-snap-align: center; }
   .toc a {
@@ -1123,15 +1135,30 @@ html:has(dialog[open]) {
 @media (max-width: 44rem) {
   /* No room beside a name at this width, and a full-width button under it read
      as the loudest thing on the page. It goes up beside the back link instead,
-     the two of them at opposite ends of one row, and smaller. */
-  .detail-top { grid-template-columns: auto 1fr; row-gap: .9rem; }
+     the two of them at opposite ends of one row.
+
+     Both at 2.75rem, which is the thumb target the rest of the phone layout
+     uses, and both the same: 33px against 36px was close enough to look like a
+     mistake rather than a hierarchy. The article's own padding already parts
+     this row from the header, so the margin that stacked on top of it goes:
+     22.4px and 25.6px met as 48px of nothing. */
+  .detail-top { grid-template-columns: auto 1fr; row-gap: .9rem; margin-top: .4rem; }
+  .detail-top .back,
+  .detail-top .btn {
+    min-height: 2.75rem;
+    font-size: .9rem;
+  }
+  .detail-top .back { padding-inline: .95rem 1.05rem; }
   .detail-top .btn {
     grid-area: 1 / 1 / 2 / -1;
     justify-self: end;
-    padding: .42rem .85rem;
-    font-size: .88rem;
+    padding-inline: 1.15rem;
   }
-  .detail-top .btn .btn-glyph { width: .95em; height: .95em; }
+  .detail-top .btn .btn-glyph { width: 1em; height: 1em; }
+  /* The pill on a detail page stands alone and is a link to the status page, so
+     it takes a thumb's worth of height. The one in a card foot keeps its size:
+     that foot is dense, and raising it there would push every card down. */
+  .detail-top .status-pill { min-height: 2.25rem; padding-inline: .8rem .9rem; font-size: .82rem; }
   .leave-acts { flex-direction: column; align-items: stretch; }
   .leave-acts .btn { margin-inline-start: 0; justify-content: center; }
 }

--- a/src/internal/render/assets/toc.js
+++ b/src/internal/render/assets/toc.js
@@ -8,6 +8,29 @@
   const sections = Array.from(document.querySelectorAll('.cat'));
   let current;
 
+  // A row that scrolls sideways has to say so. Left to itself it can cut a chip
+  // exactly at the edge and read as a complete list, which is how a reader
+  // misses two thirds of the categories. The edge with more behind it fades.
+  //
+  // Measured from the rectangles rather than from scrollLeft: that value is
+  // negative in a right-to-left page in some engines and positive in others,
+  // and what the fade needs is the physical side either way.
+  const rail = toc.querySelector('ul');
+  const edges = () => {
+    const r = rail.getBoundingClientRect();
+    let left = false, right = false;
+    for (const li of rail.children) {
+      const b = li.getBoundingClientRect();
+      if (b.right < r.left + 1) left = true;
+      if (b.left > r.right - 1) right = true;
+    }
+    const v = [left && 'left', right && 'right'].filter(Boolean).join(' ');
+    if (v) rail.setAttribute('data-more', v); else rail.removeAttribute('data-more');
+  };
+  rail.addEventListener('scroll', edges, { passive: true });
+  addEventListener('resize', edges, { passive: true });
+  edges();
+
   const spy = () => {
     const visible = sections.filter(s => !s.hidden);
     // Nothing until a section has actually crossed: at the top of the page the


### PR DESCRIPTION
Four things found on an iPhone. The scroll lock shipped in 1.20.1 does work
there, which was the open question from that release.

## Sizes

| control | before | after |
| --- | --- | --- |
| back link | 72x33 | 87x44 |
| action | 85x36 | 96x44 |
| status pill | 72x27 | 84x36 |

The action being three pixels taller than the back link is what read as off:
close enough to look like a mistake rather than a hierarchy. Both are 2.75rem
now, which is the thumb target the rest of the phone layout already uses.

The pill in a **card foot** keeps its size. That foot is dense and raising it
there would push every card down; a detail page has room. It is a size and not
a behaviour, so it does not bring back the split this cycle removed from hover.

## The gap

```console
article.detail   padding-top 22.4px
.detail-top      margin-top  25.6px
                             48px of nothing under the header
```

Two spacings stacked. The margin goes and 29px is left.

## The trail said nothing about scrolling

A row that scrolls sideways can cut a chip exactly at its edge and read as a
complete list, which is how a reader misses two thirds of the categories. The
side with chips behind it fades now:

```console
at the start     data-more="right"        faded on the right
halfway          data-more="left right"   faded both sides
at the end       data-more="left"         faded on the left
a row that fits  no attribute             not faded at all
```

Measured from the chips' rectangles rather than from `scrollLeft`, whose sign
in a right-to-left page is positive in some engines and negative in others;
what the fade needs is the physical side either way. Without JavaScript the row
still scrolls, it just does not advertise it.

## Checked on the engine that reported it

`mask-image` needs no prefix in WebKit, which is what iOS runs. Verified rather
than assumed, and the three scroll states were driven there too.

Three checks added, 82 in all:

| revert | what went red |
| --- | --- |
| the reporting removed from toc.js | the fade check |
| the fade removed from the stylesheet | the fade check |
| the back link made shorter than the action | the action check, naming both numbers |

The fade check refuses to run on a row that does not overflow, and its negative
half asserts a row that fits advertises nothing, so neither can pass by
accident.

**One of those proofs was worthless the first time.** The assertion that the two
controls match was never added: the patch failed on a string Prettier had
reformatted, and both "proof" runs passed against a check that did not contain
it. Caught by reading the file rather than the output.