### PR TITLE
Bump to 1.21.0

### DIFF
--- a/charts/cairn/Chart.yaml
+++ b/charts/cairn/Chart.yaml
@@ -7,8 +7,8 @@ type: application
 # the chart, so a published chart always carries the cairn it installs. What
 # is written here only matters to someone running `helm install ./charts/cairn`
 # from a checkout.
-version: 1.20.2
-appVersion: "1.20.2"
+version: 1.21.0
+appVersion: "1.21.0"
 
 # networking.k8s.io/v1 Ingress, which is 1.19 and later. Declaring it here
 # means the templates can use one API version instead of sniffing .Capabilities.

--- a/docs/deployment/airgap.md
+++ b/docs/deployment/airgap.md
@@ -14,7 +14,7 @@ page renders, and the icons are simply missing.
 
 | Artifact             | Size     | Where it comes from                                            |
 | -------------------- | -------- | -------------------------------------------------------------- |
-| `cairn-1.20.2.tgz`   | 4 KB     | `helm pull`, the signed artifact rather than the folder in git |
+| `cairn-1.21.0.tgz`   | 4 KB     | `helm pull`, the signed artifact rather than the folder in git |
 | `gatus-1.5.0.tgz`    | 9 KB     | the Gatus project's own chart                                  |
 | `images.tar`         | 26 MB    | `docker save` of cairn and Gatus                               |
 | `assets/icons/*.svg` | a few KB | what `cairn -emit-icons` downloads                             |
@@ -32,7 +32,7 @@ Everything in this section can be done by hand, and the rest of it shows how.
 If you have cairn checked out, two of the steps are a recipe:
 
 ```sh
-just save 1.20.2 linux/amd64   # the platform of the cluster, not of your laptop
+just save 1.21.0 linux/amd64   # the platform of the cluster, not of your laptop
 ```
 
 That pulls cairn's image for that one platform, saves it to `dist/`, pulls the
@@ -50,14 +50,14 @@ The order matters. `cosign verify` queries the public transparency log, so it is
 not something you get to do on the other side.
 
 ```sh
-helm pull oci://ghcr.io/morgankryze/charts/cairn --version 1.20.2
+helm pull oci://ghcr.io/morgankryze/charts/cairn --version 1.21.0
 
-cosign verify ghcr.io/morgankryze/charts/cairn:1.20.2 \
+cosign verify ghcr.io/morgankryze/charts/cairn:1.21.0 \
   --certificate-identity-regexp '^https://github.com/MorganKryze/cairn/' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
 
-The same two lines for `morgankryze/cairn:1.20.2`, the image. Keep the
+The same two lines for `morgankryze/cairn:1.21.0`, the image. Keep the
 output: this is the only moment where you can prove where these bytes came from.
 
 Gatus publishes its own chart, from a classic repository rather than a registry,
@@ -82,7 +82,7 @@ amd64 cluster from an arm64 laptop is the classic way to learn this at
 ```sh
 PLATFORM=linux/amd64
 
-docker pull --platform $PLATFORM morgankryze/cairn:1.20.2
+docker pull --platform $PLATFORM morgankryze/cairn:1.21.0
 docker pull --platform $PLATFORM ghcr.io/twin/gatus:v5.36.0
 ```
 
@@ -93,9 +93,9 @@ names nothing you can reason about six months later. To be exact, v5.36.0 is
 Then give both the name they will carry inside, and save them together:
 
 ```sh
-docker tag morgankryze/cairn:1.20.2 harbor.internal/cairn:1.20.2
+docker tag morgankryze/cairn:1.21.0 harbor.internal/cairn:1.21.0
 docker tag ghcr.io/twin/gatus:v5.36.0 harbor.internal/gatus:5.36.0
-docker save harbor.internal/cairn:1.20.2 harbor.internal/gatus:5.36.0 -o images.tar
+docker save harbor.internal/cairn:1.21.0 harbor.internal/gatus:5.36.0 -o images.tar
 ```
 
 Retag even if you have no registry. An image named after a host that resolves
@@ -107,7 +107,7 @@ to have a route after all: the mistake becomes loud instead of invisible.
 This is the step nothing downstream will remind you about.
 
 ```sh
-docker run --rm -v ./config:/config morgankryze/cairn:1.20.2 -emit-icons > get-icons.sh
+docker run --rm -v ./config:/config morgankryze/cairn:1.21.0 -emit-icons > get-icons.sh
 mkdir -p assets && (cd assets && sh ../get-icons.sh)
 ```
 
@@ -119,7 +119,7 @@ bring the files. See [Icons](../recipes/icons.md).
 ### The Gatus endpoints
 
 ```sh
-docker run --rm -v ./config:/config morgankryze/cairn:1.20.2 -emit-gatus > gatus-endpoints.yaml
+docker run --rm -v ./config:/config morgankryze/cairn:1.21.0 -emit-gatus > gatus-endpoints.yaml
 ```
 
 One endpoint per service, named after its id, which is how each pill finds its
@@ -129,7 +129,7 @@ service. More in [Status page](../recipes/status.md).
 
 ```sh
 docker run --rm -v ./config:/config:ro -v ./assets:/assets:ro \
-  morgankryze/cairn:1.20.2 -check
+  morgankryze/cairn:1.21.0 -check
 ```
 
 **Mount both directories.** Given only `/config`, `-check` cannot see the icons
@@ -160,7 +160,7 @@ the far side of the gap there is no fixing a broken image with a download.
 
 ```sh
 docker load -i images.tar
-docker push harbor.internal/cairn:1.20.2
+docker push harbor.internal/cairn:1.21.0
 docker push harbor.internal/gatus:5.36.0
 ```
 
@@ -170,7 +170,7 @@ Harbor, Zot or `registry:2` you already run. The chart wants one value.
 ```yaml
 image:
   repository: harbor.internal/cairn
-  tag: "1.20.2"
+  tag: "1.21.0"
 # Only if the project is private. The Secrets have to exist in the namespace
 # already; the chart names them, it does not create them.
 imagePullSecrets:
@@ -182,7 +182,7 @@ OCI artifacts, so a project named `helm` holds them next to the images and
 nothing else has to be installed:
 
 ```sh
-helm push cairn-1.20.2.tgz oci://harbor.internal/helm
+helm push cairn-1.21.0.tgz oci://harbor.internal/helm
 helm push gatus-1.5.0.tgz oci://harbor.internal/helm
 ```
 
@@ -217,7 +217,7 @@ it worked:
 
 ```console
 $ kubectl get events --field-selector reason=Pulled
-Container image "harbor.internal/cairn:1.20.2" already present on machine
+Container image "harbor.internal/cairn:1.21.0" already present on machine
 Container image "harbor.internal/gatus:5.36.0" already present on machine
 ```
 
@@ -241,7 +241,7 @@ under `binaryData` on its own.
 # values.yaml
 image:
   repository: harbor.internal/cairn
-  tag: "1.20.2"
+  tag: "1.21.0"
 
 config:
   site.yaml: |
@@ -290,7 +290,7 @@ and one version to name, which is also what Argo CD will read:
 
 ```sh
 helm registry login harbor.internal --ca-file /etc/pki/internal-ca.crt
-helm install cairn oci://harbor.internal/helm/cairn --version 1.20.2 \
+helm install cairn oci://harbor.internal/helm/cairn --version 1.21.0 \
   --ca-file /etc/pki/internal-ca.crt -f values.yaml
 ```
 
@@ -307,7 +307,7 @@ credential store: a `docker login` already done on that host does not count.
 Without a registry, install what you carried:
 
 ```sh
-helm install cairn ./cairn-1.20.2.tgz -f values.yaml
+helm install cairn ./cairn-1.21.0.tgz -f values.yaml
 ```
 
 `linked: false` is a decision rather than an omission. Without it the pills link
@@ -647,7 +647,7 @@ no shell, no busybox, nothing to attach to. What you need is in the logs, on
 The same crossing, then:
 
 ```sh
-helm upgrade cairn oci://harbor.internal/helm/cairn --version 1.20.2 -f values.yaml
+helm upgrade cairn oci://harbor.internal/helm/cairn --version 1.21.0 -f values.yaml
 ```
 
 Always pass your full values file. As soon as one `-f` is present, Helm stops

--- a/docs/deployment/helm.md
+++ b/docs/deployment/helm.md
@@ -26,8 +26,8 @@ kubectl port-forward svc/cairn 8080:80
 
 Add `--version` with the number from the
 [releases](https://github.com/MorganKryze/cairn/releases) to pin. Chart version
-and cairn version are the same number, always: chart `1.20.2` installs cairn
-`1.20.2`, so there is only ever one version to talk about, and `image.tag` is
+and cairn version are the same number, always: chart `1.21.0` installs cairn
+`1.21.0`, so there is only ever one version to talk about, and `image.tag` is
 there if you ever want to break the pair apart.
 
 ## Seeing it filled first
@@ -229,8 +229,8 @@ OCI artifact, so it can be mirrored into whatever registry you already keep, and
 driven from there:
 
 ```sh
-helm pull oci://ghcr.io/morgankryze/charts/cairn --version 1.20.2
-helm push cairn-1.20.2.tgz oci://harbor.internal/helm
+helm pull oci://ghcr.io/morgankryze/charts/cairn --version 1.21.0
+helm push cairn-1.21.0.tgz oci://harbor.internal/helm
 ```
 
 Argo CD needs the repository declared before an Application can name it. Note
@@ -266,7 +266,7 @@ spec:
   source:
     repoURL: harbor.internal/helm
     chart: cairn
-    targetRevision: 1.20.2
+    targetRevision: 1.21.0
     helm:
       valuesObject:
         ingress:
@@ -290,7 +290,7 @@ spec:
   sources:
     - repoURL: harbor.internal/helm
       chart: cairn
-      targetRevision: 1.20.2
+      targetRevision: 1.21.0
       helm:
         valueFiles:
           - $values/cairn/values.yaml
@@ -317,7 +317,7 @@ The chart is signed the same way the image is, keylessly, bound to the workflow
 that published it:
 
 ```sh
-cosign verify ghcr.io/morgankryze/charts/cairn:1.20.2 \
+cosign verify ghcr.io/morgankryze/charts/cairn:1.21.0 \
   --certificate-identity-regexp '^https://github.com/MorganKryze/cairn/' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -10,7 +10,7 @@ The new image validates your existing config without touching anything you are
 running. Do this first, every time:
 
 ```sh
-docker run --rm -v ./config:/config morgankryze/cairn:1.20.2 -check
+docker run --rm -v ./config:/config morgankryze/cairn:1.21.0 -check
 ```
 
 Exit code 0 means the upgrade will load. Exit 1 prints the exact message and

--- a/justfile
+++ b/justfile
@@ -49,7 +49,7 @@ demo:
 demo-rebuild:
     docker compose -f demo/compose.yaml up -d --build --remove-orphans
 
-# save a release to dist/ for an air-gapped move: just save 1.20.2 [linux/amd64]
+# save a release to dist/ for an air-gapped move: just save 1.21.0 [linux/amd64]
 save version platform="":
     #!/usr/bin/env bash
     set -euo pipefail


### PR DESCRIPTION
Cuts 1.21.0.

One feature since 1.20.2: `search: false` turns the header box off (#115, asked on #111). The rest is dependencies and a comment.

Checked against v1.20.2 with both binaries stamped 1.21.0 and both reading the tag's own configs: 152 responses, the only difference on the 37 pages is the stylesheet digest. The image's compiler moved with #110 and #112, and it shows: `go version` reads go1.26.6 on the published 1.20.2 image and go1.27.1 on this one.